### PR TITLE
Fix date formatting to pad month/day with leading zeros for API calls

### DIFF
--- a/app-ui/src/services/SessionsHttpClient.ts
+++ b/app-ui/src/services/SessionsHttpClient.ts
@@ -14,6 +14,6 @@ export class SessionsHttpClient extends HttpClientBase {
 
   private formatDateForApi(date: string): string {
     const [month, day, year] = date.split('/');
-    return `${year}-${month}-${day}`;
+    return `${year}-${month.padStart(2, '0')}-${day.padStart(2, '0')}`;
   }
 }


### PR DESCRIPTION
toLocaleDateString('en-US') produces single-digit months/days (e.g. 3/6/2026), which failed the API date validation regex expecting two-digit format (YYYY-MM-DD).