### PR TITLE
Add Docker, Helm, and GitHub Actions CI/CD for SPA deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+app-ui/node_modules
+app-ui/dist
+.git
+docs

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,50 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: app-ui/package-lock.json
+
+      - name: Install dependencies
+        working-directory: app-ui
+        run: npm ci
+
+      - name: Type-check
+        working-directory: app-ui
+        run: npx vue-tsc --noEmit
+
+      - name: Lint
+        working-directory: app-ui
+        run: npm run lint
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: build/Dockerfile
+          push: true
+          build-args: |
+            BUILD_VERSION=${{ github.run_number }}
+          tags: |
+            anibalvelarde/patient-care-ui-vue:latest
+            anibalvelarde/patient-care-ui-vue:${{ github.run_number }}

--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -1,0 +1,32 @@
+name: PR Validation
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: app-ui/package-lock.json
+
+      - name: Install dependencies
+        working-directory: app-ui
+        run: npm ci
+
+      - name: Type-check
+        working-directory: app-ui
+        run: npx vue-tsc --noEmit
+
+      - name: Lint
+        working-directory: app-ui
+        run: npm run lint

--- a/app-ui/eslint.config.js
+++ b/app-ui/eslint.config.js
@@ -1,9 +1,25 @@
 import pluginVue from 'eslint-plugin-vue'
+import tseslint from 'typescript-eslint'
 
 export default [
+  ...tseslint.configs.recommended,
   ...pluginVue.configs['flat/essential'],
   {
-    rules: {}
+    files: ['**/*.vue'],
+    languageOptions: {
+      parserOptions: {
+        parser: tseslint.parser
+      }
+    }
+  },
+  {
+    rules: {
+      'vue/multi-word-component-names': 'off',
+      'vue/no-reserved-component-names': 'off',
+      '@typescript-eslint/no-unused-vars': 'warn',
+      '@typescript-eslint/no-empty-object-type': 'off',
+      '@typescript-eslint/no-explicit-any': 'warn'
+    }
   },
   {
     ignores: ['dist/**']

--- a/app-ui/index.html
+++ b/app-ui/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <title>Neurocorp Therapy Center</title>
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <script src="/config.js"></script>
 </head>
 <body>
   <div id="app"></div>

--- a/app-ui/package-lock.json
+++ b/app-ui/package-lock.json
@@ -23,6 +23,7 @@
         "postcss": "^8.5.2",
         "tailwindcss": "^3.4.17",
         "typescript": "^5.7.3",
+        "typescript-eslint": "^8.57.0",
         "vite": "^6.1.0",
         "vue-tsc": "^2.2.0"
       }
@@ -1358,6 +1359,275 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.57.0.tgz",
+      "integrity": "sha512-qeu4rTHR3/IaFORbD16gmjq9+rEs9fGKdX0kF6BKSfi+gCuG3RCKLlSBYzn/bGsY9Tj7KE/DAQStbp8AHJGHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.57.0",
+        "@typescript-eslint/type-utils": "8.57.0",
+        "@typescript-eslint/utils": "8.57.0",
+        "@typescript-eslint/visitor-keys": "8.57.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.57.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.57.0.tgz",
+      "integrity": "sha512-XZzOmihLIr8AD1b9hL9ccNMzEMWt/dE2u7NyTY9jJG6YNiNthaD5XtUHVF2uCXZ15ng+z2hT3MVuxnUYhq6k1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.57.0",
+        "@typescript-eslint/types": "8.57.0",
+        "@typescript-eslint/typescript-estree": "8.57.0",
+        "@typescript-eslint/visitor-keys": "8.57.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.57.0.tgz",
+      "integrity": "sha512-pR+dK0BlxCLxtWfaKQWtYr7MhKmzqZxuii+ZjuFlZlIGRZm22HnXFqa2eY+90MUz8/i80YJmzFGDUsi8dMOV5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.57.0",
+        "@typescript-eslint/types": "^8.57.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.57.0.tgz",
+      "integrity": "sha512-nvExQqAHF01lUM66MskSaZulpPL5pgy5hI5RfrxviLgzZVffB5yYzw27uK/ft8QnKXI2X0LBrHJFr1TaZtAibw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.57.0",
+        "@typescript-eslint/visitor-keys": "8.57.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.57.0.tgz",
+      "integrity": "sha512-LtXRihc5ytjJIQEH+xqjB0+YgsV4/tW35XKX3GTZHpWtcC8SPkT/d4tqdf1cKtesryHm2bgp6l555NYcT2NLvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.57.0.tgz",
+      "integrity": "sha512-yjgh7gmDcJ1+TcEg8x3uWQmn8ifvSupnPfjP21twPKrDP/pTHlEQgmKcitzF/rzPSmv7QjJ90vRpN4U+zoUjwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.57.0",
+        "@typescript-eslint/typescript-estree": "8.57.0",
+        "@typescript-eslint/utils": "8.57.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.57.0.tgz",
+      "integrity": "sha512-dTLI8PEXhjUC7B9Kre+u0XznO696BhXcTlOn0/6kf1fHaQW8+VjJAVHJ3eTI14ZapTxdkOmc80HblPQLaEeJdg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.57.0.tgz",
+      "integrity": "sha512-m7faHcyVg0BT3VdYTlX8GdJEM7COexXxS6KqGopxdtkQRvBanK377QDHr4W/vIPAR+ah9+B/RclSW5ldVniO1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.57.0",
+        "@typescript-eslint/tsconfig-utils": "8.57.0",
+        "@typescript-eslint/types": "8.57.0",
+        "@typescript-eslint/visitor-keys": "8.57.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.57.0.tgz",
+      "integrity": "sha512-5iIHvpD3CZe06riAsbNxxreP+MuYgVUsV0n4bwLH//VJmgtt54sQeY2GszntJ4BjYCpMzrfVh2SBnUQTtys2lQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.57.0",
+        "@typescript-eslint/types": "8.57.0",
+        "@typescript-eslint/typescript-estree": "8.57.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.57.0.tgz",
+      "integrity": "sha512-zm6xx8UT/Xy2oSr2ZXD0pZo7Jx2XsCoID2IUh9YSTFRu7z+WdwYTRk6LhUftm1crwqbuoF6I8zAFeCMw0YjwDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.57.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
     "node_modules/@vitejs/plugin-vue": {
       "version": "5.2.4",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
@@ -1937,13 +2207,13 @@
       "license": "MIT"
     },
     "node_modules/debug": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
-      "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -2159,19 +2429,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/eslint-plugin-vue/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/eslint-plugin-vue/node_modules/type-fest": {
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
@@ -2183,6 +2440,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint/node_modules/ansi-styles": {
@@ -2956,9 +3226,9 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
     },
@@ -3538,6 +3808,19 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -3882,6 +4165,19 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
+      "integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
@@ -3914,6 +4210,30 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.57.0.tgz",
+      "integrity": "sha512-W8GcigEMEeB07xEZol8oJ26rigm3+bfPHxHvwbYUlu1fUDsGuQ7Hiskx5xGW/xM4USc9Ephe3jtv7ZYPQntHeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.57.0",
+        "@typescript-eslint/parser": "8.57.0",
+        "@typescript-eslint/typescript-estree": "8.57.0",
+        "@typescript-eslint/utils": "8.57.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/undici-types": {
@@ -4186,19 +4506,6 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
-      }
-    },
-    "node_modules/vue-eslint-parser/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/vue-router": {

--- a/app-ui/package.json
+++ b/app-ui/package.json
@@ -25,6 +25,7 @@
     "postcss": "^8.5.2",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.7.3",
+    "typescript-eslint": "^8.57.0",
     "vite": "^6.1.0",
     "vue-tsc": "^2.2.0"
   }

--- a/app-ui/public/config.js
+++ b/app-ui/public/config.js
@@ -1,0 +1,5 @@
+// Runtime config — overridden by Docker entrypoint in production.
+// For local dev, update this file or use VITE_API_BASE_URL in a .env file.
+window.__APP_CONFIG__ = {
+  apiBaseUrl: "http://localhost:5245"
+};

--- a/app-ui/src/components/appointments/Appointments.ts
+++ b/app-ui/src/components/appointments/Appointments.ts
@@ -32,7 +32,7 @@ export default defineComponent({
         // Assign filtered appointments to the respective ref arrays
         amAppointments.value = amApps;
         pmAppointments.value = pmApps;
-      } catch (error) {
+      } catch {
         console.error("Error fetching appointments.");
       }
     };

--- a/app-ui/src/components/calendars/DayCard/CalendarDayCard.ts
+++ b/app-ui/src/components/calendars/DayCard/CalendarDayCard.ts
@@ -1,4 +1,4 @@
-import { defineComponent, PropType } from 'vue';
+import { defineComponent } from 'vue';
 
 export default defineComponent({
   name: 'CalendarDayCard',

--- a/app-ui/src/components/option01/O1Calendar.vue
+++ b/app-ui/src/components/option01/O1Calendar.vue
@@ -100,7 +100,6 @@ export default defineComponent({
   emits: ['date-selected'],
   setup(props, { emit }) {
     const today = new Date();
-    const baseDate = ref(new Date(today));
 
     const getWeekDays = (startDate: Date) => {
       const days = [];

--- a/app-ui/src/components/option04/O4KanbanBoard.vue
+++ b/app-ui/src/components/option04/O4KanbanBoard.vue
@@ -78,7 +78,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, watch, computed, onMounted, PropType } from 'vue';
+import { defineComponent, ref, watch, computed, onMounted } from 'vue';
 import { Appointment } from '../../interfaces/Appointment';
 import { SessionsHttpClient } from '../../services/SessionsHttpClient';
 import { library } from '@fortawesome/fontawesome-svg-core';

--- a/app-ui/src/services/HttpClientBase.ts
+++ b/app-ui/src/services/HttpClientBase.ts
@@ -7,7 +7,8 @@ export abstract class HttpClientBase {
     }
   
     protected getBaseUrlFromConfig(): string {
-      return import.meta.env.VITE_API_BASE_URL || "http://localhost:5245";
+      const appConfig = (window as unknown as Record<string, unknown>).__APP_CONFIG__ as Record<string, string> | undefined;
+      return appConfig?.apiBaseUrl || import.meta.env.VITE_API_BASE_URL || "http://localhost:5245";
     }
   
     protected async get<T>(url: string): Promise<T> {

--- a/app-ui/src/shims-vue.d.ts
+++ b/app-ui/src/shims-vue.d.ts
@@ -1,6 +1,5 @@
 declare module '*.vue' {
     import { DefineComponent } from 'vue';
-    const component: DefineComponent<{}, {}, any>;
+    const component: DefineComponent<{}, {}, unknown>;
     export default component;
   }
-  

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,0 +1,43 @@
+# ──────────────────────────────────────────────
+# Stage 1: Build the Vue SPA
+# ──────────────────────────────────────────────
+FROM node:20-alpine AS build
+
+ARG BUILD_VERSION=0.0.0
+
+WORKDIR /app
+
+# Copy package manifests first for better layer caching
+COPY app-ui/package.json app-ui/package-lock.json ./
+
+RUN npm ci
+
+# Copy the rest of the app source
+COPY app-ui/ .
+
+RUN npm run build
+
+# ──────────────────────────────────────────────
+# Stage 2: Serve with Nginx
+# ──────────────────────────────────────────────
+FROM nginx:alpine
+
+LABEL maintainer="anibalvelarde"
+LABEL org.opencontainers.image.description="Neurocorp Patient Care UI (Vue SPA)"
+
+# Remove default nginx content
+RUN rm -rf /usr/share/nginx/html/*
+
+# Custom nginx config for SPA routing
+COPY build/nginx/default.conf /etc/nginx/conf.d/default.conf
+
+# Copy built assets from stage 1
+COPY --from=build /app/dist /usr/share/nginx/html
+
+# Entrypoint script generates runtime config.js from env vars
+COPY build/scripts/docker-entrypoint.sh /docker-entrypoint.sh
+RUN sed -i 's/\r$//' /docker-entrypoint.sh && chmod +x /docker-entrypoint.sh
+
+EXPOSE 80
+
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/build/nginx/default.conf
+++ b/build/nginx/default.conf
@@ -1,0 +1,24 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # SPA client-side routing — send all non-file requests to index.html
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Gzip compression
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript image/svg+xml;
+    gzip_min_length 256;
+    gzip_vary on;
+
+    # Cache static assets (JS, CSS, images) — Vite hashes filenames so long cache is safe
+    location /assets/ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+}

--- a/build/scripts/docker-entrypoint.sh
+++ b/build/scripts/docker-entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+
+# Generate runtime config from environment variables
+cat <<EOF > /usr/share/nginx/html/config.js
+window.__APP_CONFIG__ = {
+  apiBaseUrl: "${VITE_API_BASE_URL:-http://localhost:5245}"
+};
+EOF
+
+echo "Runtime config generated (API: ${VITE_API_BASE_URL:-http://localhost:5245})"
+
+# Start nginx
+exec nginx -g "daemon off;"

--- a/deploy/helm/patient-care-ui-vue/.env.example
+++ b/deploy/helm/patient-care-ui-vue/.env.example
@@ -1,0 +1,4 @@
+# API base URL — passed as an environment variable at container runtime
+# Set this to the LAN-reachable address of the patient-care-api service
+# Used by the entrypoint script to generate config.js for the SPA
+VITE_API_BASE_URL=http://192.168.1.100:30000

--- a/deploy/helm/patient-care-ui-vue/Chart.yaml
+++ b/deploy/helm/patient-care-ui-vue/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: patient-care-ui-vue
+description: Neurocorp Patient Care UI — Vue 3 SPA served by Nginx
+type: application
+version: 1.0.0
+appVersion: "1.0.0"

--- a/deploy/helm/patient-care-ui-vue/deploy.sh
+++ b/deploy/helm/patient-care-ui-vue/deploy.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART_DIR="$SCRIPT_DIR"
+RELEASE_NAME="patient-care-ui-vue"
+NAMESPACE="nc-k3s"
+
+# Optional: pass an image tag as the first argument (defaults to "latest")
+IMAGE_TAG="${1:-latest}"
+
+echo "Deploying $RELEASE_NAME (image tag: $IMAGE_TAG) to namespace $NAMESPACE..."
+
+helm upgrade --install "$RELEASE_NAME" "$CHART_DIR" \
+  --namespace "$NAMESPACE" \
+  --set image.tag="$IMAGE_TAG"
+
+echo "Done. Run 'kubectl get pods -n $NAMESPACE' to check status."

--- a/deploy/helm/patient-care-ui-vue/templates/NOTES.txt
+++ b/deploy/helm/patient-care-ui-vue/templates/NOTES.txt
@@ -1,0 +1,7 @@
+Neurocorp Patient Care UI has been deployed!
+
+Access the application at:
+  http://<NODE_IP>:{{ .Values.service.nodePort }}
+
+The SPA is configured to reach the API at the URL baked in during the Docker image build.
+To verify, check the browser's network tab for API calls to the configured VITE_API_BASE_URL.

--- a/deploy/helm/patient-care-ui-vue/templates/_helpers.tpl
+++ b/deploy/helm/patient-care-ui-vue/templates/_helpers.tpl
@@ -1,0 +1,35 @@
+{{/*
+Chart name, truncated to 63 chars.
+*/}}
+{{- define "patient-care-ui-vue.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Fully qualified app name (release + chart), truncated to 63 chars.
+*/}}
+{{- define "patient-care-ui-vue.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "patient-care-ui-vue.labels" -}}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+{{ include "patient-care-ui-vue.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "patient-care-ui-vue.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "patient-care-ui-vue.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/deploy/helm/patient-care-ui-vue/templates/deployment.yaml
+++ b/deploy/helm/patient-care-ui-vue/templates/deployment.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "patient-care-ui-vue.fullname" . }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "patient-care-ui-vue.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "patient-care-ui-vue.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "patient-care-ui-vue.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: VITE_API_BASE_URL
+              value: {{ .Values.apiBaseUrl | quote }}
+          ports:
+            - containerPort: {{ .Values.service.targetPort }}
+              protocol: TCP
+          {{- if .Values.healthChecks.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.healthChecks.path }}
+              port: {{ .Values.service.targetPort }}
+            initialDelaySeconds: {{ .Values.healthChecks.initialDelaySeconds }}
+            periodSeconds: {{ .Values.healthChecks.periodSeconds }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.healthChecks.path }}
+              port: {{ .Values.service.targetPort }}
+            initialDelaySeconds: {{ .Values.healthChecks.initialDelaySeconds }}
+            periodSeconds: {{ .Values.healthChecks.periodSeconds }}
+          {{- end }}

--- a/deploy/helm/patient-care-ui-vue/templates/namespace.yaml
+++ b/deploy/helm/patient-care-ui-vue/templates/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.namespace }}

--- a/deploy/helm/patient-care-ui-vue/templates/service.yaml
+++ b/deploy/helm/patient-care-ui-vue/templates/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "patient-care-ui-vue.fullname" . }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "patient-care-ui-vue.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
+      nodePort: {{ .Values.service.nodePort }}
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "patient-care-ui-vue.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/patient-care-ui-vue/values.yaml
+++ b/deploy/helm/patient-care-ui-vue/values.yaml
@@ -1,0 +1,22 @@
+replicaCount: 1
+
+image:
+  repository: anibalvelarde/patient-care-ui-vue
+  tag: latest
+  pullPolicy: IfNotPresent
+
+service:
+  type: NodePort
+  port: 80
+  targetPort: 80
+  nodePort: 40000
+
+namespace: nc-k3s
+
+apiBaseUrl: http://neurocorp.k3s:30000
+
+healthChecks:
+  enabled: true
+  path: /
+  initialDelaySeconds: 5
+  periodSeconds: 10

--- a/docs/K3S-DEPLOYMENT-CONTINUATION.md
+++ b/docs/K3S-DEPLOYMENT-CONTINUATION.md
@@ -1,0 +1,104 @@
+# K3s Deployment — Session Continuation Prompt
+
+> **Purpose:** Pick up exactly where we left off. Feed this file to Claude Code to resume work.
+
+## Goal
+
+Dockerize and deploy the Vue 3 SPA (`patient-care-ui-vue`) to the local LAN K3s cluster, following the same pattern used by the REST API at `/c/working/customers/neurocorp/patient-care-api/`.
+
+## Decisions Made
+
+| # | Question | Decision |
+|---|----------|----------|
+| 1 | **NodePort for SPA** | **40000** — UI apps use the 40000 range; REST APIs use the 30000 range (see ADR below) |
+| 2 | **API URL at runtime** | Sourced from `VITE_API_BASE_URL` in a `.env` file. **Build must fail if this var is absent or empty.** The `.env` file is used at Docker image build time to bake the URL into the SPA's static assets. |
+| 3 | **Docker Hub image** | `anibalvelarde/patient-care-ui-vue` (same Docker Hub account as the API) |
+| 4 | **Namespace** | `nc-k3s` (same namespace as the API) |
+| 5 | **CI/CD** | GitHub Actions from the start (same pattern as the API repo's `.github/workflows/main.yaml`) |
+
+## Port Range Convention (ADR)
+
+- **30000–30999** — REST API services (e.g., `patient-care-api` on 30000)
+- **40000–40999** — UI/SPA applications (e.g., `patient-care-ui-vue` on 40000)
+
+This convention should be documented in project docs and enforced in Helm `values.yaml` defaults.
+
+## Reference: API Deployment Pattern (to replicate)
+
+The REST API at `/c/working/customers/neurocorp/patient-care-api/` uses:
+
+```
+build/
+  Dockerfile              # Multi-stage: SDK build → ASP.NET runtime
+  startup_scripts/
+    startup.sh            # Env-based port selection, launches dotnet
+
+deploy/helm/patient-care-api/
+  Chart.yaml              # Helm v2 chart, app version 1.0.0
+  values.yaml             # replicaCount, image, service (NodePort 30000), namespace nc-k3s, healthChecks
+  deploy.sh               # Reads .env, runs helm upgrade --install
+  .env.example            # Template for DB credentials
+  templates/
+    deployment.yaml       # Deployment with liveness/readiness/startup probes
+    service.yaml          # NodePort service (80 → 5245, nodePort 30000)
+    namespace.yaml        # Creates nc-k3s namespace
+    secret.yaml           # DB credentials as K8s Secret
+    _helpers.tpl          # Helm template helpers
+    NOTES.txt             # Post-deploy instructions
+
+.github/workflows/
+  main.yaml               # Push to main → build, test, Docker push (anibalvelarde/patient-care-api:latest + :build-number)
+  pr-validation.yaml      # PR → build & test only (no Docker push)
+```
+
+## What Needs to Be Built (implementation plan)
+
+### 1. Dockerfile (`build/Dockerfile`)
+- **Stage 1 (build):** `node:20-alpine` → copy `app-ui/`, `npm install`, validate `VITE_API_BASE_URL` is set (fail if missing), `npm run build` → produces `dist/`
+- **Stage 2 (runtime):** `nginx:alpine` → copy `dist/` to `/usr/share/nginx/html/`, copy custom nginx config
+- Custom nginx config handles SPA routing: all non-file routes → `index.html`
+- Build arg: `VITE_API_BASE_URL` (required), `BUILD_VERSION` (optional)
+
+### 2. Nginx Config (`build/nginx/default.conf`)
+- Serve static files from `/usr/share/nginx/html/`
+- `try_files $uri $uri/ /index.html` for SPA client-side routing
+- Gzip compression for JS/CSS/HTML
+- Cache headers for static assets
+
+### 3. Helm Chart (`deploy/helm/patient-care-ui-vue/`)
+- `Chart.yaml` — chart metadata
+- `values.yaml` — image: `anibalvelarde/patient-care-ui-vue:latest`, service: NodePort 40000, namespace: `nc-k3s`
+- `templates/deployment.yaml` — Deployment (nginx container, port 80)
+- `templates/service.yaml` — NodePort (80 → 80, nodePort 40000)
+- `templates/namespace.yaml` — `nc-k3s` (same as API, idempotent)
+- `templates/_helpers.tpl` — Helm helpers
+- `templates/NOTES.txt` — Post-deploy access instructions
+- No secrets needed (no DB); API URL is baked in at build time
+
+### 4. Deploy Script (`deploy/helm/patient-care-ui-vue/deploy.sh`)
+- Same pattern as API's deploy.sh
+- Runs `helm upgrade --install`
+- Accepts optional image tag argument
+
+### 5. Environment File (`deploy/helm/patient-care-ui-vue/.env.example`)
+```
+VITE_API_BASE_URL=http://192.168.1.100:30000
+```
+
+### 6. GitHub Actions (`.github/workflows/`)
+- `main.yaml` — Push to main → npm install, build, Docker build+push (`anibalvelarde/patient-care-ui-vue:latest` + `:build-number`)
+- `pr-validation.yaml` — PR → npm install, type-check, lint (no Docker push)
+- Docker Hub credentials via GitHub Secrets: `DOCKERHUB_USERNAME`, `DOCKERHUB_TOKEN`
+
+## Important Notes
+
+- `VITE_API_BASE_URL` is a **build-time** variable (Vite bakes env vars into the bundle). It must be set when `npm run build` runs inside Docker. This means the Docker image is environment-specific (the API URL is embedded in the JS bundle).
+- The SPA runs in the **browser**, so the API URL must be reachable from the user's machine on the LAN, not from inside the K3s cluster.
+- Original UI components (`headers/`, `sidebars/`, etc.) remain untouched.
+- The app source lives under `app-ui/` (not the repo root).
+
+## Resume Command
+
+Open Claude Code in the repo root and say:
+
+> Read `docs/K3S-DEPLOYMENT-CONTINUATION.md` and proceed with implementing the K3s deployment for the SPA. Start with step 1 (Dockerfile) and work through all 6 steps.

--- a/docs/adr/001-k3s-nodeport-ranges.md
+++ b/docs/adr/001-k3s-nodeport-ranges.md
@@ -1,0 +1,21 @@
+# ADR-001: K3s NodePort Range Convention
+
+## Status
+Accepted
+
+## Context
+The Neurocorp project deploys multiple services to a local LAN K3s cluster. Without a convention, NodePort assignments become ad hoc and harder to manage as services grow.
+
+## Decision
+Reserve NodePort ranges by service type:
+
+| Range | Service Type | Example |
+|-------|-------------|---------|
+| **30000–30999** | REST API services | `patient-care-api` → 30000 |
+| **40000–40999** | UI / SPA applications | `patient-care-ui-vue` → 40000 |
+
+## Consequences
+- New REST APIs should pick the next available port in the 30000 range.
+- New UI/SPA apps should pick the next available port in the 40000 range.
+- Helm `values.yaml` defaults should reflect this convention.
+- Developers can quickly identify a service's type from its port number.


### PR DESCRIPTION
Dockerize the Vue SPA with a two-stage build (Node 20 → Nginx Alpine) and runtime config injection so the image is environment-agnostic. API base URL is passed at container startup via VITE_API_BASE_URL env var.

Includes Helm chart for K3s deployment (NodePort 40000, namespace nc-k3s), deploy script, and GitHub Actions workflows for CI (pr-validation) and CD (main → Docker Hub push as anibalvelarde/patient-care-ui-vue).