### PR TITLE
Add S3 deploy job to CI/CD pipeline

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,13 +1,12 @@
-name: Build and Push Docker Image
+name: Build, Push, and Deploy
 
 on:
   push:
     branches: [main]
 
 jobs:
-  build-and-push:
+  validate:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -31,6 +30,13 @@ jobs:
         working-directory: app-ui
         run: npm run lint
 
+  docker-push:
+    needs: validate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -48,3 +54,43 @@ jobs:
           tags: |
             anibalvelarde/patient-care-ui-vue:latest
             anibalvelarde/patient-care-ui-vue:${{ github.run_number }}
+
+  s3-deploy:
+    needs: validate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: app-ui/package-lock.json
+
+      - name: Install dependencies
+        working-directory: app-ui
+        run: npm ci
+
+      - name: Build SPA
+        working-directory: app-ui
+        run: npm run build
+
+      - name: Generate runtime config for S3
+        run: |
+          cat <<'EOF' > app-ui/dist/config.js
+          window.__APP_CONFIG__ = {
+            apiBaseUrl: "https://neurocorp.anibalvelarde.com"
+          };
+          EOF
+
+      - name: Deploy to S3
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Sync files to S3
+        run: aws s3 sync app-ui/dist/ s3://neurocorp --delete

--- a/docs/AWS-S3-SETUP.md
+++ b/docs/AWS-S3-SETUP.md
@@ -1,0 +1,176 @@
+# AWS S3 Static Hosting Setup
+
+This guide covers setting up the `neurocorp` S3 bucket for static website hosting and creating AWS credentials for GitHub Actions. Choose either the **Console (browser)** or **CLI** path — both achieve the same result.
+
+---
+
+## Option A: AWS Console (Browser)
+
+### 1. Create the S3 Bucket
+
+1. Go to **AWS Console → S3 → Create bucket**
+2. Bucket name: `neurocorp`
+3. Region: `us-east-1`
+4. **Uncheck** "Block all public access" and acknowledge the warning
+5. Leave all other defaults and click **Create bucket**
+
+### 2. Enable Static Website Hosting
+
+1. Open the `neurocorp` bucket → **Properties** tab
+2. Scroll to **Static website hosting** → click **Edit**
+3. Select **Enable**
+4. Index document: `index.html`
+5. Error document: `index.html` (enables SPA client-side routing — any path that doesn't match a file returns `index.html` and Vue Router handles it)
+6. Click **Save changes**
+
+### 3. Set Bucket Policy for Public Access
+
+1. Open the `neurocorp` bucket → **Permissions** tab
+2. Under **Block public access**, click **Edit**, uncheck all boxes, and save (if not already done in step 1)
+3. Under **Bucket policy**, click **Edit** and paste:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "PublicReadGetObject",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::neurocorp/*"
+    }
+  ]
+}
+```
+
+4. Click **Save changes**
+
+### 4. Create IAM User for GitHub Actions
+
+1. Go to **AWS Console → IAM → Users → Create user**
+2. User name: `github-actions-neurocorp-deploy`
+3. Do **not** enable console access — click **Next**
+4. Choose **Attach policies directly** → click **Create policy**
+5. Switch to the **JSON** tab and paste:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject",
+        "s3:DeleteObject",
+        "s3:ListBucket"
+      ],
+      "Resource": [
+        "arn:aws:s3:::neurocorp",
+        "arn:aws:s3:::neurocorp/*"
+      ]
+    }
+  ]
+}
+```
+
+6. Name the policy `s3-neurocorp-deploy` → click **Create policy**
+7. Back on the user creation page, search for and attach `s3-neurocorp-deploy` → click **Create user**
+
+### 5. Generate Access Keys
+
+1. Go to **IAM → Users → `github-actions-neurocorp-deploy`**
+2. Click the **Security credentials** tab
+3. Under **Access keys**, click **Create access key**
+4. Select **Third-party service** as the use case → click **Next**
+5. (Optional) Add a description tag → click **Create access key**
+6. **Copy both values immediately** — the Secret Access Key is only shown once
+
+---
+
+## Option B: AWS CLI
+
+### 1. Create the S3 Bucket
+
+```bash
+aws s3 mb s3://neurocorp --region us-east-1
+```
+
+### 2. Enable Static Website Hosting
+
+```bash
+aws s3 website s3://neurocorp \
+  --index-document index.html \
+  --error-document index.html
+```
+
+### 3. Set Bucket Policy for Public Access
+
+```bash
+aws s3api put-public-access-block \
+  --bucket neurocorp \
+  --public-access-block-configuration \
+    BlockPublicAcls=false,IgnorePublicAcls=false,BlockPublicPolicy=false,RestrictPublicBuckets=false
+```
+
+```bash
+aws s3api put-bucket-policy --bucket neurocorp --policy '{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "PublicReadGetObject",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::neurocorp/*"
+    }
+  ]
+}'
+```
+
+### 4. Create IAM User and Generate Access Keys
+
+```bash
+# Create the user
+aws iam create-user --user-name github-actions-neurocorp-deploy
+
+# Create and attach the policy
+aws iam put-user-policy \
+  --user-name github-actions-neurocorp-deploy \
+  --policy-name s3-neurocorp-deploy \
+  --policy-document '{
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": ["s3:PutObject", "s3:DeleteObject", "s3:ListBucket"],
+        "Resource": ["arn:aws:s3:::neurocorp", "arn:aws:s3:::neurocorp/*"]
+      }
+    ]
+  }'
+
+# Generate access keys
+aws iam create-access-key --user-name github-actions-neurocorp-deploy
+```
+
+The output will include `AccessKeyId` and `SecretAccessKey`. Save these immediately — the secret is only shown once.
+
+---
+
+## Add Credentials to GitHub Secrets
+
+In your repo: **Settings → Secrets and variables → Actions**, update:
+
+| Secret | Value |
+|--------|-------|
+| `AWS_ACCESS_KEY_ID` | The Access Key ID from above |
+| `AWS_SECRET_ACCESS_KEY` | The Secret Access Key from above |
+| `AWS_REGION` | `us-east-1` (already set) |
+
+## Access the Site
+
+Once deployed, the SPA will be available at:
+
+```
+http://neurocorp.s3-website-us-east-1.amazonaws.com
+```


### PR DESCRIPTION
Restructure main.yaml into 3 jobs: validate, docker-push, and s3-deploy. Docker and S3 jobs run in parallel after validation passes. The S3 job builds the SPA, generates config.js pointing to the Cloudflare tunnel API URL, and syncs to the neurocorp S3 bucket for static hosting.

Includes AWS S3 setup guide with Console and CLI instructions.