### PR TITLE
Switch default UI from Option 01 (Clean Medical) to Option 02 (Dashbo…

### DIFF
--- a/app-ui/src/components/option01/O1Navbar.vue
+++ b/app-ui/src/components/option01/O1Navbar.vue
@@ -96,15 +96,16 @@ export default defineComponent({
     const mobileMenuOpen = ref(false);
 
     const navItems = [
-      { label: 'Dashboard', to: '/' },
-      { label: 'Patients', to: '/patients' },
+      { label: 'Dashboard', to: '/option-01' },
+      { label: 'Patients', to: '#' },
       { label: 'Therapists', to: '#' },
       { label: 'Caretakers', to: '#' },
       { label: 'Reports', to: '#' },
     ];
 
     const isActive = (to: string) => {
-      if (to === '/') return route.path === '/';
+      if (to === '#') return false;
+      if (to === '/option-01') return route.path === '/option-01';
       return route.path.startsWith(to);
     };
 

--- a/app-ui/src/components/option02/O2Header.vue
+++ b/app-ui/src/components/option02/O2Header.vue
@@ -13,12 +13,17 @@
       <button
         v-for="action in quickActions"
         :key="action.label"
+        :disabled="action.disabled"
+        :title="action.disabled ? 'Coming soon' : action.label"
         :class="[
           'hidden sm:inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors',
-          action.primary
-            ? 'bg-violet-600 text-white hover:bg-violet-700 shadow-sm'
-            : 'text-gray-500 border border-gray-200 hover:bg-gray-50',
+          action.disabled
+            ? 'opacity-50 cursor-not-allowed bg-gray-100 text-gray-400 border border-gray-200'
+            : action.primary
+              ? 'bg-violet-600 text-white hover:bg-violet-700 shadow-sm'
+              : 'text-gray-500 border border-gray-200 hover:bg-gray-50',
         ]"
+        @click="handleAction(action)"
       >
         <font-awesome-icon :icon="['fas', action.icon]" />
         {{ action.label }}
@@ -42,12 +47,17 @@
     <button
       v-for="action in quickActions"
       :key="action.label"
+      :disabled="action.disabled"
+      :title="action.disabled ? 'Coming soon' : action.label"
       :class="[
         'inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium whitespace-nowrap transition-colors',
-        action.primary
-          ? 'bg-violet-600 text-white hover:bg-violet-700'
-          : 'text-gray-500 border border-gray-200 hover:bg-gray-50',
+        action.disabled
+          ? 'opacity-50 cursor-not-allowed bg-gray-100 text-gray-400 border border-gray-200'
+          : action.primary
+            ? 'bg-violet-600 text-white hover:bg-violet-700'
+            : 'text-gray-500 border border-gray-200 hover:bg-gray-50',
       ]"
+      @click="handleAction(action)"
     >
       <font-awesome-icon :icon="['fas', action.icon]" />
       {{ action.label }}
@@ -57,6 +67,7 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
+import { useRouter } from 'vue-router';
 import { library } from '@fortawesome/fontawesome-svg-core';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import {
@@ -82,13 +93,22 @@ export default defineComponent({
       day: 'numeric',
     });
 
+    const router = useRouter();
+
     const quickActions = [
-      { label: 'New Appointment', icon: 'calendar-plus', primary: true },
-      { label: 'Add Patient', icon: 'user-plus', primary: false },
-      { label: 'Payment', icon: 'money-bill', primary: false },
+      { label: 'New Appointment', icon: 'calendar-plus', primary: true, disabled: true },
+      { label: 'Add Patient', icon: 'user-plus', primary: false, disabled: false },
+      { label: 'Payment', icon: 'money-bill', primary: false, disabled: true },
     ];
 
-    return { greeting, todayFormatted, quickActions };
+    const handleAction = (action: { label: string; disabled: boolean }) => {
+      if (action.disabled) return;
+      if (action.label === 'Add Patient') {
+        router.push('/patients');
+      }
+    };
+
+    return { greeting, todayFormatted, quickActions, handleAction };
   },
 });
 </script>

--- a/app-ui/src/components/option02/O2MobileNav.vue
+++ b/app-ui/src/components/option02/O2MobileNav.vue
@@ -1,0 +1,99 @@
+<template>
+  <!-- Mobile top bar -->
+  <div class="md:hidden bg-violet-900 text-white flex items-center justify-between px-4 h-14">
+    <div class="flex items-center space-x-3">
+      <div class="w-8 h-8 bg-white/10 rounded-lg flex items-center justify-center">
+        <span class="text-xs font-bold text-violet-200">NC</span>
+      </div>
+      <span class="text-sm font-semibold">Neurocorp</span>
+    </div>
+    <button
+      class="p-2 rounded-lg text-violet-200 hover:bg-white/10"
+      @click="mobileOpen = !mobileOpen"
+    >
+      <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path
+          v-if="!mobileOpen"
+          stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+          d="M4 6h16M4 12h16M4 18h16"
+        />
+        <path
+          v-else
+          stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+          d="M6 18L18 6M6 6l12 12"
+        />
+      </svg>
+    </button>
+  </div>
+
+  <!-- Mobile nav drawer -->
+  <div v-if="mobileOpen" class="md:hidden bg-violet-900 text-white px-4 pb-4 space-y-1">
+    <component
+      v-for="item in navItems"
+      :key="item.label"
+      :is="item.to.startsWith('/') ? 'router-link' : 'button'"
+      :to="item.to.startsWith('/') ? item.to : undefined"
+      :class="[
+        'flex items-center space-x-3 w-full px-3 py-2 rounded-lg text-sm font-medium transition-colors',
+        isActive(item.to)
+          ? 'bg-white/20 text-white'
+          : 'text-violet-300 hover:bg-white/10 hover:text-white',
+      ]"
+      @click="mobileOpen = false"
+    >
+      <font-awesome-icon :icon="['fas', item.icon]" class="w-5" />
+      <span>{{ item.label }}</span>
+    </component>
+    <router-link
+      to="/design-options"
+      class="flex items-center space-x-3 w-full px-3 py-2 rounded-lg text-sm font-medium text-violet-300 hover:bg-white/10 hover:text-white transition-colors"
+      @click="mobileOpen = false"
+    >
+      <font-awesome-icon :icon="['fas', 'arrow-left']" class="w-5" />
+      <span>Design Options</span>
+    </router-link>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref } from 'vue';
+import { useRoute } from 'vue-router';
+import { library } from '@fortawesome/fontawesome-svg-core';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import {
+  faChartPie,
+  faUsers,
+  faUserMd,
+  faCalendarCheck,
+  faCreditCard,
+  faFileAlt,
+  faArrowLeft,
+} from '@fortawesome/free-solid-svg-icons';
+
+library.add(faChartPie, faUsers, faUserMd, faCalendarCheck, faCreditCard, faFileAlt, faArrowLeft);
+
+export default defineComponent({
+  name: 'O2MobileNav',
+  components: { FontAwesomeIcon },
+  setup() {
+    const route = useRoute();
+    const mobileOpen = ref(false);
+
+    const navItems = [
+      { label: 'Dashboard', icon: 'chart-pie', to: '/' },
+      { label: 'Patients', icon: 'users', to: '/patients' },
+      { label: 'Therapists', icon: 'user-md', to: '#' },
+      { label: 'Schedule', icon: 'calendar-check', to: '#' },
+      { label: 'Billing', icon: 'credit-card', to: '#' },
+      { label: 'Reports', icon: 'file-alt', to: '#' },
+    ];
+
+    const isActive = (to: string) => {
+      if (to === '#') return false;
+      return route.path === to;
+    };
+
+    return { navItems, isActive, mobileOpen };
+  },
+});
+</script>

--- a/app-ui/src/components/option02/O2Sidebar.vue
+++ b/app-ui/src/components/option02/O2Sidebar.vue
@@ -9,12 +9,14 @@
 
     <!-- Nav Items -->
     <nav class="flex-1 flex flex-col items-center py-6 space-y-2">
-      <button
+      <component
         v-for="item in navItems"
         :key="item.label"
+        :is="item.to.startsWith('/') ? 'router-link' : 'button'"
+        :to="item.to.startsWith('/') ? item.to : undefined"
         :class="[
           'w-12 h-12 rounded-xl flex flex-col items-center justify-center transition-all duration-150',
-          item.active
+          isActive(item.to)
             ? 'bg-white/20 text-white'
             : 'text-violet-300 hover:bg-white/10 hover:text-white',
         ]"
@@ -22,7 +24,7 @@
       >
         <font-awesome-icon :icon="['fas', item.icon]" class="text-lg" />
         <span class="text-[9px] mt-0.5 font-medium">{{ item.label }}</span>
-      </button>
+      </component>
     </nav>
 
     <!-- Bottom -->
@@ -41,6 +43,7 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
+import { useRoute } from 'vue-router';
 import { library } from '@fortawesome/fontawesome-svg-core';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import {
@@ -59,16 +62,23 @@ export default defineComponent({
   name: 'O2Sidebar',
   components: { FontAwesomeIcon },
   setup() {
+    const route = useRoute();
+
     const navItems = [
-      { label: 'Dashboard', icon: 'chart-pie', active: true },
-      { label: 'Patients', icon: 'users', active: false },
-      { label: 'Therapists', icon: 'user-md', active: false },
-      { label: 'Schedule', icon: 'calendar-check', active: false },
-      { label: 'Billing', icon: 'credit-card', active: false },
-      { label: 'Reports', icon: 'file-alt', active: false },
+      { label: 'Dashboard', icon: 'chart-pie', to: '/' },
+      { label: 'Patients', icon: 'users', to: '/patients' },
+      { label: 'Therapists', icon: 'user-md', to: '#' },
+      { label: 'Schedule', icon: 'calendar-check', to: '#' },
+      { label: 'Billing', icon: 'credit-card', to: '#' },
+      { label: 'Reports', icon: 'file-alt', to: '#' },
     ];
 
-    return { navItems };
+    const isActive = (to: string) => {
+      if (to === '#') return false;
+      return route.path === to;
+    };
+
+    return { navItems, isActive };
   },
 });
 </script>

--- a/app-ui/src/router/index.ts
+++ b/app-ui/src/router/index.ts
@@ -6,7 +6,7 @@ const router = createRouter({
     {
       path: '/',
       name: 'dashboard',
-      component: () => import('../views/Option01View.vue'),
+      component: () => import('../views/Option02View.vue'),
     },
     {
       path: '/patients',
@@ -24,9 +24,9 @@ const router = createRouter({
       component: () => import('../views/CurrentView.vue'),
     },
     {
-      path: '/option-02',
-      name: 'option-02',
-      component: () => import('../views/Option02View.vue'),
+      path: '/option-01',
+      name: 'option-01',
+      component: () => import('../views/Option01View.vue'),
     },
     {
       path: '/option-03',

--- a/app-ui/src/views/CompareView.vue
+++ b/app-ui/src/views/CompareView.vue
@@ -28,8 +28,8 @@
 
         <!-- Option 01 -->
         <router-link
-          to="/"
-          class="group block bg-white rounded-xl border-2 border-blue-200 hover:border-blue-400 shadow-sm hover:shadow-lg transition-all duration-200 overflow-hidden"
+          to="/option-01"
+          class="group block bg-white rounded-xl border-2 border-gray-200 hover:border-blue-400 shadow-sm hover:shadow-lg transition-all duration-200 overflow-hidden"
         >
           <div class="bg-gradient-to-br from-blue-600 to-teal-500 px-6 py-10 text-center">
             <span class="text-4xl">🏥</span>
@@ -45,10 +45,10 @@
           </div>
         </router-link>
 
-        <!-- Option 02 -->
+        <!-- Option 02 (current) -->
         <router-link
-          to="/option-02"
-          class="group block bg-white rounded-xl border-2 border-violet-200 hover:border-violet-400 shadow-sm hover:shadow-lg transition-all duration-200 overflow-hidden"
+          to="/"
+          class="group block bg-white rounded-xl border-2 border-violet-400 hover:border-violet-500 shadow-md hover:shadow-lg transition-all duration-200 overflow-hidden ring-2 ring-violet-200"
         >
           <div class="bg-gradient-to-br from-violet-700 to-indigo-500 px-6 py-10 text-center">
             <span class="text-4xl">📊</span>

--- a/app-ui/src/views/Option02View.vue
+++ b/app-ui/src/views/Option02View.vue
@@ -1,34 +1,29 @@
 <template>
-  <div class="flex min-h-screen bg-gray-100 font-sans">
-    <!-- Sidebar -->
-    <O2Sidebar />
-
-    <!-- Main Area -->
-    <div class="flex-1 flex flex-col min-w-0">
-      <O2Header />
-      <main class="flex-1 p-6 overflow-y-auto">
-        <!-- Stats Row -->
-        <O2StatsBar :appointments="allAppointments" />
-
-        <!-- Widgets Grid -->
-        <div class="grid grid-cols-1 xl:grid-cols-3 gap-6 mt-6">
-          <!-- Calendar Widget -->
-          <div class="xl:col-span-1">
-            <O2Calendar
-              :selectedDate="selectedDate"
-              @date-selected="updateSelectedDate"
-            />
+  <div class="min-h-screen bg-gray-100 font-sans">
+    <O2MobileNav />
+    <div class="flex flex-1">
+      <O2Sidebar />
+      <div class="flex-1 flex flex-col min-w-0">
+        <O2Header />
+        <main class="flex-1 p-6 overflow-y-auto">
+          <O2StatsBar :appointments="allAppointments" />
+          <div class="grid grid-cols-1 xl:grid-cols-3 gap-6 mt-6">
+            <div class="xl:col-span-1">
+              <O2Calendar
+                :selectedDate="selectedDate"
+                @date-selected="updateSelectedDate"
+              />
+            </div>
+            <div class="xl:col-span-2">
+              <O2Appointments
+                :selectedDate="selectedDate"
+                @appointments-loaded="onAppointmentsLoaded"
+              />
+            </div>
           </div>
-          <!-- Appointments Widget -->
-          <div class="xl:col-span-2">
-            <O2Appointments
-              :selectedDate="selectedDate"
-              @appointments-loaded="onAppointmentsLoaded"
-            />
-          </div>
-        </div>
-      </main>
-      <O2Footer />
+        </main>
+        <O2Footer />
+      </div>
     </div>
   </div>
 </template>
@@ -36,6 +31,7 @@
 <script lang="ts">
 import { defineComponent, ref } from 'vue';
 import { Appointment } from '../interfaces/Appointment';
+import O2MobileNav from '../components/option02/O2MobileNav.vue';
 import O2Sidebar from '../components/option02/O2Sidebar.vue';
 import O2Header from '../components/option02/O2Header.vue';
 import O2StatsBar from '../components/option02/O2StatsBar.vue';
@@ -46,6 +42,7 @@ import O2Footer from '../components/option02/O2Footer.vue';
 export default defineComponent({
   name: 'Option02View',
   components: {
+    O2MobileNav,
     O2Sidebar,
     O2Header,
     O2StatsBar,

--- a/app-ui/src/views/PatientsView.vue
+++ b/app-ui/src/views/PatientsView.vue
@@ -1,22 +1,28 @@
 <template>
   <div class="min-h-screen bg-slate-50 font-sans">
-    <O1Navbar />
-    <main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
-      <div class="mb-6">
-        <h1 class="text-2xl font-bold text-slate-800">Patient Management</h1>
-        <p class="text-sm text-slate-500 mt-1">View and manage patient records</p>
+    <O2MobileNav />
+    <div class="flex flex-1">
+      <O2Sidebar />
+      <div class="flex-1 flex flex-col">
+      <O2Header />
+      <main class="flex-1 max-w-7xl mx-auto w-full px-4 sm:px-6 lg:px-8 py-6">
+        <div class="mb-6">
+          <h1 class="text-2xl font-bold text-slate-800">Patient Management</h1>
+          <p class="text-sm text-slate-500 mt-1">View and manage patient records</p>
+        </div>
+        <PatientList
+          :patients="patients"
+          :loading="loading"
+          :error="error"
+          @add="openAdd"
+          @edit="openEdit"
+          @toggle-active="toggleActive"
+          @retry="loadPatients"
+        />
+      </main>
+        <O2Footer />
       </div>
-      <PatientList
-        :patients="patients"
-        :loading="loading"
-        :error="error"
-        @add="openAdd"
-        @edit="openEdit"
-        @toggle-active="toggleActive"
-        @retry="loadPatients"
-      />
-    </main>
-    <O1Footer />
+    </div>
 
     <PatientFormModal
       :visible="modalVisible"
@@ -29,8 +35,10 @@
 
 <script lang="ts">
 import { defineComponent, ref, onMounted } from 'vue';
-import O1Navbar from '../components/option01/O1Navbar.vue';
-import O1Footer from '../components/option01/O1Footer.vue';
+import O2MobileNav from '../components/option02/O2MobileNav.vue';
+import O2Sidebar from '../components/option02/O2Sidebar.vue';
+import O2Header from '../components/option02/O2Header.vue';
+import O2Footer from '../components/option02/O2Footer.vue';
 import PatientList from '../components/patients/PatientList.vue';
 import PatientFormModal from '../components/patients/PatientFormModal.vue';
 import { PatientsHttpClient } from '../services/PatientsHttpClient';
@@ -38,7 +46,7 @@ import type { Patient } from '../interfaces/Patient';
 
 export default defineComponent({
   name: 'PatientsView',
-  components: { O1Navbar, O1Footer, PatientList, PatientFormModal },
+  components: { O2MobileNav, O2Sidebar, O2Header, O2Footer, PatientList, PatientFormModal },
   setup() {
     const client = new PatientsHttpClient();
     const patients = ref<Patient[]>([]);


### PR DESCRIPTION
…ard Cards)

- Rewire routes: / loads Option02View, /option-01 added for gallery demo
- O2Sidebar: route-aware nav with active highlighting (Dashboard, Patients)
- PatientsView: swap O1 shell for O2 shell (sidebar + header + footer)
- CompareView: Option 02 card highlighted as current, Option 01 links to /option-01
- O1Navbar: self-contained demo links (Dashboard → /option-01, Patients → #)
- O2Header: Add Patient button navigates to /patients, others disabled with tooltip
- O2MobileNav: new hamburger menu + drawer for mobile screens (<md breakpoint)