### PR TITLE
Add Delinquent tab to Patient Management with dashboard deep linking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ Thumbs.db
 
 # User directories and files
 logs/**
+*.png
 
 # Editor directories and files
 .idea/

--- a/app-ui/src/components/option02/O2Appointments.vue
+++ b/app-ui/src/components/option02/O2Appointments.vue
@@ -205,7 +205,6 @@ export default defineComponent({
       activeTab,
       tabs,
       highlightedEl,
-      highlightedSessionId: computed(() => props.highlightedSessionId),
     };
   },
 });

--- a/app-ui/src/components/option02/O2Appointments.vue
+++ b/app-ui/src/components/option02/O2Appointments.vue
@@ -30,9 +30,12 @@
         <div
           v-for="appt in visibleAppointments"
           :key="appt.sessionId"
+          :ref="(el) => { if (el && appt.sessionId === highlightedSessionId) highlightedEl = el as HTMLElement; }"
           :class="[
             'flex items-center px-5 py-3 gap-4 transition-colors',
-            appt.isPastDue ? 'bg-red-50 hover:bg-red-100' : 'hover:bg-gray-50',
+            appt.sessionId === highlightedSessionId
+              ? 'ring-2 ring-amber-400 bg-amber-50'
+              : appt.isPastDue ? 'bg-red-50 hover:bg-red-100' : 'hover:bg-gray-50',
           ]"
         >
           <!-- Time -->
@@ -104,7 +107,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, watch, computed, onMounted } from 'vue';
+import { defineComponent, ref, watch, computed, onMounted, nextTick } from 'vue';
 import { Appointment } from '../../interfaces/Appointment';
 import { SessionsHttpClient } from '../../services/SessionsHttpClient';
 import { library } from '@fortawesome/fontawesome-svg-core';
@@ -127,12 +130,17 @@ export default defineComponent({
       type: String,
       required: true,
     },
+    highlightedSessionId: {
+      type: Number,
+      default: null,
+    },
   },
   emits: ['appointments-loaded'],
   setup(props, { emit }) {
     const sessionsHttpClient = new SessionsHttpClient();
     const allAppointments = ref<Appointment[]>([]);
     const activeTab = ref<'all' | 'am' | 'pm'>('all');
+    const highlightedEl = ref<HTMLElement | null>(null);
 
     const determineTime = (app: Appointment): 'AM' | 'PM' => {
       if (app.time) {
@@ -147,6 +155,10 @@ export default defineComponent({
         const appointments = await sessionsHttpClient.getSessions(date);
         allAppointments.value = appointments;
         emit('appointments-loaded', appointments);
+        if (props.highlightedSessionId) {
+          await nextTick();
+          highlightedEl.value?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        }
       } catch (error) {
         console.error('Error fetching appointments:', error);
         allAppointments.value = [];
@@ -192,6 +204,8 @@ export default defineComponent({
       visibleAppointments,
       activeTab,
       tabs,
+      highlightedEl,
+      highlightedSessionId: computed(() => props.highlightedSessionId),
     };
   },
 });

--- a/app-ui/src/components/patients/DelinquentTable.vue
+++ b/app-ui/src/components/patients/DelinquentTable.vue
@@ -1,0 +1,179 @@
+<template>
+  <!-- Desktop table -->
+  <div class="hidden md:block bg-white rounded-xl border border-slate-200 overflow-hidden">
+    <table class="w-full">
+      <thead>
+        <tr class="bg-amber-50 border-b border-amber-200">
+          <th class="px-4 py-3 text-left text-xs font-semibold text-amber-700 uppercase tracking-wider w-8"></th>
+          <th class="px-4 py-3 text-left text-xs font-semibold text-amber-700 uppercase tracking-wider">Patient</th>
+          <th class="px-4 py-3 text-left text-xs font-semibold text-amber-700 uppercase tracking-wider">Past-Due Sessions</th>
+          <th class="px-4 py-3 text-left text-xs font-semibold text-amber-700 uppercase tracking-wider">Total Due</th>
+          <th class="px-4 py-3 text-left text-xs font-semibold text-amber-700 uppercase tracking-wider">Paid So Far</th>
+          <th class="px-4 py-3 text-left text-xs font-semibold text-amber-700 uppercase tracking-wider">Balance</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-slate-100">
+        <template v-for="dp in filteredPatients" :key="dp.party.id">
+          <!-- Summary row -->
+          <tr
+            class="hover:bg-amber-50/50 transition-colors cursor-pointer"
+            @click="toggleExpand(dp.party.id)"
+          >
+            <td class="px-4 py-3 text-sm text-slate-400">
+              <svg
+                :class="['w-4 h-4 transition-transform', expanded.has(dp.party.id) ? 'rotate-90' : '']"
+                fill="none" stroke="currentColor" viewBox="0 0 24 24"
+              >
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+              </svg>
+            </td>
+            <td class="px-4 py-3 text-sm font-medium text-slate-800">{{ dp.party.name }}</td>
+            <td class="px-4 py-3 text-sm">
+              <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-700">
+                {{ dp.pastDueSessions }}
+              </span>
+            </td>
+            <td class="px-4 py-3 text-sm font-medium text-amber-700">${{ dp.pastDueTotalAmount.toFixed(2) }}</td>
+            <td class="px-4 py-3 text-sm text-slate-600">${{ dp.amountPaidSoFar.toFixed(2) }}</td>
+            <td class="px-4 py-3 text-sm font-semibold text-red-600">${{ (dp.pastDueTotalAmount - dp.amountPaidSoFar).toFixed(2) }}</td>
+          </tr>
+          <!-- Expanded session detail rows -->
+          <template v-if="expanded.has(dp.party.id)">
+            <tr
+              v-for="session in dp.delinquency"
+              :key="session.sessionId"
+              class="bg-amber-50/30"
+            >
+              <td class="px-4 py-2"></td>
+              <td colspan="5" class="px-4 py-2">
+                <router-link
+                  :to="{ path: '/', query: { date: session.sessionDate, highlightSession: String(session.sessionId) } }"
+                  class="flex items-center justify-between group hover:bg-amber-100/50 rounded-lg px-3 py-2 -mx-3 transition-colors"
+                >
+                  <div class="flex items-center space-x-4">
+                    <span class="text-xs text-slate-400 w-20">{{ formatDate(session.sessionDate) }}</span>
+                    <span class="text-xs text-slate-600">{{ session.therapist }}</span>
+                    <span class="text-xs text-slate-400">{{ session.therapyTypes }}</span>
+                  </div>
+                  <div class="flex items-center space-x-4">
+                    <span class="text-xs text-slate-500">${{ session.amount.toFixed(2) }}</span>
+                    <span v-if="session.discount > 0" class="text-xs text-green-600">-${{ session.discount.toFixed(2) }}</span>
+                    <span class="text-xs font-medium text-amber-700">${{ session.amountDue.toFixed(2) }} due</span>
+                    <svg class="w-3.5 h-3.5 text-slate-400 group-hover:text-blue-500 transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                    </svg>
+                  </div>
+                </router-link>
+              </td>
+            </tr>
+          </template>
+        </template>
+        <tr v-if="filteredPatients.length === 0">
+          <td colspan="6" class="px-4 py-12 text-center text-sm text-slate-400">
+            No delinquent patients found.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <!-- Mobile cards -->
+  <div class="md:hidden space-y-3">
+    <div
+      v-for="dp in filteredPatients"
+      :key="dp.party.id"
+      class="bg-white rounded-xl border border-slate-200 overflow-hidden"
+    >
+      <!-- Summary card header -->
+      <div
+        class="p-4 cursor-pointer"
+        @click="toggleExpand(dp.party.id)"
+      >
+        <div class="flex items-start justify-between mb-2">
+          <div class="flex items-center space-x-2">
+            <svg
+              :class="['w-4 h-4 text-slate-400 transition-transform', expanded.has(dp.party.id) ? 'rotate-90' : '']"
+              fill="none" stroke="currentColor" viewBox="0 0 24 24"
+            >
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+            </svg>
+            <p class="text-sm font-semibold text-slate-800">{{ dp.party.name }}</p>
+          </div>
+          <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-700">
+            {{ dp.pastDueSessions }} past due
+          </span>
+        </div>
+        <div class="grid grid-cols-3 gap-2 text-xs text-slate-500">
+          <div><span class="font-medium">Total Due:</span> ${{ dp.pastDueTotalAmount.toFixed(2) }}</div>
+          <div><span class="font-medium">Paid:</span> ${{ dp.amountPaidSoFar.toFixed(2) }}</div>
+          <div><span class="font-medium text-red-600">Balance:</span> <span class="text-red-600">${{ (dp.pastDueTotalAmount - dp.amountPaidSoFar).toFixed(2) }}</span></div>
+        </div>
+      </div>
+
+      <!-- Expanded sessions -->
+      <div v-if="expanded.has(dp.party.id)" class="border-t border-slate-100 divide-y divide-slate-50">
+        <router-link
+          v-for="session in dp.delinquency"
+          :key="session.sessionId"
+          :to="{ path: '/', query: { date: session.sessionDate, highlightSession: String(session.sessionId) } }"
+          class="block px-4 py-3 bg-amber-50/30 hover:bg-amber-100/50 transition-colors"
+        >
+          <div class="flex items-center justify-between text-xs">
+            <div class="space-x-2">
+              <span class="text-slate-500">{{ formatDate(session.sessionDate) }}</span>
+              <span class="text-slate-600">{{ session.therapist }}</span>
+              <span class="text-slate-400">{{ session.therapyTypes }}</span>
+            </div>
+            <span class="font-medium text-amber-700">${{ session.amountDue.toFixed(2) }}</span>
+          </div>
+        </router-link>
+      </div>
+    </div>
+    <div v-if="filteredPatients.length === 0" class="text-center py-12 text-sm text-slate-400">
+      No delinquent patients found.
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref, computed, type PropType } from 'vue';
+import type { DelinquentPatient } from '../../interfaces/Delinquency';
+
+export default defineComponent({
+  name: 'DelinquentTable',
+  props: {
+    patients: { type: Array as PropType<DelinquentPatient[]>, required: true },
+    search: { type: String, default: '' },
+  },
+  setup(props) {
+    const expanded = ref<Set<number>>(new Set());
+
+    const toggleExpand = (id: number) => {
+      const next = new Set(expanded.value);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      expanded.value = next;
+    };
+
+    const filteredPatients = computed(() => {
+      const q = props.search.trim().toLowerCase();
+      if (!q) return props.patients;
+      return props.patients.filter((dp) =>
+        dp.party.name.toLowerCase().includes(q)
+      );
+    });
+
+    const formatDate = (dateStr: string) => {
+      if (!dateStr) return '';
+      const d = new Date(dateStr + 'T00:00:00');
+      if (isNaN(d.getTime())) return dateStr;
+      return d.toLocaleDateString('en-US', { month: '2-digit', day: '2-digit', year: 'numeric' });
+    };
+
+    return { expanded, toggleExpand, filteredPatients, formatDate };
+  },
+});
+</script>

--- a/app-ui/src/components/patients/PatientList.vue
+++ b/app-ui/src/components/patients/PatientList.vue
@@ -147,7 +147,7 @@ export default defineComponent({
       return list;
     });
 
-    return { search, activeFilter, tabs, filteredPatients, onTabClick, pastDuePatients: computed(() => props.pastDuePatients) };
+    return { search, activeFilter, tabs, filteredPatients, onTabClick };
   },
 });
 </script>

--- a/app-ui/src/components/patients/PatientList.vue
+++ b/app-ui/src/components/patients/PatientList.vue
@@ -33,16 +33,21 @@
           :class="[
             'px-4 py-1.5 rounded-md text-sm font-medium transition-colors',
             activeFilter === tab.value
-              ? 'bg-white text-slate-800 shadow-sm'
+              ? tab.value === 'delinquent'
+                ? 'bg-white text-amber-700 shadow-sm'
+                : 'bg-white text-slate-800 shadow-sm'
               : 'text-slate-500 hover:text-slate-700',
           ]"
-          @click="activeFilter = tab.value"
+          @click="onTabClick(tab.value)"
         >
           {{ tab.label }}
         </button>
       </div>
-      <span class="text-sm text-slate-500">
+      <span v-if="activeFilter !== 'delinquent'" class="text-sm text-slate-500">
         {{ filteredPatients.length }} patient{{ filteredPatients.length !== 1 ? 's' : '' }}
+      </span>
+      <span v-else class="text-sm text-amber-600">
+        {{ pastDuePatients.length }} patient{{ pastDuePatients.length !== 1 ? 's' : '' }} past due
       </span>
     </div>
 
@@ -63,7 +68,14 @@
       </button>
     </div>
 
-    <!-- Table -->
+    <!-- Delinquent tab -->
+    <DelinquentTable
+      v-else-if="activeFilter === 'delinquent'"
+      :patients="pastDuePatients"
+      :search="search"
+    />
+
+    <!-- Standard patient table -->
     <PatientTable
       v-else
       :patients="filteredPatients"
@@ -74,28 +86,44 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, computed, type PropType } from 'vue';
+import { defineComponent, ref, computed, onMounted, type PropType } from 'vue';
 import type { Patient } from '../../interfaces/Patient';
+import type { DelinquentPatient } from '../../interfaces/Delinquency';
 import PatientTable from './PatientTable.vue';
+import DelinquentTable from './DelinquentTable.vue';
 
 export default defineComponent({
   name: 'PatientList',
-  components: { PatientTable },
+  components: { PatientTable, DelinquentTable },
   props: {
     patients: { type: Array as PropType<Patient[]>, required: true },
+    pastDuePatients: { type: Array as PropType<DelinquentPatient[]>, default: () => [] },
+    initialTab: { type: String as PropType<'all' | 'active' | 'inactive' | 'delinquent'>, default: 'all' },
     loading: { type: Boolean, default: false },
     error: { type: String, default: '' },
   },
-  emits: ['add', 'edit', 'toggle-active', 'retry'],
-  setup(props) {
+  emits: ['add', 'edit', 'toggle-active', 'retry', 'tab-change'],
+  setup(props, { emit }) {
     const search = ref('');
-    const activeFilter = ref<'all' | 'active' | 'inactive'>('all');
+    const activeFilter = ref<'all' | 'active' | 'inactive' | 'delinquent'>(props.initialTab);
+
+    onMounted(() => {
+      if (props.initialTab !== 'all') {
+        emit('tab-change', props.initialTab);
+      }
+    });
 
     const tabs = [
       { label: 'All', value: 'all' as const },
       { label: 'Active', value: 'active' as const },
       { label: 'Inactive', value: 'inactive' as const },
+      { label: 'Delinquent', value: 'delinquent' as const },
     ];
+
+    const onTabClick = (value: 'all' | 'active' | 'inactive' | 'delinquent') => {
+      activeFilter.value = value;
+      emit('tab-change', value);
+    };
 
     const filteredPatients = computed(() => {
       let list = props.patients;
@@ -119,7 +147,7 @@ export default defineComponent({
       return list;
     });
 
-    return { search, activeFilter, tabs, filteredPatients };
+    return { search, activeFilter, tabs, filteredPatients, onTabClick, pastDuePatients: computed(() => props.pastDuePatients) };
   },
 });
 </script>

--- a/app-ui/src/interfaces/Delinquency.ts
+++ b/app-ui/src/interfaces/Delinquency.ts
@@ -1,0 +1,34 @@
+// interfaces/Delinquency.ts
+
+export interface DelinquentParty {
+  id: number;
+  name: string;
+  isValid: boolean;
+}
+
+export interface DelinquentSession {
+  sessionId: number;
+  sessionDate: string;
+  sessionTime: string;
+  patient: string;
+  therapist: string;
+  therapyTypes: string;
+  amount: number;
+  discount: number;
+  amountPaid: number;
+  amountDue: number;
+  isPastDue: boolean;
+  isPaidOff: boolean;
+  notes: string;
+  patientId: number;
+  therapistId: number;
+}
+
+export interface DelinquentPatient {
+  partyType: string;
+  party: DelinquentParty;
+  pastDueSessions: number;
+  pastDueTotalAmount: number;
+  amountPaidSoFar: number;
+  delinquency: DelinquentSession[];
+}

--- a/app-ui/src/services/PatientsHttpClient.ts
+++ b/app-ui/src/services/PatientsHttpClient.ts
@@ -1,6 +1,7 @@
 // services/PatientsHttpClient.ts
 import { HttpClientBase } from './HttpClientBase';
 import type { Patient, PatientCreateRequest, PatientUpdateRequest } from '../interfaces/Patient';
+import type { DelinquentPatient } from '../interfaces/Delinquency';
 
 export class PatientsHttpClient extends HttpClientBase {
   async getPatients(): Promise<Patient[]> {
@@ -17,5 +18,9 @@ export class PatientsHttpClient extends HttpClientBase {
 
   async updatePatient(id: number, data: PatientUpdateRequest): Promise<void> {
     return this.put(`/api/patients/${id}`, data);
+  }
+
+  async getPastDuePatients(): Promise<DelinquentPatient[]> {
+    return this.get<DelinquentPatient[]>('/api/patients/pastdue');
   }
 }

--- a/app-ui/src/views/Option02View.vue
+++ b/app-ui/src/views/Option02View.vue
@@ -6,6 +6,18 @@
       <div class="flex-1 flex flex-col min-w-0">
         <O2Header />
         <main class="flex-1 p-6 overflow-y-auto">
+          <!-- Back to delinquent review banner -->
+          <router-link
+            v-if="cameFromDelinquent"
+            to="/patients?tab=delinquent"
+            class="mb-4 flex items-center space-x-2 px-4 py-2.5 bg-amber-50 border border-amber-200 rounded-lg text-sm text-amber-700 hover:bg-amber-100 transition-colors w-fit"
+          >
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+            </svg>
+            <span class="font-medium">Back to Delinquent Review</span>
+          </router-link>
+
           <O2StatsBar :appointments="allAppointments" />
           <div class="grid grid-cols-1 xl:grid-cols-3 gap-6 mt-6">
             <div class="xl:col-span-1">
@@ -17,6 +29,7 @@
             <div class="xl:col-span-2">
               <O2Appointments
                 :selectedDate="selectedDate"
+                :highlightedSessionId="highlightedSessionId"
                 @appointments-loaded="onAppointmentsLoaded"
               />
             </div>
@@ -29,7 +42,8 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref } from 'vue';
+import { defineComponent, ref, onMounted, computed } from 'vue';
+import { useRoute } from 'vue-router';
 import { Appointment } from '../interfaces/Appointment';
 import O2MobileNav from '../components/option02/O2MobileNav.vue';
 import O2Sidebar from '../components/option02/O2Sidebar.vue';
@@ -51,8 +65,27 @@ export default defineComponent({
     O2Footer,
   },
   setup() {
+    const route = useRoute();
     const selectedDate = ref<string>(new Date().toLocaleDateString('en-US'));
     const allAppointments = ref<Appointment[]>([]);
+
+    const highlightedSessionId = computed(() => {
+      const val = route.query.highlightSession;
+      return val ? Number(val) : undefined;
+    });
+
+    const cameFromDelinquent = computed(() => !!route.query.highlightSession);
+
+    onMounted(() => {
+      const dateParam = route.query.date as string | undefined;
+      if (dateParam) {
+        // Convert yyyy-MM-dd to en-US locale string
+        const d = new Date(dateParam + 'T00:00:00');
+        if (!isNaN(d.getTime())) {
+          selectedDate.value = d.toLocaleDateString('en-US');
+        }
+      }
+    });
 
     const updateSelectedDate = (date: string) => {
       selectedDate.value = date;
@@ -65,6 +98,8 @@ export default defineComponent({
     return {
       selectedDate,
       allAppointments,
+      highlightedSessionId,
+      cameFromDelinquent,
       updateSelectedDate,
       onAppointmentsLoaded,
     };

--- a/app-ui/src/views/PatientsView.vue
+++ b/app-ui/src/views/PatientsView.vue
@@ -12,12 +12,15 @@
         </div>
         <PatientList
           :patients="patients"
+          :initial-tab="initialTab"
           :loading="loading"
           :error="error"
+          :past-due-patients="pastDuePatients"
           @add="openAdd"
           @edit="openEdit"
           @toggle-active="toggleActive"
           @retry="loadPatients"
+          @tab-change="onTabChange"
         />
       </main>
         <O2Footer />
@@ -63,7 +66,8 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, onMounted } from 'vue';
+import { defineComponent, ref, computed, onMounted } from 'vue';
+import { useRoute } from 'vue-router';
 import O2MobileNav from '../components/option02/O2MobileNav.vue';
 import O2Sidebar from '../components/option02/O2Sidebar.vue';
 import O2Header from '../components/option02/O2Header.vue';
@@ -73,18 +77,29 @@ import PatientFormModal from '../components/patients/PatientFormModal.vue';
 import { PatientsHttpClient } from '../services/PatientsHttpClient';
 import type { Patient } from '../interfaces/Patient';
 import { isTemporaryMrn } from '../interfaces/Patient';
+import type { DelinquentPatient } from '../interfaces/Delinquency';
 
 export default defineComponent({
   name: 'PatientsView',
   components: { O2MobileNav, O2Sidebar, O2Header, O2Footer, PatientList, PatientFormModal },
   setup() {
+    const route = useRoute();
     const client = new PatientsHttpClient();
+
+    const validTabs = ['all', 'active', 'inactive', 'delinquent'] as const;
+    type TabValue = typeof validTabs[number];
+    const initialTab = computed<TabValue>(() => {
+      const tab = route.query.tab as string | undefined;
+      return tab && (validTabs as readonly string[]).includes(tab) ? tab as TabValue : 'all';
+    });
     const patients = ref<Patient[]>([]);
     const loading = ref(false);
     const error = ref('');
     const modalVisible = ref(false);
     const editingPatient = ref<Patient | null>(null);
     const tempMrnBanner = ref('');
+    const pastDuePatients = ref<DelinquentPatient[]>([]);
+    const pastDueLoaded = ref(false);
 
     const loadPatients = async () => {
       loading.value = true;
@@ -127,13 +142,31 @@ export default defineComponent({
           activeStatus: !patient.isActive,
         });
         await loadPatients();
+        pastDueLoaded.value = false;
       } catch (e: unknown) {
         error.value = e instanceof Error ? e.message : 'Failed to update patient status.';
       }
     };
 
+    const loadPastDuePatients = async () => {
+      if (pastDueLoaded.value) return;
+      try {
+        pastDuePatients.value = await client.getPastDuePatients();
+        pastDueLoaded.value = true;
+      } catch (e: unknown) {
+        error.value = e instanceof Error ? e.message : 'Failed to load delinquent patients.';
+      }
+    };
+
+    const onTabChange = (tab: string) => {
+      if (tab === 'delinquent') {
+        loadPastDuePatients();
+      }
+    };
+
     const onSaved = () => {
       loadPatients();
+      pastDueLoaded.value = false;
     };
 
     const onCreatedTempMrn = (patient: Patient) => {
@@ -150,12 +183,15 @@ export default defineComponent({
       modalVisible,
       editingPatient,
       tempMrnBanner,
+      pastDuePatients,
+      initialTab,
       loadPatients,
       openAdd,
       openEdit,
       toggleActive,
       onSaved,
       onCreatedTempMrn,
+      onTabChange,
     };
   },
 });

--- a/docs/adr/002-ui-alert-color-conventions.md
+++ b/docs/adr/002-ui-alert-color-conventions.md
@@ -1,0 +1,36 @@
+# ADR-002: UI Alert Color Conventions
+
+## Status
+Accepted
+
+## Context
+As the patient care UI grows, we need consistent color conventions for alert states across components. Without a shared standard, different developers may use conflicting colors for similar states, confusing front-desk staff.
+
+## Decision
+We adopt the following Tailwind color conventions for semantic UI states:
+
+### Amber — "Needs Attention"
+- **Classes**: `bg-amber-100 text-amber-700`, `bg-amber-50 border-amber-300`
+- **Usage**: Temporary MRN badges, delinquent patient tab, warning banners, highlighted sessions from deep links
+- **Highlight ring**: `ring-2 ring-amber-400 bg-amber-50`
+
+### Green — Positive / Active Status
+- **Classes**: `bg-green-100 text-green-700`
+- **Usage**: Active status badges, paid-off session indicators
+
+### Slate — Neutral / Inactive Status
+- **Classes**: `bg-slate-100 text-slate-500`
+- **Usage**: Inactive status badges, disabled controls, secondary text
+
+### Red — Error States
+- **Classes**: `bg-red-50 text-red-700`
+- **Usage**: API failures, validation errors, past-due session rows
+
+### Blue — Interactive / Focus States
+- **Classes**: `ring-blue-500`, `text-blue-600`, `bg-blue-600` (buttons)
+- **Usage**: Focused inputs, clickable links, primary action buttons, sort indicators
+
+## Consequences
+- All new UI components should follow these conventions
+- Existing components already conform (temp-MRN badges, status badges, error states)
+- The delinquent tab uses amber to align with the "needs attention" pattern


### PR DESCRIPTION
Adds a lazy-loaded "Delinquent" tab to the Patients page that fetches past-due data from GET /api/patients/pastdue. Summary rows show per-patient totals with expandable session details. Clicking a session deep links to the dashboard with that session highlighted (amber ring + auto-scroll). A "Back to Delinquent Review" banner on the dashboard returns the user to the Patients page with the Delinquent tab pre-selected.