### PR TITLE
Add past due financial summary to Option 02 dashboard

### DIFF
--- a/app-ui/src/components/option02/O2Appointments.vue
+++ b/app-ui/src/components/option02/O2Appointments.vue
@@ -86,6 +86,7 @@
             >
               <font-awesome-icon :icon="['fas', 'exclamation-circle']" class="text-[9px]" />
               Past Due
+              <span class="text-red-500">&middot; {{ formatCurrency(appt.amountDue) }}</span>
             </span>
             <span
               v-else
@@ -109,6 +110,7 @@
 <script lang="ts">
 import { defineComponent, ref, watch, computed, onMounted, nextTick } from 'vue';
 import { Appointment } from '../../interfaces/Appointment';
+import { formatCurrency } from '../../utils/formatCurrency';
 import { SessionsHttpClient } from '../../services/SessionsHttpClient';
 import { library } from '@fortawesome/fontawesome-svg-core';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
@@ -205,6 +207,7 @@ export default defineComponent({
       activeTab,
       tabs,
       highlightedEl,
+      formatCurrency,
     };
   },
 });

--- a/app-ui/src/components/option02/O2StatsBar.vue
+++ b/app-ui/src/components/option02/O2StatsBar.vue
@@ -1,19 +1,49 @@
 <template>
-  <div class="grid grid-cols-2 lg:grid-cols-4 gap-4">
-    <div
-      v-for="stat in stats"
-      :key="stat.label"
-      :class="[
-        'bg-white rounded-xl border px-5 py-4 flex items-center gap-4',
-        stat.borderClass,
-      ]"
-    >
-      <div :class="['w-10 h-10 rounded-lg flex items-center justify-center', stat.iconBg]">
-        <font-awesome-icon :icon="['fas', stat.icon]" :class="stat.iconColor" />
+  <div>
+    <div class="grid grid-cols-2 lg:grid-cols-4 gap-4">
+      <div
+        v-for="stat in stats"
+        :key="stat.label"
+        :class="[
+          'bg-white rounded-xl border px-5 py-4 flex items-center gap-4',
+          stat.borderClass,
+        ]"
+      >
+        <div :class="['w-10 h-10 rounded-lg flex items-center justify-center', stat.iconBg]">
+          <font-awesome-icon :icon="['fas', stat.icon]" :class="stat.iconColor" />
+        </div>
+        <div>
+          <p class="text-2xl font-bold text-gray-800">{{ stat.value }}</p>
+          <p class="text-xs text-gray-400">{{ stat.label }}</p>
+        </div>
       </div>
-      <div>
-        <p class="text-2xl font-bold text-gray-800">{{ stat.value }}</p>
-        <p class="text-xs text-gray-400">{{ stat.label }}</p>
+    </div>
+
+    <div
+      v-if="pastDueFinancials.count > 0"
+      class="mt-3 bg-red-50 border border-red-200 rounded-xl px-5 py-3 flex items-center justify-between"
+    >
+      <div class="flex items-center gap-2">
+        <font-awesome-icon :icon="['fas', 'dollar-sign']" class="text-red-500" />
+        <span class="text-xs font-semibold text-red-700 uppercase tracking-wider">Past Due Summary</span>
+      </div>
+      <div class="flex items-center gap-6">
+        <div class="text-right">
+          <p class="text-[10px] text-gray-400 uppercase">Billed</p>
+          <p class="text-sm font-semibold text-gray-700">{{ formatCurrency(pastDueFinancials.totalAmount) }}</p>
+        </div>
+        <div class="text-right">
+          <p class="text-[10px] text-gray-400 uppercase">Discount</p>
+          <p class="text-sm font-semibold text-gray-700">{{ formatCurrency(pastDueFinancials.totalDiscount) }}</p>
+        </div>
+        <div class="text-right">
+          <p class="text-[10px] text-gray-400 uppercase">Paid</p>
+          <p class="text-sm font-semibold text-gray-700">{{ formatCurrency(pastDueFinancials.totalPaid) }}</p>
+        </div>
+        <div class="text-right">
+          <p class="text-[10px] text-gray-400 uppercase">Due</p>
+          <p class="text-sm font-bold text-red-700">{{ formatCurrency(pastDueFinancials.totalDue) }}</p>
+        </div>
       </div>
     </div>
   </div>
@@ -22,6 +52,7 @@
 <script lang="ts">
 import { defineComponent, computed, PropType } from 'vue';
 import { Appointment } from '../../interfaces/Appointment';
+import { formatCurrency } from '../../utils/formatCurrency';
 import { library } from '@fortawesome/fontawesome-svg-core';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import {
@@ -29,9 +60,10 @@ import {
   faHourglassHalf,
   faExclamationTriangle,
   faCheckCircle,
+  faDollarSign,
 } from '@fortawesome/free-solid-svg-icons';
 
-library.add(faCalendarDay, faHourglassHalf, faExclamationTriangle, faCheckCircle);
+library.add(faCalendarDay, faHourglassHalf, faExclamationTriangle, faCheckCircle, faDollarSign);
 
 export default defineComponent({
   name: 'O2StatsBar',
@@ -85,7 +117,18 @@ export default defineComponent({
       ];
     });
 
-    return { stats };
+    const pastDueFinancials = computed(() => {
+      const pastDue = props.appointments.filter((a) => a.isPastDue);
+      return {
+        count: pastDue.length,
+        totalAmount: pastDue.reduce((sum, a) => sum + a.amount, 0),
+        totalDiscount: pastDue.reduce((sum, a) => sum + a.discount, 0),
+        totalPaid: pastDue.reduce((sum, a) => sum + a.amountPaid, 0),
+        totalDue: pastDue.reduce((sum, a) => sum + a.amountDue, 0),
+      };
+    });
+
+    return { stats, pastDueFinancials, formatCurrency };
   },
 });
 </script>

--- a/app-ui/src/utils/formatCurrency.ts
+++ b/app-ui/src/utils/formatCurrency.ts
@@ -1,0 +1,3 @@
+export function formatCurrency(value: number): string {
+  return `$${value.toFixed(2)}`;
+}


### PR DESCRIPTION
Surface aggregated financial data (Billed, Discount, Paid, Due) in a conditional red summary strip below the stats cards when past-due appointments exist. Also extend the Past Due badge in appointment rows to show the individual amount due inline.