### PR TITLE
Add coordinator context and pickup-task prompt

### DIFF
--- a/.claude/prompts/pickup-task.md
+++ b/.claude/prompts/pickup-task.md
@@ -1,0 +1,31 @@
+# Pick Up Task from Coordinator
+
+Read the active plan files from the coordinator to pick up your portion of a cross-cutting task.
+
+## Steps
+
+1. List available plans:
+   ```
+   ls ../patient-care-super/planning/active/
+   ```
+
+2. Read the plan file(s) to understand:
+   - What is the overall goal?
+   - What is the **UI layer's** responsibility in this plan?
+   - What has already been completed in DB and API layers?
+
+3. Read the coordinator's CLAUDE.md if you need broader context:
+   ```
+   ../patient-care-super/CLAUDE.md
+   ```
+
+4. Check relevant API contracts for the response shapes you need to consume:
+   ```
+   ../patient-care-super/_contracts/
+   ```
+
+5. Summarize what you need to do and confirm with the user before implementing.
+
+## Reminder
+
+You are the **final consumer** in the chain. API changes must land before yours. After implementing, run `npx vue-tsc --noEmit && npm run lint` from `app-ui/` to verify. Follow component naming conventions (`O{N}` prefix) and use Tailwind utility classes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,3 +88,18 @@ The app fetches appointment data from the `patient-care-api` (.NET 8 REST API):
 - **Styling**: All styling via Tailwind utility classes — no separate CSS files for option components
 - **Original UI**: Components in `headers/`, `sidebars/`, etc. are preserved untouched
 - **Target user**: Front-desk staff (role badge shown in UI)
+
+## Coordinator Context
+
+This project is part of a multi-repo system managed by a coordinator instance at `../patient-care-super/`.
+
+- **Coordinator guide**: `../patient-care-super/CLAUDE.md`
+- **API contracts**: `../patient-care-super/_contracts/`
+- **Active plans**: `../patient-care-super/planning/active/`
+
+### Dependency Position
+
+API changes must land before yours. You are the **final consumer** in the dependency chain. When making changes:
+1. DB layer (`../patient-care-db/`) applies schema changes first
+2. API layer (`../patient-care-api/`) updates endpoints and contracts
+3. You update TypeScript types, HTTP clients, and components to match


### PR DESCRIPTION
Adds coordinator awareness section to CLAUDE.md (dependency position: final consumer after DB and API) and pickup-task prompt for receiving handoffs from the patient-care-super coordinator instance.