### PR TITLE
Add therapist CRUD UI with full management interface

### DIFF
--- a/app-ui/src/components/option02/O2MobileNav.vue
+++ b/app-ui/src/components/option02/O2MobileNav.vue
@@ -82,7 +82,7 @@ export default defineComponent({
     const navItems = [
       { label: 'Dashboard', icon: 'chart-pie', to: '/' },
       { label: 'Patients', icon: 'users', to: '/patients' },
-      { label: 'Therapists', icon: 'user-md', to: '#' },
+      { label: 'Therapists', icon: 'user-md', to: '/therapists' },
       { label: 'Schedule', icon: 'calendar-check', to: '#' },
       { label: 'Billing', icon: 'credit-card', to: '#' },
       { label: 'Reports', icon: 'file-alt', to: '#' },

--- a/app-ui/src/components/option02/O2Sidebar.vue
+++ b/app-ui/src/components/option02/O2Sidebar.vue
@@ -67,7 +67,7 @@ export default defineComponent({
     const navItems = [
       { label: 'Dashboard', icon: 'chart-pie', to: '/' },
       { label: 'Patients', icon: 'users', to: '/patients' },
-      { label: 'Therapists', icon: 'user-md', to: '#' },
+      { label: 'Therapists', icon: 'user-md', to: '/therapists' },
       { label: 'Schedule', icon: 'calendar-check', to: '#' },
       { label: 'Billing', icon: 'credit-card', to: '#' },
       { label: 'Reports', icon: 'file-alt', to: '#' },

--- a/app-ui/src/components/therapists/TherapistDelinquentTable.vue
+++ b/app-ui/src/components/therapists/TherapistDelinquentTable.vue
@@ -1,0 +1,179 @@
+<template>
+  <!-- Desktop table -->
+  <div class="hidden md:block bg-white rounded-xl border border-slate-200 overflow-hidden">
+    <table class="w-full">
+      <thead>
+        <tr class="bg-amber-50 border-b border-amber-200">
+          <th class="px-4 py-3 text-left text-xs font-semibold text-amber-700 uppercase tracking-wider w-8"></th>
+          <th class="px-4 py-3 text-left text-xs font-semibold text-amber-700 uppercase tracking-wider">Therapist</th>
+          <th class="px-4 py-3 text-left text-xs font-semibold text-amber-700 uppercase tracking-wider">Past-Due Sessions</th>
+          <th class="px-4 py-3 text-left text-xs font-semibold text-amber-700 uppercase tracking-wider">Total Due</th>
+          <th class="px-4 py-3 text-left text-xs font-semibold text-amber-700 uppercase tracking-wider">Paid So Far</th>
+          <th class="px-4 py-3 text-left text-xs font-semibold text-amber-700 uppercase tracking-wider">Balance</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-slate-100">
+        <template v-for="dt in filteredTherapists" :key="dt.party.id">
+          <!-- Summary row -->
+          <tr
+            class="hover:bg-amber-50/50 transition-colors cursor-pointer"
+            @click="toggleExpand(dt.party.id)"
+          >
+            <td class="px-4 py-3 text-sm text-slate-400">
+              <svg
+                :class="['w-4 h-4 transition-transform', expanded.has(dt.party.id) ? 'rotate-90' : '']"
+                fill="none" stroke="currentColor" viewBox="0 0 24 24"
+              >
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+              </svg>
+            </td>
+            <td class="px-4 py-3 text-sm font-medium text-slate-800">{{ dt.party.name }}</td>
+            <td class="px-4 py-3 text-sm">
+              <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-700">
+                {{ dt.pastDueSessions }}
+              </span>
+            </td>
+            <td class="px-4 py-3 text-sm font-medium text-amber-700">${{ dt.pastDueTotalAmount.toFixed(2) }}</td>
+            <td class="px-4 py-3 text-sm text-slate-600">${{ dt.amountPaidSoFar.toFixed(2) }}</td>
+            <td class="px-4 py-3 text-sm font-semibold text-red-600">${{ (dt.pastDueTotalAmount - dt.amountPaidSoFar).toFixed(2) }}</td>
+          </tr>
+          <!-- Expanded session detail rows -->
+          <template v-if="expanded.has(dt.party.id)">
+            <tr
+              v-for="session in dt.delinquency"
+              :key="session.sessionId"
+              class="bg-amber-50/30"
+            >
+              <td class="px-4 py-2"></td>
+              <td colspan="5" class="px-4 py-2">
+                <router-link
+                  :to="{ path: '/', query: { date: session.sessionDate, highlightSession: String(session.sessionId) } }"
+                  class="flex items-center justify-between group hover:bg-amber-100/50 rounded-lg px-3 py-2 -mx-3 transition-colors"
+                >
+                  <div class="flex items-center space-x-4">
+                    <span class="text-xs text-slate-400 w-20">{{ formatDate(session.sessionDate) }}</span>
+                    <span class="text-xs text-slate-600">{{ session.patient }}</span>
+                    <span class="text-xs text-slate-400">{{ session.therapyTypes }}</span>
+                  </div>
+                  <div class="flex items-center space-x-4">
+                    <span class="text-xs text-slate-500">${{ session.amount.toFixed(2) }}</span>
+                    <span v-if="session.discount > 0" class="text-xs text-green-600">-${{ session.discount.toFixed(2) }}</span>
+                    <span class="text-xs font-medium text-amber-700">${{ session.amountDue.toFixed(2) }} due</span>
+                    <svg class="w-3.5 h-3.5 text-slate-400 group-hover:text-blue-500 transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                    </svg>
+                  </div>
+                </router-link>
+              </td>
+            </tr>
+          </template>
+        </template>
+        <tr v-if="filteredTherapists.length === 0">
+          <td colspan="6" class="px-4 py-12 text-center text-sm text-slate-400">
+            No delinquent therapists found.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <!-- Mobile cards -->
+  <div class="md:hidden space-y-3">
+    <div
+      v-for="dt in filteredTherapists"
+      :key="dt.party.id"
+      class="bg-white rounded-xl border border-slate-200 overflow-hidden"
+    >
+      <!-- Summary card header -->
+      <div
+        class="p-4 cursor-pointer"
+        @click="toggleExpand(dt.party.id)"
+      >
+        <div class="flex items-start justify-between mb-2">
+          <div class="flex items-center space-x-2">
+            <svg
+              :class="['w-4 h-4 text-slate-400 transition-transform', expanded.has(dt.party.id) ? 'rotate-90' : '']"
+              fill="none" stroke="currentColor" viewBox="0 0 24 24"
+            >
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+            </svg>
+            <p class="text-sm font-semibold text-slate-800">{{ dt.party.name }}</p>
+          </div>
+          <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-700">
+            {{ dt.pastDueSessions }} past due
+          </span>
+        </div>
+        <div class="grid grid-cols-3 gap-2 text-xs text-slate-500">
+          <div><span class="font-medium">Total Due:</span> ${{ dt.pastDueTotalAmount.toFixed(2) }}</div>
+          <div><span class="font-medium">Paid:</span> ${{ dt.amountPaidSoFar.toFixed(2) }}</div>
+          <div><span class="font-medium text-red-600">Balance:</span> <span class="text-red-600">${{ (dt.pastDueTotalAmount - dt.amountPaidSoFar).toFixed(2) }}</span></div>
+        </div>
+      </div>
+
+      <!-- Expanded sessions -->
+      <div v-if="expanded.has(dt.party.id)" class="border-t border-slate-100 divide-y divide-slate-50">
+        <router-link
+          v-for="session in dt.delinquency"
+          :key="session.sessionId"
+          :to="{ path: '/', query: { date: session.sessionDate, highlightSession: String(session.sessionId) } }"
+          class="block px-4 py-3 bg-amber-50/30 hover:bg-amber-100/50 transition-colors"
+        >
+          <div class="flex items-center justify-between text-xs">
+            <div class="space-x-2">
+              <span class="text-slate-500">{{ formatDate(session.sessionDate) }}</span>
+              <span class="text-slate-600">{{ session.patient }}</span>
+              <span class="text-slate-400">{{ session.therapyTypes }}</span>
+            </div>
+            <span class="font-medium text-amber-700">${{ session.amountDue.toFixed(2) }}</span>
+          </div>
+        </router-link>
+      </div>
+    </div>
+    <div v-if="filteredTherapists.length === 0" class="text-center py-12 text-sm text-slate-400">
+      No delinquent therapists found.
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref, computed, type PropType } from 'vue';
+import type { DelinquentTherapist } from '../../interfaces/Delinquency';
+
+export default defineComponent({
+  name: 'TherapistDelinquentTable',
+  props: {
+    therapists: { type: Array as PropType<DelinquentTherapist[]>, required: true },
+    search: { type: String, default: '' },
+  },
+  setup(props) {
+    const expanded = ref<Set<number>>(new Set());
+
+    const toggleExpand = (id: number) => {
+      const next = new Set(expanded.value);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      expanded.value = next;
+    };
+
+    const filteredTherapists = computed(() => {
+      const q = props.search.trim().toLowerCase();
+      if (!q) return props.therapists;
+      return props.therapists.filter((dt) =>
+        dt.party.name.toLowerCase().includes(q)
+      );
+    });
+
+    const formatDate = (dateStr: string) => {
+      if (!dateStr) return '';
+      const d = new Date(dateStr + 'T00:00:00');
+      if (isNaN(d.getTime())) return dateStr;
+      return d.toLocaleDateString('en-US', { month: '2-digit', day: '2-digit', year: 'numeric' });
+    };
+
+    return { expanded, toggleExpand, filteredTherapists, formatDate };
+  },
+});
+</script>

--- a/app-ui/src/components/therapists/TherapistFormModal.vue
+++ b/app-ui/src/components/therapists/TherapistFormModal.vue
@@ -1,0 +1,305 @@
+<template>
+  <teleport to="body">
+    <div v-if="visible" class="fixed inset-0 z-50 flex justify-end">
+      <!-- Backdrop -->
+      <div class="absolute inset-0 bg-black/30" @click="$emit('close')"></div>
+
+      <!-- Slide-over panel -->
+      <div class="relative w-full max-w-md bg-white shadow-xl flex flex-col">
+        <!-- Header -->
+        <div class="px-6 py-4 border-b border-slate-200 flex items-center justify-between">
+          <h2 class="text-lg font-semibold text-slate-800">
+            {{ isEdit ? 'Edit Therapist' : 'Add Therapist' }}
+          </h2>
+          <button
+            class="p-1 rounded-lg text-slate-400 hover:text-slate-600 hover:bg-slate-100"
+            @click="$emit('close')"
+          >
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <!-- Form -->
+        <form class="flex-1 overflow-y-auto px-6 py-4 space-y-4" @submit.prevent="handleSubmit">
+          <div class="grid grid-cols-2 gap-4">
+            <div>
+              <label class="block text-sm font-medium text-slate-700 mb-1">First Name *</label>
+              <input
+                v-model="form.firstName"
+                type="text"
+                required
+                class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              />
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-slate-700 mb-1">Middle Name</label>
+              <input
+                v-model="form.middleName"
+                type="text"
+                class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              />
+            </div>
+          </div>
+
+          <div>
+            <label class="block text-sm font-medium text-slate-700 mb-1">Last Name *</label>
+            <input
+              v-model="form.lastName"
+              type="text"
+              required
+              class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            />
+          </div>
+
+          <div>
+            <label class="block text-sm font-medium text-slate-700 mb-1">Date of Birth *</label>
+            <input
+              v-model="form.dateOfBirth"
+              type="date"
+              required
+              class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            />
+          </div>
+
+          <div>
+            <label class="block text-sm font-medium text-slate-700 mb-1">Email *</label>
+            <input
+              v-model="form.email"
+              type="email"
+              required
+              class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            />
+          </div>
+
+          <div>
+            <label class="block text-sm font-medium text-slate-700 mb-1">Phone *</label>
+            <input
+              v-model="form.phoneNumber"
+              type="tel"
+              required
+              class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            />
+          </div>
+
+          <div>
+            <label class="block text-sm font-medium text-slate-700 mb-1">Gender *</label>
+            <select
+              v-model="form.gender"
+              required
+              class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            >
+              <option value="" disabled>Select gender</option>
+              <option value="Male">Male</option>
+              <option value="Female">Female</option>
+              <option value="Other">Other</option>
+            </select>
+          </div>
+
+          <div class="grid grid-cols-2 gap-4">
+            <div>
+              <label class="block text-sm font-medium text-slate-700 mb-1">Fee/Session ($) *</label>
+              <input
+                v-model.number="form.feePerSession"
+                type="number"
+                step="0.01"
+                min="0"
+                required
+                class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              />
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-slate-700 mb-1">Fee % *</label>
+              <input
+                v-model.number="form.feePctPerSession"
+                type="number"
+                step="0.01"
+                min="0"
+                max="100"
+                required
+                class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              />
+            </div>
+          </div>
+
+          <div v-if="isEdit" class="space-y-1">
+            <div class="flex items-center space-x-3">
+              <label class="text-sm font-medium text-slate-700">Active Status</label>
+              <button
+                type="button"
+                :class="[
+                  'relative inline-flex h-6 w-11 items-center rounded-full transition-colors',
+                  form.activeStatus ? 'bg-blue-600' : 'bg-slate-300',
+                ]"
+                @click="form.activeStatus = !form.activeStatus"
+              >
+                <span
+                  :class="[
+                    'inline-block h-4 w-4 transform rounded-full bg-white transition-transform',
+                    form.activeStatus ? 'translate-x-6' : 'translate-x-1',
+                  ]"
+                />
+              </button>
+            </div>
+          </div>
+
+          <!-- Error message -->
+          <div v-if="error" class="rounded-lg bg-red-50 p-3 text-sm text-red-700">
+            {{ error }}
+          </div>
+        </form>
+
+        <!-- Footer -->
+        <div class="px-6 py-4 border-t border-slate-200 flex items-center justify-end space-x-3">
+          <button
+            type="button"
+            class="px-4 py-2 rounded-lg text-sm font-medium text-slate-700 bg-white border border-slate-300 hover:bg-slate-50"
+            @click="$emit('close')"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            :disabled="saving"
+            class="px-4 py-2 rounded-lg text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 disabled:opacity-50"
+            @click="handleSubmit"
+          >
+            {{ saving ? 'Saving...' : 'Save Therapist' }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </teleport>
+</template>
+
+<script lang="ts">
+import { defineComponent, reactive, ref, watch, type PropType } from 'vue';
+import type { Therapist } from '../../interfaces/Therapist';
+
+function parseName(therapistName: string) {
+  const [last, rest] = therapistName.split(', ');
+  const [first, ...middleParts] = (rest || '').split(' ');
+  return { firstName: first || '', middleName: middleParts.join(' '), lastName: last || '' };
+}
+
+function formatDobForApi(dob: string): string {
+  if (!dob) return '';
+  if (/^\d{4}-\d{2}-\d{2}$/.test(dob)) return `${dob}T00:00:00`;
+  const d = new Date(dob);
+  if (isNaN(d.getTime())) return dob;
+  const yyyy = String(d.getFullYear()).padStart(4, '0');
+  const mm = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}T00:00:00`;
+}
+
+export default defineComponent({
+  name: 'TherapistFormModal',
+  props: {
+    visible: { type: Boolean, required: true },
+    therapist: { type: Object as PropType<Therapist | null>, default: null },
+  },
+  emits: ['close', 'saved'],
+  setup(props, { emit }) {
+    const saving = ref(false);
+    const error = ref('');
+
+    const form = reactive({
+      firstName: '',
+      middleName: '',
+      lastName: '',
+      dateOfBirth: '',
+      email: '',
+      phoneNumber: '',
+      gender: '',
+      feePerSession: 0,
+      feePctPerSession: 0,
+      activeStatus: true,
+    });
+
+    const isEdit = ref(false);
+
+    watch(
+      () => props.visible,
+      (val) => {
+        if (!val) return;
+        error.value = '';
+        if (props.therapist) {
+          isEdit.value = true;
+          const parsed = parseName(props.therapist.therapistName);
+          form.firstName = parsed.firstName;
+          form.middleName = parsed.middleName;
+          form.lastName = parsed.lastName;
+          form.dateOfBirth = '';
+          form.email = props.therapist.email;
+          form.phoneNumber = props.therapist.phoneNumber;
+          form.gender = '';
+          form.feePerSession = props.therapist.feePerSession;
+          form.feePctPerSession = props.therapist.feePctPerSession;
+          form.activeStatus = props.therapist.isActive;
+        } else {
+          isEdit.value = false;
+          form.firstName = '';
+          form.middleName = '';
+          form.lastName = '';
+          form.dateOfBirth = '';
+          form.email = '';
+          form.phoneNumber = '';
+          form.gender = '';
+          form.feePerSession = 0;
+          form.feePctPerSession = 0;
+          form.activeStatus = true;
+        }
+      }
+    );
+
+    const handleSubmit = async () => {
+      if (!form.firstName || !form.lastName || !form.dateOfBirth || !form.email || !form.phoneNumber || !form.gender) {
+        error.value = 'Please fill in all required fields.';
+        return;
+      }
+      saving.value = true;
+      error.value = '';
+      try {
+        const { TherapistsHttpClient } = await import('../../services/TherapistsHttpClient');
+        const client = new TherapistsHttpClient();
+        if (isEdit.value && props.therapist) {
+          await client.updateTherapist(props.therapist.therapistId, {
+            firstName: form.firstName,
+            middleName: form.middleName || undefined,
+            lastName: form.lastName,
+            dateOfBirth: formatDobForApi(form.dateOfBirth),
+            email: form.email,
+            phoneNumber: form.phoneNumber,
+            gender: form.gender,
+            feePerSession: form.feePerSession,
+            feePctPerSession: form.feePctPerSession,
+            activeStatus: form.activeStatus,
+          });
+        } else {
+          await client.createTherapist({
+            firstName: form.firstName,
+            middleName: form.middleName || undefined,
+            lastName: form.lastName,
+            dateOfBirth: formatDobForApi(form.dateOfBirth),
+            email: form.email,
+            phoneNumber: form.phoneNumber,
+            gender: form.gender,
+            feePerSession: form.feePerSession,
+            feePctPerSession: form.feePctPerSession,
+          });
+        }
+        emit('saved');
+        emit('close');
+      } catch (e: unknown) {
+        error.value = e instanceof Error ? e.message : 'An error occurred while saving.';
+      } finally {
+        saving.value = false;
+      }
+    };
+
+    return { form, isEdit, saving, error, handleSubmit };
+  },
+});
+</script>

--- a/app-ui/src/components/therapists/TherapistList.vue
+++ b/app-ui/src/components/therapists/TherapistList.vue
@@ -1,0 +1,152 @@
+<template>
+  <div class="space-y-4">
+    <!-- Top bar: Search + Add button -->
+    <div class="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3">
+      <div class="relative w-full sm:w-80">
+        <svg class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+        </svg>
+        <input
+          v-model="search"
+          type="text"
+          placeholder="Search therapists..."
+          class="w-full pl-10 pr-4 py-2 rounded-lg border border-slate-300 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+        />
+      </div>
+      <button
+        class="flex items-center space-x-2 px-4 py-2 rounded-lg text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 transition-colors"
+        @click="$emit('add')"
+      >
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+        </svg>
+        <span>Add Therapist</span>
+      </button>
+    </div>
+
+    <!-- Filter tabs + count -->
+    <div class="flex items-center justify-between">
+      <div class="inline-flex rounded-lg bg-slate-100 p-0.5">
+        <button
+          v-for="tab in tabs"
+          :key="tab.value"
+          :class="[
+            'px-4 py-1.5 rounded-md text-sm font-medium transition-colors',
+            activeFilter === tab.value
+              ? tab.value === 'delinquent'
+                ? 'bg-white text-amber-700 shadow-sm'
+                : 'bg-white text-slate-800 shadow-sm'
+              : 'text-slate-500 hover:text-slate-700',
+          ]"
+          @click="onTabClick(tab.value)"
+        >
+          {{ tab.label }}
+        </button>
+      </div>
+      <span v-if="activeFilter !== 'delinquent'" class="text-sm text-slate-500">
+        {{ filteredTherapists.length }} therapist{{ filteredTherapists.length !== 1 ? 's' : '' }}
+      </span>
+      <span v-else class="text-sm text-amber-600">
+        {{ pastDueTherapists.length }} therapist{{ pastDueTherapists.length !== 1 ? 's' : '' }} past due
+      </span>
+    </div>
+
+    <!-- Loading state -->
+    <div v-if="loading" class="text-center py-12">
+      <div class="inline-block w-6 h-6 border-2 border-blue-600 border-t-transparent rounded-full animate-spin"></div>
+      <p class="mt-2 text-sm text-slate-500">Loading therapists...</p>
+    </div>
+
+    <!-- Error state -->
+    <div v-else-if="error" class="bg-red-50 rounded-xl p-6 text-center">
+      <p class="text-sm text-red-700">{{ error }}</p>
+      <button
+        class="mt-2 text-sm font-medium text-red-600 hover:text-red-800"
+        @click="$emit('retry')"
+      >
+        Try again
+      </button>
+    </div>
+
+    <!-- Delinquent tab -->
+    <TherapistDelinquentTable
+      v-else-if="activeFilter === 'delinquent'"
+      :therapists="pastDueTherapists"
+      :search="search"
+    />
+
+    <!-- Standard therapist table -->
+    <TherapistTable
+      v-else
+      :therapists="filteredTherapists"
+      @edit="(t) => $emit('edit', t)"
+      @toggle-active="(t) => $emit('toggle-active', t)"
+    />
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref, computed, onMounted, type PropType } from 'vue';
+import type { Therapist } from '../../interfaces/Therapist';
+import type { DelinquentTherapist } from '../../interfaces/Delinquency';
+import TherapistTable from './TherapistTable.vue';
+import TherapistDelinquentTable from './TherapistDelinquentTable.vue';
+
+export default defineComponent({
+  name: 'TherapistList',
+  components: { TherapistTable, TherapistDelinquentTable },
+  props: {
+    therapists: { type: Array as PropType<Therapist[]>, required: true },
+    pastDueTherapists: { type: Array as PropType<DelinquentTherapist[]>, default: () => [] },
+    initialTab: { type: String as PropType<'all' | 'active' | 'inactive' | 'delinquent'>, default: 'all' },
+    loading: { type: Boolean, default: false },
+    error: { type: String, default: '' },
+  },
+  emits: ['add', 'edit', 'toggle-active', 'retry', 'tab-change'],
+  setup(props, { emit }) {
+    const search = ref('');
+    const activeFilter = ref<'all' | 'active' | 'inactive' | 'delinquent'>(props.initialTab);
+
+    onMounted(() => {
+      if (props.initialTab !== 'all') {
+        emit('tab-change', props.initialTab);
+      }
+    });
+
+    const tabs = [
+      { label: 'All', value: 'all' as const },
+      { label: 'Active', value: 'active' as const },
+      { label: 'Inactive', value: 'inactive' as const },
+      { label: 'Delinquent', value: 'delinquent' as const },
+    ];
+
+    const onTabClick = (value: 'all' | 'active' | 'inactive' | 'delinquent') => {
+      activeFilter.value = value;
+      emit('tab-change', value);
+    };
+
+    const filteredTherapists = computed(() => {
+      let list = props.therapists;
+
+      if (activeFilter.value === 'active') {
+        list = list.filter((t) => t.isActive);
+      } else if (activeFilter.value === 'inactive') {
+        list = list.filter((t) => !t.isActive);
+      }
+
+      const q = search.value.trim().toLowerCase();
+      if (q) {
+        list = list.filter((t) =>
+          t.therapistName.toLowerCase().includes(q) ||
+          t.email.toLowerCase().includes(q) ||
+          t.phoneNumber.includes(q)
+        );
+      }
+
+      return list;
+    });
+
+    return { search, activeFilter, tabs, filteredTherapists, onTabClick };
+  },
+});
+</script>

--- a/app-ui/src/components/therapists/TherapistTable.vue
+++ b/app-ui/src/components/therapists/TherapistTable.vue
@@ -1,0 +1,183 @@
+<template>
+  <!-- Desktop table -->
+  <div class="hidden md:block bg-white rounded-xl border border-slate-200 overflow-hidden">
+    <table class="w-full">
+      <thead>
+        <tr class="bg-slate-50 border-b border-slate-200">
+          <th
+            v-for="col in columns"
+            :key="col.key"
+            class="px-4 py-3 text-left text-xs font-semibold text-slate-500 uppercase tracking-wider cursor-pointer select-none hover:text-slate-700"
+            @click="toggleSort(col.key)"
+          >
+            <span class="flex items-center space-x-1">
+              <span>{{ col.label }}</span>
+              <span v-if="sortKey === col.key" class="text-blue-600">
+                {{ sortAsc ? '&#9650;' : '&#9660;' }}
+              </span>
+            </span>
+          </th>
+          <th class="px-4 py-3 text-right text-xs font-semibold text-slate-500 uppercase tracking-wider">Actions</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-slate-100">
+        <tr
+          v-for="therapist in sortedTherapists"
+          :key="therapist.therapistId"
+          class="hover:bg-slate-50 transition-colors"
+        >
+          <td class="px-4 py-3 text-sm font-medium text-slate-800">{{ therapist.therapistName }}</td>
+          <td class="px-4 py-3 text-sm text-slate-600">{{ therapist.email }}</td>
+          <td class="px-4 py-3 text-sm text-slate-600">{{ therapist.phoneNumber }}</td>
+          <td class="px-4 py-3 text-sm text-slate-600">${{ therapist.feePerSession.toFixed(2) }}</td>
+          <td class="px-4 py-3 text-sm text-slate-600">{{ therapist.feePctPerSession.toFixed(2) }}%</td>
+          <td class="px-4 py-3">
+            <span
+              :class="[
+                'inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium',
+                therapist.isActive
+                  ? 'bg-green-100 text-green-700'
+                  : 'bg-slate-100 text-slate-500',
+              ]"
+            >
+              {{ therapist.isActive ? 'Active' : 'Inactive' }}
+            </span>
+          </td>
+          <td class="px-4 py-3 text-right">
+            <div class="flex items-center justify-end space-x-2">
+              <button
+                class="p-1.5 rounded-lg text-slate-400 hover:text-blue-600 hover:bg-blue-50 transition-colors"
+                title="Edit therapist"
+                @click="$emit('edit', therapist)"
+              >
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
+                </svg>
+              </button>
+              <button
+                class="p-1.5 rounded-lg text-slate-400 hover:text-amber-600 hover:bg-amber-50 transition-colors"
+                :title="therapist.isActive ? 'Deactivate therapist' : 'Activate therapist'"
+                @click="$emit('toggle-active', therapist)"
+              >
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path v-if="therapist.isActive" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636" />
+                  <path v-else stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+              </button>
+            </div>
+          </td>
+        </tr>
+        <tr v-if="sortedTherapists.length === 0">
+          <td colspan="7" class="px-4 py-12 text-center text-sm text-slate-400">
+            No therapists found.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <!-- Mobile cards -->
+  <div class="md:hidden space-y-3">
+    <div
+      v-for="therapist in sortedTherapists"
+      :key="therapist.therapistId"
+      class="bg-white rounded-xl border border-slate-200 p-4"
+    >
+      <div class="flex items-start justify-between mb-2">
+        <div>
+          <p class="text-sm font-semibold text-slate-800">{{ therapist.therapistName }}</p>
+        </div>
+        <span
+          :class="[
+            'inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium',
+            therapist.isActive
+              ? 'bg-green-100 text-green-700'
+              : 'bg-slate-100 text-slate-500',
+          ]"
+        >
+          {{ therapist.isActive ? 'Active' : 'Inactive' }}
+        </span>
+      </div>
+      <div class="grid grid-cols-2 gap-2 text-xs text-slate-500 mb-3">
+        <div><span class="font-medium">Email:</span> {{ therapist.email }}</div>
+        <div><span class="font-medium">Phone:</span> {{ therapist.phoneNumber }}</div>
+        <div><span class="font-medium">Fee/Session:</span> ${{ therapist.feePerSession.toFixed(2) }}</div>
+        <div><span class="font-medium">Fee %:</span> {{ therapist.feePctPerSession.toFixed(2) }}%</div>
+      </div>
+      <div class="flex items-center justify-end space-x-2 border-t border-slate-100 pt-2">
+        <button
+          class="px-3 py-1.5 rounded-lg text-xs font-medium text-blue-600 hover:bg-blue-50 transition-colors"
+          @click="$emit('edit', therapist)"
+        >
+          Edit
+        </button>
+        <button
+          class="px-3 py-1.5 rounded-lg text-xs font-medium transition-colors"
+          :class="therapist.isActive ? 'text-amber-600 hover:bg-amber-50' : 'text-green-600 hover:bg-green-50'"
+          @click="$emit('toggle-active', therapist)"
+        >
+          {{ therapist.isActive ? 'Deactivate' : 'Activate' }}
+        </button>
+      </div>
+    </div>
+    <div v-if="sortedTherapists.length === 0" class="text-center py-12 text-sm text-slate-400">
+      No therapists found.
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref, computed, type PropType } from 'vue';
+import type { Therapist } from '../../interfaces/Therapist';
+
+export default defineComponent({
+  name: 'TherapistTable',
+  props: {
+    therapists: { type: Array as PropType<Therapist[]>, required: true },
+  },
+  emits: ['edit', 'toggle-active'],
+  setup(props) {
+    const sortKey = ref('therapistName');
+    const sortAsc = ref(true);
+
+    const columns = [
+      { key: 'therapistName', label: 'Name' },
+      { key: 'email', label: 'Email' },
+      { key: 'phoneNumber', label: 'Phone' },
+      { key: 'feePerSession', label: 'Fee/Session ($)' },
+      { key: 'feePctPerSession', label: 'Fee (%)' },
+      { key: 'isActive', label: 'Status' },
+    ];
+
+    const toggleSort = (key: string) => {
+      if (sortKey.value === key) {
+        sortAsc.value = !sortAsc.value;
+      } else {
+        sortKey.value = key;
+        sortAsc.value = true;
+      }
+    };
+
+    const sortedTherapists = computed(() => {
+      const list = [...props.therapists];
+      list.sort((a, b) => {
+        const aVal = (a as unknown as Record<string, unknown>)[sortKey.value];
+        const bVal = (b as unknown as Record<string, unknown>)[sortKey.value];
+        if (typeof aVal === 'string' && typeof bVal === 'string') {
+          return sortAsc.value ? aVal.localeCompare(bVal) : bVal.localeCompare(aVal);
+        }
+        if (typeof aVal === 'number' && typeof bVal === 'number') {
+          return sortAsc.value ? aVal - bVal : bVal - aVal;
+        }
+        if (typeof aVal === 'boolean' && typeof bVal === 'boolean') {
+          return sortAsc.value ? (aVal === bVal ? 0 : aVal ? -1 : 1) : (aVal === bVal ? 0 : aVal ? 1 : -1);
+        }
+        return 0;
+      });
+      return list;
+    });
+
+    return { columns, sortKey, sortAsc, sortedTherapists, toggleSort };
+  },
+});
+</script>

--- a/app-ui/src/interfaces/Delinquency.ts
+++ b/app-ui/src/interfaces/Delinquency.ts
@@ -32,3 +32,5 @@ export interface DelinquentPatient {
   amountPaidSoFar: number;
   delinquency: DelinquentSession[];
 }
+
+export type DelinquentTherapist = DelinquentPatient;

--- a/app-ui/src/interfaces/Therapist.ts
+++ b/app-ui/src/interfaces/Therapist.ts
@@ -1,0 +1,41 @@
+// interfaces/Therapist.ts
+
+// Maps to API's TherapistProfile response
+export interface Therapist {
+  therapistId: number;
+  userId: number;
+  feePerSession: number;
+  feePctPerSession: number;
+  therapistName: string;       // "Last, First Middle" from API
+  email: string;
+  phoneNumber: string;
+  createdTimestamp: string;
+  isActive: boolean;
+}
+
+// Maps to API's TherapistProfileRequest (POST)
+export interface TherapistCreateRequest {
+  firstName: string;
+  middleName?: string;
+  lastName: string;
+  dateOfBirth: string;
+  email: string;
+  phoneNumber: string;
+  gender: string;
+  feePerSession: number;
+  feePctPerSession: number;
+}
+
+// Maps to API's TherapistProfileUpdateRequest (PUT)
+export interface TherapistUpdateRequest {
+  firstName: string;
+  middleName?: string;
+  lastName: string;
+  dateOfBirth: string;
+  email: string;
+  phoneNumber: string;
+  gender: string;
+  feePerSession: number;
+  feePctPerSession: number;
+  activeStatus: boolean;
+}

--- a/app-ui/src/router/index.ts
+++ b/app-ui/src/router/index.ts
@@ -14,6 +14,11 @@ const router = createRouter({
       component: () => import('../views/PatientsView.vue'),
     },
     {
+      path: '/therapists',
+      name: 'therapists',
+      component: () => import('../views/TherapistsView.vue'),
+    },
+    {
       path: '/design-options',
       name: 'design-options',
       component: () => import('../views/CompareView.vue'),

--- a/app-ui/src/services/TherapistsHttpClient.ts
+++ b/app-ui/src/services/TherapistsHttpClient.ts
@@ -1,0 +1,35 @@
+// services/TherapistsHttpClient.ts
+import { HttpClientBase } from './HttpClientBase';
+import type { Therapist, TherapistCreateRequest, TherapistUpdateRequest } from '../interfaces/Therapist';
+import type { DelinquentTherapist } from '../interfaces/Delinquency';
+
+export class TherapistsHttpClient extends HttpClientBase {
+  async getTherapists(): Promise<Therapist[]> {
+    return this.get<Therapist[]>('/api/therapists');
+  }
+
+  async getTherapist(id: number): Promise<Therapist> {
+    return this.get<Therapist>(`/api/therapists/${id}`);
+  }
+
+  async createTherapist(data: TherapistCreateRequest): Promise<Therapist> {
+    return this.post<Therapist>('/api/therapists', data);
+  }
+
+  async updateTherapist(id: number, data: TherapistUpdateRequest): Promise<void> {
+    return this.put(`/api/therapists/${id}`, data);
+  }
+
+  async getPastDueForTherapist(id: number): Promise<DelinquentTherapist> {
+    return this.get<DelinquentTherapist>(`/api/therapists/${id}/pastdue`);
+  }
+
+  async getPastDueTherapists(therapists: Therapist[]): Promise<DelinquentTherapist[]> {
+    const results = await Promise.all(
+      therapists.map((t) => this.getPastDueForTherapist(t.therapistId).catch(() => null))
+    );
+    return results.filter(
+      (r): r is DelinquentTherapist => r !== null && r.pastDueSessions > 0
+    );
+  }
+}

--- a/app-ui/src/views/TherapistsView.vue
+++ b/app-ui/src/views/TherapistsView.vue
@@ -1,0 +1,164 @@
+<template>
+  <div class="min-h-screen bg-slate-50 font-sans">
+    <O2MobileNav />
+    <div class="flex flex-1">
+      <O2Sidebar />
+      <div class="flex-1 flex flex-col">
+      <O2Header />
+      <main class="flex-1 max-w-7xl mx-auto w-full px-4 sm:px-6 lg:px-8 py-6">
+        <div class="mb-6">
+          <h1 class="text-2xl font-bold text-slate-800">Therapist Management</h1>
+          <p class="text-sm text-slate-500 mt-1">View and manage therapist records</p>
+        </div>
+        <TherapistList
+          :therapists="therapists"
+          :initial-tab="initialTab"
+          :loading="loading"
+          :error="error"
+          :past-due-therapists="pastDueTherapists"
+          @add="openAdd"
+          @edit="openEdit"
+          @toggle-active="toggleActive"
+          @retry="loadTherapists"
+          @tab-change="onTabChange"
+        />
+      </main>
+        <O2Footer />
+      </div>
+    </div>
+
+    <TherapistFormModal
+      :visible="modalVisible"
+      :therapist="editingTherapist"
+      @close="modalVisible = false"
+      @saved="onSaved"
+    />
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref, computed, onMounted } from 'vue';
+import { useRoute } from 'vue-router';
+import O2MobileNav from '../components/option02/O2MobileNav.vue';
+import O2Sidebar from '../components/option02/O2Sidebar.vue';
+import O2Header from '../components/option02/O2Header.vue';
+import O2Footer from '../components/option02/O2Footer.vue';
+import TherapistList from '../components/therapists/TherapistList.vue';
+import TherapistFormModal from '../components/therapists/TherapistFormModal.vue';
+import { TherapistsHttpClient } from '../services/TherapistsHttpClient';
+import type { Therapist } from '../interfaces/Therapist';
+import type { DelinquentTherapist } from '../interfaces/Delinquency';
+
+export default defineComponent({
+  name: 'TherapistsView',
+  components: { O2MobileNav, O2Sidebar, O2Header, O2Footer, TherapistList, TherapistFormModal },
+  setup() {
+    const route = useRoute();
+    const client = new TherapistsHttpClient();
+
+    const validTabs = ['all', 'active', 'inactive', 'delinquent'] as const;
+    type TabValue = typeof validTabs[number];
+    const initialTab = computed<TabValue>(() => {
+      const tab = route.query.tab as string | undefined;
+      return tab && (validTabs as readonly string[]).includes(tab) ? tab as TabValue : 'all';
+    });
+    const therapists = ref<Therapist[]>([]);
+    const loading = ref(false);
+    const error = ref('');
+    const modalVisible = ref(false);
+    const editingTherapist = ref<Therapist | null>(null);
+    const pastDueTherapists = ref<DelinquentTherapist[]>([]);
+    const pastDueLoaded = ref(false);
+
+    const loadTherapists = async () => {
+      loading.value = true;
+      error.value = '';
+      try {
+        therapists.value = await client.getTherapists();
+      } catch (e: unknown) {
+        error.value = e instanceof Error ? e.message : 'Failed to load therapists.';
+      } finally {
+        loading.value = false;
+      }
+    };
+
+    const openAdd = () => {
+      editingTherapist.value = null;
+      modalVisible.value = true;
+    };
+
+    const openEdit = (therapist: Therapist) => {
+      editingTherapist.value = therapist;
+      modalVisible.value = true;
+    };
+
+    const toggleActive = async (therapist: Therapist) => {
+      try {
+        const parsed = parseName(therapist.therapistName);
+        await client.updateTherapist(therapist.therapistId, {
+          firstName: parsed.firstName,
+          middleName: parsed.middleName || undefined,
+          lastName: parsed.lastName,
+          dateOfBirth: '',
+          email: therapist.email,
+          phoneNumber: therapist.phoneNumber,
+          gender: '',
+          feePerSession: therapist.feePerSession,
+          feePctPerSession: therapist.feePctPerSession,
+          activeStatus: !therapist.isActive,
+        });
+        await loadTherapists();
+        pastDueLoaded.value = false;
+      } catch (e: unknown) {
+        error.value = e instanceof Error ? e.message : 'Failed to update therapist status.';
+      }
+    };
+
+    const loadPastDueTherapists = async () => {
+      if (pastDueLoaded.value) return;
+      try {
+        pastDueTherapists.value = await client.getPastDueTherapists(therapists.value);
+        pastDueLoaded.value = true;
+      } catch (e: unknown) {
+        error.value = e instanceof Error ? e.message : 'Failed to load delinquent therapists.';
+      }
+    };
+
+    const onTabChange = (tab: string) => {
+      if (tab === 'delinquent') {
+        loadPastDueTherapists();
+      }
+    };
+
+    const onSaved = () => {
+      loadTherapists();
+      pastDueLoaded.value = false;
+    };
+
+    onMounted(loadTherapists);
+
+    return {
+      therapists,
+      loading,
+      error,
+      modalVisible,
+      editingTherapist,
+      pastDueTherapists,
+      initialTab,
+      loadTherapists,
+      openAdd,
+      openEdit,
+      toggleActive,
+      onSaved,
+      onTabChange,
+    };
+  },
+});
+
+function parseName(therapistName: string) {
+  const [last, rest] = therapistName.split(', ');
+  const [first, ...middleParts] = (rest || '').split(' ');
+  return { firstName: first || '', middleName: middleParts.join(' '), lastName: last || '' };
+}
+
+</script>


### PR DESCRIPTION
Implement complete therapist management page following the patients module pattern: sortable table, search/filter tabs (All/Active/Inactive/Delinquent), slide-over form modal for create/edit, and active status toggle. Includes fee fields (feePerSession, feePctPerSession), per-therapist past-due loading via Promise.all, and responsive desktop table + mobile card layouts.

New files:
- Therapist interface + create/update request types
- TherapistsHttpClient with CRUD + per-therapist pastdue endpoints
- TherapistTable, TherapistDelinquentTable, TherapistFormModal, TherapistList
- TherapistsView with O2 layout

Modified:
- Router: /therapists route (lazy-loaded)
- O2Sidebar + O2MobileNav: Therapists nav link now routes to /therapists
- Delinquency interface: added DelinquentTherapist type alias