### PR TITLE
Replace past due banner with unified financial summary progress bar

### DIFF
--- a/app-ui/src/components/option02/O2StatsBar.vue
+++ b/app-ui/src/components/option02/O2StatsBar.vue
@@ -1,5 +1,6 @@
 <template>
   <div>
+    <!-- Stat Tiles -->
     <div class="grid grid-cols-2 lg:grid-cols-4 gap-4">
       <div
         v-for="stat in stats"
@@ -19,30 +20,99 @@
       </div>
     </div>
 
-    <div
-      v-if="pastDueFinancials.count > 0"
-      class="mt-3 bg-red-50 border border-red-200 rounded-xl px-5 py-3 flex items-center justify-between"
-    >
-      <div class="flex items-center gap-2">
-        <font-awesome-icon :icon="['fas', 'dollar-sign']" class="text-red-500" />
-        <span class="text-xs font-semibold text-red-700 uppercase tracking-wider">Past Due Summary</span>
+    <!-- Financial Summary: Progress Banner -->
+    <div v-if="appointments.length > 0" class="mt-3 bg-white border border-gray-200 rounded-xl px-5 py-4">
+      <!-- Header -->
+      <div class="flex items-center justify-between mb-3">
+        <div class="flex items-center gap-2">
+          <font-awesome-icon :icon="['fas', 'dollar-sign']" class="text-violet-500" />
+          <span class="text-xs font-semibold text-gray-700 uppercase tracking-wider">
+            Daily Financial Summary
+          </span>
+        </div>
+        <span class="text-xs text-gray-400">{{ appointments.length }} Sessions</span>
       </div>
-      <div class="flex items-center gap-6">
-        <div class="text-right">
-          <p class="text-[10px] text-gray-400 uppercase">Billed</p>
-          <p class="text-sm font-semibold text-gray-700">{{ formatCurrency(pastDueFinancials.totalAmount) }}</p>
+
+      <!-- Progress Bar -->
+      <div class="mb-4">
+        <div class="flex h-4 rounded-full overflow-hidden bg-gray-100">
+          <div
+            class="bg-green-500 transition-all duration-500 flex items-center justify-center"
+            :style="{ width: paidPercent + '%' }"
+          >
+            <span v-if="paidPercent >= 15" class="text-[9px] font-bold text-white">
+              {{ paidPercent }}%
+            </span>
+          </div>
+          <div
+            class="bg-red-400 transition-all duration-500 flex items-center justify-center"
+            :style="{ width: unpaidPercent + '%' }"
+          >
+            <span v-if="unpaidPercent >= 15" class="text-[9px] font-bold text-white">
+              {{ unpaidPercent }}%
+            </span>
+          </div>
         </div>
-        <div class="text-right">
-          <p class="text-[10px] text-gray-400 uppercase">Discount</p>
-          <p class="text-sm font-semibold text-gray-700">{{ formatCurrency(pastDueFinancials.totalDiscount) }}</p>
+        <div class="flex justify-between mt-1 text-[10px]">
+          <span class="text-green-600 font-medium">Settled {{ paidPercent }}%</span>
+          <span class="text-red-600 font-medium">Past Due {{ unpaidPercent }}%</span>
         </div>
-        <div class="text-right">
-          <p class="text-[10px] text-gray-400 uppercase">Paid</p>
-          <p class="text-sm font-semibold text-gray-700">{{ formatCurrency(pastDueFinancials.totalPaid) }}</p>
+      </div>
+
+      <!-- Two-Column Breakdown -->
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <!-- Settled Column -->
+        <div class="bg-green-50 rounded-lg px-4 py-3">
+          <p class="text-[10px] font-semibold text-green-700 uppercase tracking-wider mb-2">
+            Settled ({{ settledFinancials.count }})
+          </p>
+          <div class="space-y-1.5">
+            <div class="flex justify-between text-xs">
+              <span class="text-gray-500">Billed</span>
+              <span class="text-gray-700 font-medium">{{ formatCurrency(settledFinancials.totalAmount) }}</span>
+            </div>
+            <div class="flex justify-between text-xs">
+              <span class="text-gray-500">Discount</span>
+              <span class="text-gray-700 font-medium">{{ formatCurrency(settledFinancials.totalDiscount) }}</span>
+            </div>
+            <div class="flex justify-between text-xs">
+              <span class="text-gray-500">Paid</span>
+              <span class="text-gray-700 font-medium">{{ formatCurrency(settledFinancials.totalPaid) }}</span>
+            </div>
+            <div class="border-t border-green-200 pt-1.5 flex justify-between text-xs">
+              <span class="text-green-700 font-semibold">Collected</span>
+              <span class="text-green-700 font-bold">{{ formatCurrency(settledFinancials.totalPaid) }}</span>
+            </div>
+          </div>
         </div>
-        <div class="text-right">
-          <p class="text-[10px] text-gray-400 uppercase">Due</p>
-          <p class="text-sm font-bold text-red-700">{{ formatCurrency(pastDueFinancials.totalDue) }}</p>
+
+        <!-- Past Due Column -->
+        <div class="bg-red-50 rounded-lg px-4 py-3">
+          <p class="text-[10px] font-semibold text-red-700 uppercase tracking-wider mb-2">
+            Past Due ({{ pastDueFinancials.count }})
+          </p>
+          <div class="space-y-1.5">
+            <div class="flex justify-between text-xs">
+              <span class="text-gray-500">Billed</span>
+              <span class="text-gray-700 font-medium">{{ formatCurrency(pastDueFinancials.totalAmount) }}</span>
+            </div>
+            <div class="flex justify-between text-xs">
+              <span class="text-gray-500">Discount</span>
+              <span class="text-gray-700 font-medium">{{ formatCurrency(pastDueFinancials.totalDiscount) }}</span>
+            </div>
+            <div class="flex justify-between text-xs">
+              <span class="text-gray-500">Paid</span>
+              <span class="text-gray-700 font-medium">{{ formatCurrency(pastDueFinancials.totalPaid) }}</span>
+            </div>
+            <div class="flex justify-between text-xs">
+              <span class="text-gray-500">Due</span>
+              <span class="text-gray-700 font-medium">{{ formatCurrency(pastDueFinancials.totalDue) }}</span>
+            </div>
+            <div class="border-t border-red-200 pt-1.5 flex justify-between text-xs">
+              <span class="text-red-700 font-semibold">Outstanding</span>
+              <span class="text-red-700 font-bold">{{ formatCurrency(pastDueFinancials.totalDue) }}</span>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -128,7 +198,37 @@ export default defineComponent({
       };
     });
 
-    return { stats, pastDueFinancials, formatCurrency };
+    const settledFinancials = computed(() => {
+      const settled = props.appointments.filter((a) => a.isPaidOff);
+      return {
+        count: settled.length,
+        totalAmount: settled.reduce((sum, a) => sum + a.amount, 0),
+        totalDiscount: settled.reduce((sum, a) => sum + a.discount, 0),
+        totalPaid: settled.reduce((sum, a) => sum + a.amountPaid, 0),
+        totalDue: settled.reduce((sum, a) => sum + a.amountDue, 0),
+      };
+    });
+
+    const paidPercent = computed(() => {
+      const total = props.appointments.length;
+      if (total === 0) return 0;
+      return Math.round((settledFinancials.value.count / total) * 100);
+    });
+
+    const unpaidPercent = computed(() => {
+      const total = props.appointments.length;
+      if (total === 0) return 0;
+      return Math.round((pastDueFinancials.value.count / total) * 100);
+    });
+
+    return {
+      stats,
+      pastDueFinancials,
+      settledFinancials,
+      paidPercent,
+      unpaidPercent,
+      formatCurrency,
+    };
   },
 });
 </script>


### PR DESCRIPTION
Show both settled and past due financials with a visual progress bar showing paid vs unpaid percentages. Includes two-column breakdown with Billed/Discount/Paid/Due details for each category. Mobile-responsive layout stacks columns on smaller screens.