### PR TITLE
WP-6C: Site management UI with Admin menu

### DIFF
--- a/app-ui/src/components/option02/O2MobileNav.vue
+++ b/app-ui/src/components/option02/O2MobileNav.vue
@@ -44,6 +44,20 @@
       <font-awesome-icon :icon="['fas', item.icon]" class="w-5" />
       <span>{{ item.label }}</span>
     </component>
+    <div class="border-t border-violet-800 my-1"></div>
+    <router-link
+      to="/admin"
+      :class="[
+        'flex items-center space-x-3 w-full px-3 py-2 rounded-lg text-sm font-medium transition-colors',
+        isActive('/admin')
+          ? 'bg-white/20 text-white'
+          : 'text-violet-300 hover:bg-white/10 hover:text-white',
+      ]"
+      @click="mobileOpen = false"
+    >
+      <font-awesome-icon :icon="['fas', 'gear']" class="w-5" />
+      <span>Admin</span>
+    </router-link>
     <router-link
       to="/design-options"
       class="flex items-center space-x-3 w-full px-3 py-2 rounded-lg text-sm font-medium text-violet-300 hover:bg-white/10 hover:text-white transition-colors"
@@ -68,10 +82,11 @@ import {
   faCalendarCheck,
   faCreditCard,
   faFileAlt,
+  faGear,
   faArrowLeft,
 } from '@fortawesome/free-solid-svg-icons';
 
-library.add(faChartPie, faUsers, faUserMd, faHandHoldingHeart, faCalendarCheck, faCreditCard, faFileAlt, faArrowLeft);
+library.add(faChartPie, faUsers, faUserMd, faHandHoldingHeart, faCalendarCheck, faCreditCard, faFileAlt, faGear, faArrowLeft);
 
 export default defineComponent({
   name: 'O2MobileNav',

--- a/app-ui/src/components/option02/O2Sidebar.vue
+++ b/app-ui/src/components/option02/O2Sidebar.vue
@@ -29,6 +29,20 @@
 
     <!-- Bottom -->
     <div class="flex flex-col items-center pb-6 space-y-2">
+      <div class="w-10 border-t border-violet-800 mb-1"></div>
+      <router-link
+        to="/admin"
+        :class="[
+          'w-12 h-12 rounded-xl flex flex-col items-center justify-center transition-all duration-150',
+          isActive('/admin')
+            ? 'bg-white/20 text-white'
+            : 'text-violet-300 hover:bg-white/10 hover:text-white',
+        ]"
+        title="Admin"
+      >
+        <font-awesome-icon :icon="['fas', 'gear']" class="text-lg" />
+        <span class="text-[9px] mt-0.5 font-medium">Admin</span>
+      </router-link>
       <router-link
         to="/design-options"
         class="w-12 h-12 rounded-xl flex flex-col items-center justify-center text-violet-300 hover:bg-white/10 hover:text-white transition-all duration-150"
@@ -54,10 +68,11 @@ import {
   faCalendarCheck,
   faCreditCard,
   faFileAlt,
+  faGear,
   faArrowLeft,
 } from '@fortawesome/free-solid-svg-icons';
 
-library.add(faChartPie, faUsers, faUserMd, faHandHoldingHeart, faCalendarCheck, faCreditCard, faFileAlt, faArrowLeft);
+library.add(faChartPie, faUsers, faUserMd, faHandHoldingHeart, faCalendarCheck, faCreditCard, faFileAlt, faGear, faArrowLeft);
 
 export default defineComponent({
   name: 'O2Sidebar',

--- a/app-ui/src/components/sites/SiteFormModal.vue
+++ b/app-ui/src/components/sites/SiteFormModal.vue
@@ -1,0 +1,215 @@
+<template>
+  <teleport to="body">
+    <div v-if="visible" class="fixed inset-0 z-50 flex justify-end">
+      <!-- Backdrop -->
+      <div class="absolute inset-0 bg-black/30" @click="$emit('close')"></div>
+
+      <!-- Slide-over panel -->
+      <div class="relative w-full max-w-md bg-white shadow-xl flex flex-col">
+        <!-- Header -->
+        <div class="px-6 py-4 border-b border-slate-200 flex items-center justify-between">
+          <h2 class="text-lg font-semibold text-slate-800">
+            {{ isEdit ? 'Edit Site' : 'Add Site' }}
+          </h2>
+          <button
+            class="p-1 rounded-lg text-slate-400 hover:text-slate-600 hover:bg-slate-100"
+            @click="$emit('close')"
+          >
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <!-- Form -->
+        <form class="flex-1 overflow-y-auto px-6 py-4 space-y-4" @submit.prevent="handleSubmit">
+          <div>
+            <label class="block text-sm font-medium text-slate-700 mb-1">Site Name *</label>
+            <input
+              v-model="form.siteName"
+              type="text"
+              required
+              class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            />
+          </div>
+
+          <div>
+            <label class="block text-sm font-medium text-slate-700 mb-1">RUC</label>
+            <input
+              v-model="form.ruc"
+              type="text"
+              class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              placeholder="Taxpayer ID"
+            />
+          </div>
+
+          <div>
+            <label class="block text-sm font-medium text-slate-700 mb-1">Inception Date *</label>
+            <input
+              v-model="form.inceptionDate"
+              type="date"
+              required
+              class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            />
+          </div>
+
+          <div>
+            <label class="block text-sm font-medium text-slate-700 mb-1">Address</label>
+            <textarea
+              v-model="form.address"
+              rows="3"
+              class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              placeholder="Full address"
+            ></textarea>
+          </div>
+
+          <div class="grid grid-cols-2 gap-4">
+            <div>
+              <label class="block text-sm font-medium text-slate-700 mb-1">Latitude</label>
+              <input
+                v-model.number="form.latitude"
+                type="number"
+                step="0.000001"
+                class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                placeholder="e.g. 8.983333"
+              />
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-slate-700 mb-1">Longitude</label>
+              <input
+                v-model.number="form.longitude"
+                type="number"
+                step="0.000001"
+                class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                placeholder="e.g. -79.516670"
+              />
+            </div>
+          </div>
+
+          <!-- Error message -->
+          <div v-if="error" class="rounded-lg bg-red-50 p-3 text-sm text-red-700">
+            {{ error }}
+          </div>
+        </form>
+
+        <!-- Footer -->
+        <div class="px-6 py-4 border-t border-slate-200 flex items-center justify-end space-x-3">
+          <button
+            type="button"
+            class="px-4 py-2 rounded-lg text-sm font-medium text-slate-700 bg-white border border-slate-300 hover:bg-slate-50"
+            @click="$emit('close')"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            :disabled="saving"
+            class="px-4 py-2 rounded-lg text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 disabled:opacity-50"
+            @click="handleSubmit"
+          >
+            {{ saving ? 'Saving...' : 'Save Site' }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </teleport>
+</template>
+
+<script lang="ts">
+import { defineComponent, reactive, ref, watch, type PropType } from 'vue';
+import type { Site } from '../../interfaces/Site';
+import { SitesHttpClient } from '../../services/SitesHttpClient';
+
+function formatDateForInput(dateStr: string): string {
+  if (!dateStr) return '';
+  const d = new Date(dateStr);
+  if (isNaN(d.getTime())) return dateStr;
+  const yyyy = String(d.getFullYear()).padStart(4, '0');
+  const mm = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+export default defineComponent({
+  name: 'SiteFormModal',
+  props: {
+    visible: { type: Boolean, required: true },
+    site: { type: Object as PropType<Site | null>, default: null },
+  },
+  emits: ['close', 'saved'],
+  setup(props, { emit }) {
+    const saving = ref(false);
+    const error = ref('');
+    const client = new SitesHttpClient();
+
+    const form = reactive({
+      siteName: '',
+      ruc: '',
+      inceptionDate: '',
+      address: '',
+      latitude: null as number | null,
+      longitude: null as number | null,
+    });
+
+    const isEdit = ref(false);
+
+    watch(
+      () => props.visible,
+      (val) => {
+        if (!val) return;
+        error.value = '';
+        if (props.site) {
+          isEdit.value = true;
+          form.siteName = props.site.siteName;
+          form.ruc = props.site.ruc || '';
+          form.inceptionDate = formatDateForInput(props.site.inceptionDate);
+          form.address = props.site.address || '';
+          form.latitude = props.site.latitude;
+          form.longitude = props.site.longitude;
+        } else {
+          isEdit.value = false;
+          form.siteName = '';
+          form.ruc = '';
+          form.inceptionDate = '';
+          form.address = '';
+          form.latitude = null;
+          form.longitude = null;
+        }
+      }
+    );
+
+    const handleSubmit = async () => {
+      if (!form.siteName || !form.inceptionDate) {
+        error.value = 'Please fill in all required fields.';
+        return;
+      }
+      saving.value = true;
+      error.value = '';
+      try {
+        const data = {
+          siteName: form.siteName,
+          ruc: form.ruc || undefined,
+          inceptionDate: form.inceptionDate,
+          address: form.address || undefined,
+          latitude: form.latitude ?? undefined,
+          longitude: form.longitude ?? undefined,
+        };
+
+        if (isEdit.value && props.site) {
+          await client.updateSite(props.site.siteId, data);
+        } else {
+          await client.createSite(data);
+        }
+        emit('saved');
+        emit('close');
+      } catch (e: unknown) {
+        error.value = e instanceof Error ? e.message : 'An error occurred while saving.';
+      } finally {
+        saving.value = false;
+      }
+    };
+
+    return { form, isEdit, saving, error, handleSubmit };
+  },
+});
+</script>

--- a/app-ui/src/components/sites/SiteList.vue
+++ b/app-ui/src/components/sites/SiteList.vue
@@ -1,0 +1,105 @@
+<template>
+  <div class="bg-white rounded-xl shadow-sm border border-slate-200">
+    <!-- Toolbar -->
+    <div class="flex items-center justify-between p-4 border-b border-slate-100">
+      <div>
+        <h2 class="text-base font-semibold text-slate-800">Sites</h2>
+        <p class="text-xs text-slate-500 mt-0.5">Manage clinic locations</p>
+      </div>
+      <button
+        class="px-4 py-2 bg-violet-600 text-white text-sm font-medium rounded-lg hover:bg-violet-700 transition-colors"
+        @click="$emit('add')"
+      >
+        <font-awesome-icon :icon="['fas', 'plus']" class="mr-1.5" />
+        Add Site
+      </button>
+    </div>
+
+    <!-- Loading -->
+    <div v-if="loading" class="p-8 text-center text-slate-400">
+      <p class="text-sm">Loading sites...</p>
+    </div>
+
+    <!-- Error -->
+    <div v-else-if="error" class="p-8 text-center">
+      <p class="text-sm text-red-600">{{ error }}</p>
+      <button
+        class="mt-2 text-sm text-blue-600 hover:text-blue-800"
+        @click="$emit('retry')"
+      >
+        Try again
+      </button>
+    </div>
+
+    <!-- Empty state -->
+    <div v-else-if="sites.length === 0" class="p-8 text-center text-slate-400">
+      <font-awesome-icon :icon="['fas', 'building']" class="text-3xl mb-2" />
+      <p class="text-sm">No sites configured yet.</p>
+    </div>
+
+    <!-- Table -->
+    <table v-else class="w-full">
+      <thead>
+        <tr class="text-left text-xs font-medium text-slate-500 uppercase tracking-wider border-b border-slate-100">
+          <th class="px-4 py-3">Site Name</th>
+          <th class="px-4 py-3">RUC</th>
+          <th class="px-4 py-3">Address</th>
+          <th class="px-4 py-3">Since</th>
+          <th class="px-4 py-3 text-right">Actions</th>
+        </tr>
+      </thead>
+      <tbody class="text-sm text-slate-700">
+        <tr
+          v-for="site in sites"
+          :key="site.siteId"
+          class="border-b border-slate-50 hover:bg-slate-50 transition-colors"
+        >
+          <td class="px-4 py-3 font-medium">{{ site.siteName }}</td>
+          <td class="px-4 py-3 text-slate-500">{{ site.ruc || '--' }}</td>
+          <td class="px-4 py-3 text-slate-500">{{ site.address || '--' }}</td>
+          <td class="px-4 py-3 text-slate-500">{{ formatDate(site.inceptionDate) }}</td>
+          <td class="px-4 py-3 text-right">
+            <button
+              class="text-violet-600 hover:text-violet-800"
+              title="Edit"
+              @click="$emit('edit', site)"
+            >
+              <font-awesome-icon :icon="['fas', 'pen']" class="text-xs" />
+            </button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, type PropType } from 'vue';
+import { library } from '@fortawesome/fontawesome-svg-core';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import { faPlus, faPen, faBuilding } from '@fortawesome/free-solid-svg-icons';
+import type { Site } from '../../interfaces/Site';
+
+library.add(faPlus, faPen, faBuilding);
+
+export default defineComponent({
+  name: 'SiteList',
+  components: { FontAwesomeIcon },
+  props: {
+    sites: { type: Array as PropType<Site[]>, required: true },
+    loading: { type: Boolean, default: false },
+    error: { type: String, default: '' },
+  },
+  emits: ['add', 'edit', 'retry'],
+  setup() {
+    const formatDate = (dateStr: string) => {
+      if (!dateStr) return '--';
+      const d = new Date(dateStr);
+      if (isNaN(d.getTime())) return dateStr;
+      return d.toLocaleDateString('en-US', { month: 'short', year: 'numeric' });
+    };
+
+    return { formatDate };
+  },
+});
+</script>

--- a/app-ui/src/interfaces/Appointment.ts
+++ b/app-ui/src/interfaces/Appointment.ts
@@ -19,6 +19,8 @@ export interface Appointment {
     appointmentStatusId: number;
     statusName: string;
     isConfirmed: boolean;
+    siteId: number | null;
+    siteName: string | null;
 }
 
 export interface AppointmentStatusInfo {
@@ -40,6 +42,7 @@ export interface SessionEventRequest {
     isPaidOff: boolean;
     notes: string;
     appointmentStatusId: number;
+    siteId?: number;
 }
 
 export interface ConfirmationRequest {

--- a/app-ui/src/interfaces/Site.ts
+++ b/app-ui/src/interfaces/Site.ts
@@ -1,0 +1,32 @@
+// interfaces/Site.ts
+
+// Maps to API's SiteProfile response
+export interface Site {
+  siteId: number;
+  siteName: string;
+  ruc: string | null;
+  inceptionDate: string;
+  address: string | null;
+  latitude: number | null;
+  longitude: number | null;
+}
+
+// Maps to API's SiteProfileRequest (POST)
+export interface SiteCreateRequest {
+  siteName: string;
+  ruc?: string;
+  inceptionDate: string;
+  address?: string;
+  latitude?: number;
+  longitude?: number;
+}
+
+// Maps to API's SiteProfileUpdateRequest (PUT)
+export interface SiteUpdateRequest {
+  siteName?: string;
+  ruc?: string;
+  inceptionDate?: string;
+  address?: string;
+  latitude?: number;
+  longitude?: number;
+}

--- a/app-ui/src/router/index.ts
+++ b/app-ui/src/router/index.ts
@@ -39,6 +39,11 @@ const router = createRouter({
       component: () => import('../views/AppointmentsView.vue'),
     },
     {
+      path: '/admin',
+      name: 'admin',
+      component: () => import('../views/AdminView.vue'),
+    },
+    {
       path: '/design-options',
       name: 'design-options',
       component: () => import('../views/CompareView.vue'),

--- a/app-ui/src/services/SitesHttpClient.ts
+++ b/app-ui/src/services/SitesHttpClient.ts
@@ -1,0 +1,21 @@
+// services/SitesHttpClient.ts
+import { HttpClientBase } from './HttpClientBase';
+import type { Site, SiteCreateRequest, SiteUpdateRequest } from '../interfaces/Site';
+
+export class SitesHttpClient extends HttpClientBase {
+  async getSites(): Promise<Site[]> {
+    return this.get<Site[]>('/api/sites');
+  }
+
+  async getSite(id: number): Promise<Site> {
+    return this.get<Site>(`/api/sites/${id}`);
+  }
+
+  async createSite(data: SiteCreateRequest): Promise<Site> {
+    return this.post<Site>('/api/sites', data);
+  }
+
+  async updateSite(id: number, data: SiteUpdateRequest): Promise<void> {
+    return this.put(`/api/sites/${id}`, data);
+  }
+}

--- a/app-ui/src/views/AdminView.vue
+++ b/app-ui/src/views/AdminView.vue
@@ -1,0 +1,100 @@
+<template>
+  <div class="min-h-screen bg-slate-50 font-sans">
+    <O2MobileNav />
+    <div class="flex flex-1">
+      <O2Sidebar />
+      <div class="flex-1 flex flex-col">
+        <O2Header />
+        <main class="flex-1 max-w-7xl mx-auto w-full px-4 sm:px-6 lg:px-8 py-6">
+          <div class="mb-6">
+            <h1 class="text-2xl font-bold text-slate-800">Admin</h1>
+            <p class="text-sm text-slate-500 mt-1">System configuration and settings</p>
+          </div>
+
+          <SiteList
+            :sites="sites"
+            :loading="loading"
+            :error="error"
+            @add="openAdd"
+            @edit="openEdit"
+            @retry="loadSites"
+          />
+        </main>
+        <O2Footer />
+      </div>
+    </div>
+
+    <SiteFormModal
+      :visible="modalVisible"
+      :site="editingSite"
+      @close="modalVisible = false"
+      @saved="onSaved"
+    />
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref, onMounted } from 'vue';
+import O2MobileNav from '../components/option02/O2MobileNav.vue';
+import O2Sidebar from '../components/option02/O2Sidebar.vue';
+import O2Header from '../components/option02/O2Header.vue';
+import O2Footer from '../components/option02/O2Footer.vue';
+import SiteList from '../components/sites/SiteList.vue';
+import SiteFormModal from '../components/sites/SiteFormModal.vue';
+import { SitesHttpClient } from '../services/SitesHttpClient';
+import type { Site } from '../interfaces/Site';
+
+export default defineComponent({
+  name: 'AdminView',
+  components: { O2MobileNav, O2Sidebar, O2Header, O2Footer, SiteList, SiteFormModal },
+  setup() {
+    const client = new SitesHttpClient();
+
+    const sites = ref<Site[]>([]);
+    const loading = ref(false);
+    const error = ref('');
+    const modalVisible = ref(false);
+    const editingSite = ref<Site | null>(null);
+
+    const loadSites = async () => {
+      loading.value = true;
+      error.value = '';
+      try {
+        sites.value = await client.getSites();
+      } catch (e: unknown) {
+        error.value = e instanceof Error ? e.message : 'Failed to load sites.';
+      } finally {
+        loading.value = false;
+      }
+    };
+
+    const openAdd = () => {
+      editingSite.value = null;
+      modalVisible.value = true;
+    };
+
+    const openEdit = (site: Site) => {
+      editingSite.value = site;
+      modalVisible.value = true;
+    };
+
+    const onSaved = () => {
+      loadSites();
+    };
+
+    onMounted(loadSites);
+
+    return {
+      sites,
+      loading,
+      error,
+      modalVisible,
+      editingSite,
+      loadSites,
+      openAdd,
+      openEdit,
+      onSaved,
+    };
+  },
+});
+</script>


### PR DESCRIPTION
- Add Site interface, SitesHttpClient (CRUD)
- Add SiteList and SiteFormModal components (slide-over modal)
- Add AdminView with site management table
- Add gear icon to sidebar bottom (with divider separator)
- Add Admin item to mobile nav
- Add /admin route
- Add siteId/siteName to Appointment interface and SessionEventRequest