### PR TITLE
WP-9C: Replace free-text therapy type with specialty dropdown in book…

### DIFF
--- a/app-ui/src/components/appointments/BookingFormModal.vue
+++ b/app-ui/src/components/appointments/BookingFormModal.vue
@@ -54,11 +54,16 @@
             </div>
           </div>
 
-          <!-- Therapy Type & Duration -->
+          <!-- Specialty Type & Duration -->
           <div class="grid grid-cols-2 gap-3">
             <div>
-              <label class="block text-sm font-medium text-slate-700 mb-1">Therapy Type</label>
-              <input v-model="form.therapyType" type="text" placeholder="e.g., Speech, OT" class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:ring-2 focus:ring-violet-500 focus:border-violet-500" />
+              <label class="block text-sm font-medium text-slate-700 mb-1">Specialty Type</label>
+              <select v-model="form.specialtyTypeId" class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:ring-2 focus:ring-violet-500 focus:border-violet-500">
+                <option :value="0" disabled>Select specialty...</option>
+                <option v-for="s in specialtyTypes" :key="s.id" :value="s.id">
+                  {{ s.abbreviation }} — {{ s.name }}
+                </option>
+              </select>
             </div>
             <div>
               <label class="block text-sm font-medium text-slate-700 mb-1">Duration (min)</label>
@@ -122,9 +127,11 @@ import { defineComponent, ref, computed, watch } from 'vue';
 import { SessionsHttpClient } from '../../services/SessionsHttpClient';
 import { PatientsHttpClient } from '../../services/PatientsHttpClient';
 import { TherapistsHttpClient } from '../../services/TherapistsHttpClient';
+import { LookupHttpClient } from '../../services/LookupHttpClient';
 import type { SessionEventRequest } from '../../interfaces/Appointment';
 import type { Patient } from '../../interfaces/Patient';
 import type { Therapist } from '../../interfaces/Therapist';
+import type { LookupItem } from '../../interfaces/Lookups';
 
 export default defineComponent({
   name: 'BookingFormModal',
@@ -137,9 +144,11 @@ export default defineComponent({
     const sessionsClient = new SessionsHttpClient();
     const patientsClient = new PatientsHttpClient();
     const therapistsClient = new TherapistsHttpClient();
+    const lookupClient = new LookupHttpClient();
 
     const patients = ref<Patient[]>([]);
     const therapists = ref<Therapist[]>([]);
+    const specialtyTypes = ref<LookupItem[]>([]);
     const saving = ref(false);
     const saveError = ref('');
     const caretakerWarning = ref(false);
@@ -152,7 +161,7 @@ export default defineComponent({
       therapistId: 0,
       sessionDate: today,
       sessionTime: nowTime,
-      therapyType: 'N/A',
+      specialtyTypeId: 0,
       duration: 60,
       amount: 0,
       discount: 0,
@@ -161,17 +170,19 @@ export default defineComponent({
     });
 
     const isValid = computed(() => {
-      return form.value.patientId > 0 && form.value.therapistId > 0;
+      return form.value.patientId > 0 && form.value.therapistId > 0 && form.value.specialtyTypeId > 0;
     });
 
     const loadDropdowns = async () => {
       try {
-        const [p, t] = await Promise.all([
+        const [p, t, s] = await Promise.all([
           patientsClient.getPatients(),
           therapistsClient.getTherapists(),
+          lookupClient.getAll('specialty-types'),
         ]);
         patients.value = p.sort((a, b) => a.patientName.localeCompare(b.patientName));
         therapists.value = t.sort((a, b) => a.therapistName.localeCompare(b.therapistName));
+        specialtyTypes.value = s.sort((a, b) => a.sortOrder - b.sortOrder || a.abbreviation.localeCompare(b.abbreviation));
       } catch {
         // Silently fail — dropdowns will be empty
       }
@@ -198,7 +209,7 @@ export default defineComponent({
           therapistId: 0,
           sessionDate: props.isWalkIn ? today : today,
           sessionTime: props.isWalkIn ? nowTime : '09:00',
-          therapyType: 'N/A',
+          specialtyTypeId: 0,
           duration: 60,
           amount: 0,
           discount: 0,
@@ -217,7 +228,7 @@ export default defineComponent({
           sessionTime: form.value.sessionTime + ':00',
           patientId: form.value.patientId,
           therapistId: form.value.therapistId,
-          therapyType: form.value.therapyType,
+          therapyType: 'N/A', // backward compat — API resolves from specialtyTypeId
           duration: form.value.duration,
           amount: form.value.amount,
           discount: form.value.discount,
@@ -225,6 +236,7 @@ export default defineComponent({
           isPaidOff: false,
           notes: form.value.notes,
           appointmentStatusId: props.isWalkIn ? 6 : 1, // CheckedIn for walk-in, Proposed for booking
+          specialtyTypeId: form.value.specialtyTypeId,
         };
         await sessionsClient.createSession(request);
         emit('saved');
@@ -236,7 +248,7 @@ export default defineComponent({
       }
     };
 
-    return { form, patients, therapists, saving, saveError, caretakerWarning, isValid, handleSubmit };
+    return { form, patients, therapists, specialtyTypes, saving, saveError, caretakerWarning, isValid, handleSubmit };
   },
 });
 </script>

--- a/app-ui/src/interfaces/Appointment.ts
+++ b/app-ui/src/interfaces/Appointment.ts
@@ -21,6 +21,10 @@ export interface Appointment {
     isConfirmed: boolean;
     siteId: number | null;
     siteName: string | null;
+    specialtyTypeId: number | null;
+    specialtyAbbreviation: string | null;
+    specialtyName: string | null;
+    isDiscovery: boolean | null;
 }
 
 export interface AppointmentStatusInfo {
@@ -43,6 +47,7 @@ export interface SessionEventRequest {
     notes: string;
     appointmentStatusId: number;
     siteId?: number;
+    specialtyTypeId?: number;
 }
 
 export interface ConfirmationRequest {


### PR DESCRIPTION
…ing form

- Appointment interface: add specialtyTypeId, specialtyAbbreviation, specialtyName, isDiscovery fields
- SessionEventRequest: add optional specialtyTypeId
- BookingFormModal: replace text input with <select> dropdown populated from specialty-types lookup API, sorted by sortOrder then abbreviation. Display format: "Abbreviation — Name". Specialty selection is now required for form submission. Sends specialtyTypeId in request; API resolves TherapyTypes for backward compat.

Type-check and lint pass clean.