### PR TITLE
WP-10C: Treatment plan UI, discovery-first booking, entry point links

### DIFF
--- a/app-ui/src/components/appointments/ActionsPanel.vue
+++ b/app-ui/src/components/appointments/ActionsPanel.vue
@@ -41,9 +41,12 @@
                 <span class="text-slate-500">Time</span>
                 <span class="text-slate-700">{{ appointment.sessionTime }}</span>
               </div>
-              <div class="flex justify-between">
+              <div class="flex justify-between items-center">
                 <span class="text-slate-500">Therapy Type</span>
-                <span class="text-slate-700">{{ appointment.therapyTypes || 'N/A' }}</span>
+                <span class="text-slate-700">
+                  {{ appointment.therapyTypes || 'N/A' }}
+                  <span v-if="appointment.isDiscovery" class="ml-1.5 inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-700">Discovery</span>
+                </span>
               </div>
               <div v-if="appointment.notes" class="pt-1 border-t border-slate-200">
                 <span class="text-slate-500">Notes</span>
@@ -170,6 +173,37 @@
             </button>
           </div>
 
+          <!-- Treatment Plan Section -->
+          <div class="space-y-3">
+            <h3 class="text-sm font-semibold text-slate-700 flex items-center">
+              <svg class="w-4 h-4 text-violet-500 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01" />
+              </svg>
+              Treatment Plan
+            </h3>
+            <div v-if="isCompletedDiscovery" class="bg-violet-50 border border-violet-200 rounded-lg p-4 text-center">
+              <p class="text-sm text-violet-700 font-medium">Create a treatment plan from this discovery session</p>
+              <button
+                class="mt-3 inline-flex items-center px-4 py-2 text-sm font-medium text-white bg-violet-600 rounded-lg hover:bg-violet-700 transition-colors"
+                @click="createPlanFromDiscovery"
+              >
+                <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+                </svg>
+                Create Treatment Plan
+              </button>
+            </div>
+            <button
+              class="inline-flex items-center px-3 py-1.5 text-xs font-medium text-violet-600 bg-violet-50 rounded-lg hover:bg-violet-100 transition-colors"
+              @click="viewPatientPlans"
+            >
+              <svg class="w-3.5 h-3.5 mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+              </svg>
+              View Patient's Treatment Plans
+            </button>
+          </div>
+
           <!-- Status Actions -->
           <div class="space-y-2">
             <div class="flex items-center justify-between">
@@ -230,6 +264,7 @@
 
 <script lang="ts">
 import { defineComponent, ref, computed, watch, type PropType } from 'vue';
+import { useRouter } from 'vue-router';
 import StatusBadge from './StatusBadge.vue';
 import { SessionsHttpClient } from '../../services/SessionsHttpClient';
 import type { Appointment } from '../../interfaces/Appointment';
@@ -245,6 +280,7 @@ export default defineComponent({
   },
   emits: ['close', 'updated'],
   setup(props, { emit }) {
+    const router = useRouter();
     const client = new SessionsHttpClient();
     const actionInProgress = ref(false);
     const actionError = ref('');
@@ -264,6 +300,32 @@ export default defineComponent({
       const id = props.appointment?.appointmentStatusId;
       return id !== undefined && id !== 3 && id !== 4 && id !== 5;
     });
+
+    const isCompletedDiscovery = computed(() =>
+      props.appointment?.isDiscovery === true && props.appointment?.appointmentStatusId === 4
+    );
+
+    const createPlanFromDiscovery = () => {
+      if (!props.appointment) return;
+      router.push({
+        path: '/treatment-plans',
+        query: {
+          patientId: String(props.appointment.patientId),
+          create: 'true',
+          discoverySessionId: String(props.appointment.sessionId),
+        },
+      });
+      emit('close');
+    };
+
+    const viewPatientPlans = () => {
+      if (!props.appointment) return;
+      router.push({
+        path: '/treatment-plans',
+        query: { patientId: String(props.appointment.patientId) },
+      });
+      emit('close');
+    };
 
     const availableActions = computed(() => {
       const currentId = props.appointment?.appointmentStatusId;
@@ -385,6 +447,7 @@ export default defineComponent({
       confirmForm, cancelReason, actionInProgress, actionError,
       correctionConfirmed, editingFinancials, financialForm, isTerminalStatus,
       showConfirmSection, showCancelSection, availableActions,
+      isCompletedDiscovery, createPlanFromDiscovery, viewPatientPlans,
       startEditFinancials, saveFinancials,
       handleConfirm, handleStatusChange, handleCancel,
     };

--- a/app-ui/src/components/appointments/BookingFormModal.vue
+++ b/app-ui/src/components/appointments/BookingFormModal.vue
@@ -31,6 +31,19 @@
             </p>
           </div>
 
+          <!-- Discovery-first banner -->
+          <div v-if="needsDiscovery" class="bg-amber-50 border border-amber-200 rounded-lg p-3">
+            <div class="flex items-start">
+              <svg class="w-4 h-4 text-amber-600 mr-2 mt-0.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+              <div>
+                <span class="text-sm text-amber-800 font-medium">This patient needs a discovery session first.</span>
+                <span class="text-xs text-amber-600 block mt-1">Only discovery specialties are available for booking.</span>
+              </div>
+            </div>
+          </div>
+
           <!-- Therapist -->
           <div>
             <label class="block text-sm font-medium text-slate-700 mb-1">Therapist</label>
@@ -133,12 +146,14 @@ import type { SessionEventRequest } from '../../interfaces/Appointment';
 import type { Patient } from '../../interfaces/Patient';
 import type { Therapist } from '../../interfaces/Therapist';
 import type { LookupItem } from '../../interfaces/Lookups';
+import { isDiscoverySpecialty } from '../../interfaces/TreatmentPlan';
 
 export default defineComponent({
   name: 'BookingFormModal',
   props: {
     visible: { type: Boolean, required: true },
     isWalkIn: { type: Boolean, default: false },
+    preSelectPatientId: { type: Number, default: 0 },
   },
   emits: ['close', 'saved'],
   setup(props, { emit }) {
@@ -153,6 +168,7 @@ export default defineComponent({
     const saving = ref(false);
     const saveError = ref('');
     const caretakerWarning = ref(false);
+    const needsDiscovery = ref(false);
 
     const today = new Date().toISOString().split('T')[0];
     const nowTime = new Date().toTimeString().slice(0, 5);
@@ -170,20 +186,38 @@ export default defineComponent({
       notes: '',
     });
 
-    // Bidirectional filtering: specialty ↔ therapist
+    // Bidirectional filtering: specialty ↔ therapist (with discovery-first)
     const filteredSpecialties = computed(() => {
-      if (form.value.therapistId <= 0) return specialtyTypes.value;
-      const therapist = therapists.value.find(t => t.therapistId === form.value.therapistId);
-      if (!therapist || therapist.specialties.length === 0) return specialtyTypes.value;
-      const qualifiedIds = new Set(therapist.specialties.map(s => s.specialtyId));
-      return specialtyTypes.value.filter(s => qualifiedIds.has(s.id));
+      let specs = specialtyTypes.value;
+      // Discovery-first: only discovery types when patient needs discovery
+      if (needsDiscovery.value) {
+        specs = specs.filter(s => isDiscoverySpecialty(s.abbreviation));
+      }
+      // Therapist-based filtering
+      if (form.value.therapistId > 0) {
+        const therapist = therapists.value.find(t => t.therapistId === form.value.therapistId);
+        if (therapist && therapist.specialties.length > 0) {
+          const qualifiedIds = new Set(therapist.specialties.map(s => s.specialtyId));
+          specs = specs.filter(s => qualifiedIds.has(s.id));
+        }
+      }
+      return specs;
     });
 
     const filteredTherapists = computed(() => {
-      if (form.value.specialtyTypeId <= 0) return therapists.value;
-      return therapists.value.filter(t =>
-        t.specialties.some(s => s.specialtyId === form.value.specialtyTypeId)
-      );
+      let pool = therapists.value;
+      // Discovery-first: only therapists qualified in discovery specialties
+      if (needsDiscovery.value) {
+        const discoverySpecialtyIds = new Set(
+          specialtyTypes.value.filter(s => isDiscoverySpecialty(s.abbreviation)).map(s => s.id)
+        );
+        pool = pool.filter(t => t.specialties.some(s => discoverySpecialtyIds.has(s.specialtyId)));
+      }
+      // Specialty-based filtering
+      if (form.value.specialtyTypeId > 0) {
+        pool = pool.filter(t => t.specialties.some(s => s.specialtyId === form.value.specialtyTypeId));
+      }
+      return pool;
     });
 
     // Reset the other selection when it becomes invalid after filtering
@@ -228,15 +262,26 @@ export default defineComponent({
       }
     };
 
-    watch(() => form.value.patientId, checkCaretaker);
+    const checkDiscovery = async (patientId: number) => {
+      if (patientId <= 0) { needsDiscovery.value = false; return; }
+      try {
+        const patient = await patientsClient.getPatient(patientId);
+        needsDiscovery.value = patient.hasCompletedDiscovery === false;
+      } catch {
+        needsDiscovery.value = false; // Fail open — don't block booking
+      }
+    };
+
+    watch(() => form.value.patientId, (id) => { checkCaretaker(id); checkDiscovery(id); });
     watch(form, () => { saveError.value = ''; }, { deep: true });
 
     watch(() => props.visible, (val) => {
       if (val) {
         loadDropdowns();
         saveError.value = '';
+        needsDiscovery.value = false;
         form.value = {
-          patientId: 0,
+          patientId: props.preSelectPatientId || 0,
           therapistId: 0,
           sessionDate: props.isWalkIn ? today : today,
           sessionTime: props.isWalkIn ? nowTime : '09:00',
@@ -279,7 +324,7 @@ export default defineComponent({
       }
     };
 
-    return { form, patients, filteredTherapists, filteredSpecialties, saving, saveError, caretakerWarning, isValid, handleSubmit };
+    return { form, patients, filteredTherapists, filteredSpecialties, saving, saveError, caretakerWarning, needsDiscovery, isValid, handleSubmit };
   },
 });
 </script>

--- a/app-ui/src/components/caretakers/CaretakerPatientsList.vue
+++ b/app-ui/src/components/caretakers/CaretakerPatientsList.vue
@@ -43,12 +43,20 @@
             Primary
           </span>
         </div>
-        <button
-          class="px-3 py-1 rounded-lg text-xs font-medium text-red-600 hover:bg-red-50 transition-colors"
-          @click="confirmUnlink(lp)"
-        >
-          Unlink
-        </button>
+        <div class="flex items-center space-x-2">
+          <button
+            class="px-3 py-1 rounded-lg text-xs font-medium text-violet-600 hover:bg-violet-50 transition-colors"
+            @click="viewPlans(lp.patientId)"
+          >
+            Plans
+          </button>
+          <button
+            class="px-3 py-1 rounded-lg text-xs font-medium text-red-600 hover:bg-red-50 transition-colors"
+            @click="confirmUnlink(lp)"
+          >
+            Unlink
+          </button>
+        </div>
       </div>
     </div>
     <p v-else class="text-sm text-slate-400 mb-4">No patients linked.</p>
@@ -168,6 +176,7 @@
 
 <script lang="ts">
 import { defineComponent, ref, computed, onMounted, type PropType } from 'vue';
+import { useRouter } from 'vue-router';
 import type { Caretaker, CaretakerPatientSummary } from '../../interfaces/Caretaker';
 import type { Patient } from '../../interfaces/Patient';
 import { CaretakersHttpClient } from '../../services/CaretakersHttpClient';
@@ -180,6 +189,7 @@ export default defineComponent({
   },
   emits: ['close', 'updated'],
   setup(props, { emit }) {
+    const router = useRouter();
     const caretakerClient = new CaretakersHttpClient();
     const patientClient = new PatientsHttpClient();
 
@@ -254,6 +264,10 @@ export default defineComponent({
       linkIsPrimary.value = true;
     };
 
+    const viewPlans = (patientId: number) => {
+      router.push({ path: '/treatment-plans', query: { patientId: String(patientId) } });
+    };
+
     onMounted(loadData);
 
     return {
@@ -270,6 +284,7 @@ export default defineComponent({
       doUnlink,
       doLink,
       resetLinkForm,
+      viewPlans,
     };
   },
 });

--- a/app-ui/src/components/option02/O2Sidebar.vue
+++ b/app-ui/src/components/option02/O2Sidebar.vue
@@ -20,7 +20,7 @@
             ? 'bg-white/20 text-white'
             : 'text-violet-300 hover:bg-white/10 hover:text-white',
         ]"
-        :title="item.label"
+        :title="item.title || item.label"
       >
         <font-awesome-icon :icon="['fas', item.icon]" class="text-lg" />
         <span class="text-[9px] mt-0.5 font-medium">{{ item.label }}</span>
@@ -85,7 +85,7 @@ export default defineComponent({
       { label: 'Patients', icon: 'users', to: '/patients' },
       { label: 'Therapists', icon: 'user-md', to: '/therapists' },
       { label: 'Caretakers', icon: 'hand-holding-heart', to: '/caretakers' },
-      { label: 'Schedule', icon: 'calendar-check', to: '/appointments' },
+      { label: 'Appts', icon: 'calendar-check', to: '/appointments', title: 'Appointments' },
       { label: 'Billing', icon: 'credit-card', to: '/payments' },
       { label: 'Statements', icon: 'file-alt', to: '/statements' },
     ];

--- a/app-ui/src/components/patients/PatientList.vue
+++ b/app-ui/src/components/patients/PatientList.vue
@@ -83,6 +83,7 @@
       @edit="(p) => $emit('edit', p)"
       @toggle-active="(p) => $emit('toggle-active', p)"
       @view-caretakers="(p) => $emit('view-caretakers', p)"
+      @view-plans="(p) => $emit('view-plans', p)"
     />
   </div>
 </template>
@@ -104,7 +105,7 @@ export default defineComponent({
     loading: { type: Boolean, default: false },
     error: { type: String, default: '' },
   },
-  emits: ['add', 'edit', 'toggle-active', 'retry', 'tab-change', 'view-caretakers', 'pay-delinquent'],
+  emits: ['add', 'edit', 'toggle-active', 'retry', 'tab-change', 'view-caretakers', 'view-plans', 'pay-delinquent'],
   setup(props, { emit }) {
     const search = ref('');
     const activeFilter = ref<'all' | 'active' | 'inactive' | 'delinquent'>(props.initialTab);

--- a/app-ui/src/components/patients/PatientTable.vue
+++ b/app-ui/src/components/patients/PatientTable.vue
@@ -76,6 +76,15 @@
                 </svg>
               </button>
               <button
+                class="p-1.5 rounded-lg text-slate-400 hover:text-violet-600 hover:bg-violet-50 transition-colors"
+                title="Treatment Plans"
+                @click="$emit('view-plans', patient)"
+              >
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01" />
+                </svg>
+              </button>
+              <button
                 class="p-1.5 rounded-lg text-slate-400 hover:text-blue-600 hover:bg-blue-50 transition-colors"
                 title="Edit patient"
                 @click="$emit('edit', patient)"
@@ -157,6 +166,12 @@
           Caretakers
         </button>
         <button
+          class="px-3 py-1.5 rounded-lg text-xs font-medium text-violet-600 hover:bg-violet-50 transition-colors"
+          @click="$emit('view-plans', patient)"
+        >
+          Plans
+        </button>
+        <button
           class="px-3 py-1.5 rounded-lg text-xs font-medium text-blue-600 hover:bg-blue-50 transition-colors"
           @click="$emit('edit', patient)"
         >
@@ -193,7 +208,7 @@ export default defineComponent({
   props: {
     patients: { type: Array as PropType<Patient[]>, required: true },
   },
-  emits: ['edit', 'toggle-active', 'view-caretakers'],
+  emits: ['edit', 'toggle-active', 'view-caretakers', 'view-plans'],
   setup(props) {
     const sortKey = ref('patientName');
     const sortAsc = ref(true);

--- a/app-ui/src/components/treatment-plans/TreatmentPlanFormModal.vue
+++ b/app-ui/src/components/treatment-plans/TreatmentPlanFormModal.vue
@@ -1,0 +1,468 @@
+<template>
+  <teleport to="body">
+    <div v-if="visible" class="fixed inset-0 z-50 flex justify-end">
+      <div class="absolute inset-0 bg-black/30" @click="$emit('close')"></div>
+      <div class="relative w-full max-w-2xl bg-white shadow-xl flex flex-col h-full">
+        <!-- Header -->
+        <div class="px-6 py-4 border-b border-slate-200 flex items-center justify-between">
+          <div class="flex items-center space-x-3">
+            <h2 class="text-lg font-semibold text-slate-800">
+              {{ isEditing ? 'Edit Treatment Plan' : 'Create Treatment Plan' }}
+            </h2>
+            <span
+              v-if="isEditing && plan"
+              :class="['inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium', planStatusBadgeClass(plan.planStatus)]"
+            >
+              {{ plan.planStatus }}
+            </span>
+          </div>
+          <button @click="$emit('close')" class="p-1 text-slate-400 hover:text-slate-600 rounded-lg hover:bg-slate-100">
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <!-- Body -->
+        <div class="flex-1 overflow-y-auto px-6 py-4 space-y-6">
+          <!-- Section 1: Discovery Session -->
+          <div class="bg-slate-50 rounded-lg p-4">
+            <label class="text-sm font-semibold text-slate-700 mb-3 block">Discovery Session</label>
+            <div v-if="isEditing && plan">
+              <p class="text-sm text-slate-600">
+                Discovery Session #{{ plan.discoverySessionId }}
+                &mdash; {{ plan.discoverySpecialty }}, {{ formatDate(plan.discoveryDate) }}
+              </p>
+            </div>
+            <div v-else-if="discoverySessionId > 0">
+              <p class="text-sm text-slate-600">Discovery Session #{{ discoverySessionId }}</p>
+            </div>
+            <div v-else>
+              <label class="block text-sm font-medium text-slate-700 mb-1">Discovery Session ID</label>
+              <input
+                v-model.number="form.discoverySessionId"
+                type="number"
+                min="1"
+                placeholder="Enter the ID of a completed discovery session"
+                class="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-violet-500 focus:border-transparent"
+              />
+              <p class="mt-1 text-xs text-slate-400">Enter the ID of a completed discovery session</p>
+            </div>
+          </div>
+
+          <!-- Section 2: Plan Details -->
+          <div>
+            <label class="text-sm font-semibold text-slate-700 mb-3 block">Plan Details</label>
+            <div class="space-y-4">
+              <div>
+                <label class="block text-sm font-medium text-slate-700 mb-1">Results Document URL</label>
+                <input
+                  v-model="form.resultsDocumentUrl"
+                  type="text"
+                  placeholder="https://drive.google.com/..."
+                  class="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-violet-500 focus:border-transparent"
+                />
+              </div>
+              <div class="grid grid-cols-2 gap-4">
+                <div>
+                  <label class="block text-sm font-medium text-slate-700 mb-1">Sessions per Week</label>
+                  <input
+                    v-model.number="form.weeklyFrequency"
+                    type="number"
+                    min="1"
+                    max="5"
+                    class="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-violet-500 focus:border-transparent"
+                  />
+                </div>
+                <div>
+                  <label class="block text-sm font-medium text-slate-700 mb-1">Duration Weeks</label>
+                  <input
+                    v-model.number="form.durationWeeks"
+                    type="number"
+                    min="1"
+                    max="52"
+                    class="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-violet-500 focus:border-transparent"
+                  />
+                </div>
+              </div>
+              <div>
+                <label class="block text-sm font-medium text-slate-700 mb-1">Notes</label>
+                <textarea
+                  v-model="form.notes"
+                  rows="3"
+                  class="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-violet-500 focus:border-transparent"
+                  placeholder="Optional notes..."
+                ></textarea>
+              </div>
+            </div>
+          </div>
+
+          <!-- Section 3: Treatment Lines -->
+          <div>
+            <div class="flex items-center justify-between mb-3">
+              <div class="flex items-center space-x-2">
+                <label class="text-sm font-semibold text-slate-700">Treatment Lines</label>
+                <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-slate-100 text-slate-600">
+                  {{ lines.length }}
+                </span>
+              </div>
+              <button
+                type="button"
+                class="px-3 py-1.5 rounded-lg text-xs font-medium bg-violet-50 text-violet-600 hover:bg-violet-100 transition-colors"
+                @click="addLine"
+              >
+                + Add Line
+              </button>
+            </div>
+
+            <div class="space-y-3">
+              <div
+                v-for="(line, index) in lines"
+                :key="index"
+                class="bg-white border border-slate-200 rounded-lg p-4 space-y-3"
+              >
+                <!-- Line header -->
+                <div class="flex items-center justify-between">
+                  <span class="text-xs font-semibold text-slate-500 uppercase">Line {{ index + 1 }}</span>
+                  <button
+                    v-if="lines.length > 1"
+                    type="button"
+                    class="text-red-500 hover:text-red-700 text-xs font-medium"
+                    @click="removeLine(index)"
+                  >
+                    Remove
+                  </button>
+                </div>
+
+                <!-- Row 1: Specialty + Therapist -->
+                <div class="grid grid-cols-2 gap-4">
+                  <div>
+                    <label class="block text-sm font-medium text-slate-700 mb-1">Specialty</label>
+                    <select
+                      v-model="line.specialtyTypeId"
+                      class="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-violet-500 focus:border-transparent"
+                    >
+                      <option :value="0" disabled>Select specialty...</option>
+                      <option v-for="s in treatmentSpecialties" :key="s.id" :value="s.id">
+                        {{ s.abbreviation }} &mdash; {{ s.name }}
+                      </option>
+                    </select>
+                  </div>
+                  <div>
+                    <label class="block text-sm font-medium text-slate-700 mb-1">Therapist</label>
+                    <select
+                      v-model="line.preferredTherapistId"
+                      class="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-violet-500 focus:border-transparent"
+                    >
+                      <option :value="null">Any Qualified Therapist</option>
+                      <option v-for="t in therapistsForLine(line)" :key="t.therapistId" :value="t.therapistId">
+                        {{ t.therapistName }}
+                      </option>
+                    </select>
+                  </div>
+                </div>
+
+                <!-- Row 2: Day + Time + Duration -->
+                <div class="grid grid-cols-3 gap-4">
+                  <div>
+                    <label class="block text-sm font-medium text-slate-700 mb-1">Day of Week</label>
+                    <select
+                      v-model="line.dayOfWeek"
+                      class="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-violet-500 focus:border-transparent"
+                    >
+                      <option :value="null">Flexible</option>
+                      <option v-for="(label, key) in DAY_OF_WEEK_LABELS" :key="key" :value="Number(key)">
+                        {{ label }}
+                      </option>
+                    </select>
+                  </div>
+                  <div>
+                    <label class="block text-sm font-medium text-slate-700 mb-1">Preferred Time</label>
+                    <input
+                      v-model="line.preferredTime"
+                      type="time"
+                      class="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-violet-500 focus:border-transparent"
+                    />
+                  </div>
+                  <div>
+                    <label class="block text-sm font-medium text-slate-700 mb-1">Duration (min)</label>
+                    <input
+                      v-model.number="line.duration"
+                      type="number"
+                      min="15"
+                      step="15"
+                      class="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-violet-500 focus:border-transparent"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Footer -->
+        <div class="px-6 py-4 border-t border-slate-200 space-y-3">
+          <div v-if="saveError" class="bg-red-50 border border-red-200 rounded-lg p-3">
+            <p class="text-sm text-red-700">{{ saveError }}</p>
+          </div>
+          <div class="flex items-center justify-end space-x-3">
+            <button
+              @click="$emit('close')"
+              class="px-4 py-2 text-sm font-medium text-slate-600 bg-slate-100 rounded-lg hover:bg-slate-200 transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              v-if="isEditing && plan && plan.planStatus === 'Draft'"
+              @click="handleActivate"
+              :disabled="saving"
+              :class="[
+                'px-4 py-2 text-sm font-medium rounded-lg transition-colors',
+                saving
+                  ? 'bg-emerald-300 text-white cursor-not-allowed'
+                  : 'bg-emerald-600 text-white hover:bg-emerald-700',
+              ]"
+            >
+              {{ saving ? 'Saving...' : 'Activate' }}
+            </button>
+            <button
+              v-if="!isEditing || (plan && plan.planStatus === 'Draft')"
+              @click="handleSave"
+              :disabled="saving"
+              :class="[
+                'px-4 py-2 text-sm font-medium rounded-lg transition-colors',
+                saving
+                  ? 'bg-violet-300 text-white cursor-not-allowed'
+                  : 'bg-violet-600 text-white hover:bg-violet-700',
+              ]"
+            >
+              {{ saving ? 'Saving...' : 'Save as Draft' }}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </teleport>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref, watch, type PropType } from 'vue';
+import { TreatmentPlansHttpClient } from '../../services/TreatmentPlansHttpClient';
+import { LookupHttpClient } from '../../services/LookupHttpClient';
+import { TherapistsHttpClient } from '../../services/TherapistsHttpClient';
+import type { TreatmentPlan, TreatmentPlanRequest, TreatmentPlanLineRequest } from '../../interfaces/TreatmentPlan';
+import { DAY_OF_WEEK_LABELS, isDiscoverySpecialty, planStatusBadgeClass } from '../../interfaces/TreatmentPlan';
+import type { LookupItem } from '../../interfaces/Lookups';
+import type { Therapist } from '../../interfaces/Therapist';
+
+interface FormLine {
+  specialtyTypeId: number;
+  preferredTherapistId: number | null;
+  dayOfWeek: number | null;
+  preferredTime: string;
+  duration: number;
+}
+
+export default defineComponent({
+  name: 'TreatmentPlanFormModal',
+  props: {
+    visible: { type: Boolean, required: true },
+    plan: { type: Object as PropType<TreatmentPlan | null>, default: null },
+    patientId: { type: Number, required: true },
+    patientName: { type: String, default: '' },
+    discoverySessionId: { type: Number, default: 0 },
+  },
+  emits: ['close', 'saved'],
+  setup(props, { emit }) {
+    const plansClient = new TreatmentPlansHttpClient();
+    const lookupClient = new LookupHttpClient();
+    const therapistsClient = new TherapistsHttpClient();
+
+    const specialtyTypes = ref<LookupItem[]>([]);
+    const therapists = ref<Therapist[]>([]);
+    const saving = ref(false);
+    const saveError = ref('');
+
+    const isEditing = ref(false);
+
+    const form = ref({
+      discoverySessionId: 0,
+      resultsDocumentUrl: '',
+      weeklyFrequency: 2,
+      durationWeeks: 8,
+      notes: '',
+    });
+
+    const lines = ref<FormLine[]>([]);
+
+    const treatmentSpecialties = ref<LookupItem[]>([]);
+
+    const emptyLine = (): FormLine => ({
+      specialtyTypeId: 0,
+      preferredTherapistId: null,
+      dayOfWeek: null,
+      preferredTime: '',
+      duration: 60,
+    });
+
+    const therapistsForLine = (line: FormLine): Therapist[] => {
+      if (line.specialtyTypeId <= 0) return therapists.value;
+      return therapists.value.filter(t =>
+        t.specialties.some(s => s.specialtyId === line.specialtyTypeId)
+      );
+    };
+
+    const loadDropdowns = async () => {
+      try {
+        const [allSpecialties, allTherapists] = await Promise.all([
+          lookupClient.getAll('specialty-types'),
+          therapistsClient.getTherapists(),
+        ]);
+        specialtyTypes.value = allSpecialties.sort((a, b) => a.sortOrder - b.sortOrder || a.abbreviation.localeCompare(b.abbreviation));
+        // Filter out discovery specialties for treatment lines
+        treatmentSpecialties.value = specialtyTypes.value.filter(s => !isDiscoverySpecialty(s.abbreviation));
+        therapists.value = allTherapists.sort((a, b) => a.therapistName.localeCompare(b.therapistName));
+      } catch {
+        // Dropdowns will be empty
+      }
+    };
+
+    const resetForm = () => {
+      form.value = {
+        discoverySessionId: props.discoverySessionId || 0,
+        resultsDocumentUrl: '',
+        weeklyFrequency: 2,
+        durationWeeks: 8,
+        notes: '',
+      };
+      lines.value = [emptyLine()];
+      saveError.value = '';
+    };
+
+    const populateFromPlan = (p: TreatmentPlan) => {
+      form.value = {
+        discoverySessionId: p.discoverySessionId,
+        resultsDocumentUrl: p.resultsDocumentUrl || '',
+        weeklyFrequency: p.weeklyFrequency,
+        durationWeeks: p.durationWeeks,
+        notes: p.notes || '',
+      };
+      lines.value = p.lines.map(l => ({
+        specialtyTypeId: l.specialtyTypeId,
+        preferredTherapistId: l.preferredTherapistId,
+        dayOfWeek: l.dayOfWeek,
+        preferredTime: l.preferredTime || '',
+        duration: l.duration,
+      }));
+      if (lines.value.length === 0) {
+        lines.value = [emptyLine()];
+      }
+    };
+
+    watch(() => props.visible, (val) => {
+      if (val) {
+        loadDropdowns();
+        isEditing.value = !!props.plan;
+        if (props.plan) {
+          populateFromPlan(props.plan);
+        } else {
+          resetForm();
+        }
+      }
+    });
+
+    // Clear error on form change
+    watch(form, () => { saveError.value = ''; }, { deep: true });
+    watch(lines, () => { saveError.value = ''; }, { deep: true });
+
+    const buildRequest = (): TreatmentPlanRequest => {
+      const lineRequests: TreatmentPlanLineRequest[] = lines.value.map((l, i) => ({
+        specialtyTypeId: l.specialtyTypeId,
+        preferredTherapistId: l.preferredTherapistId,
+        dayOfWeek: l.dayOfWeek,
+        preferredTime: l.preferredTime ? (l.preferredTime.length === 5 ? l.preferredTime + ':00' : l.preferredTime) : null,
+        duration: l.duration,
+        sortOrder: i + 1,
+      }));
+
+      return {
+        patientId: props.patientId,
+        discoverySessionId: form.value.discoverySessionId,
+        createdByTherapistId: props.plan?.createdByTherapistId || 1,
+        resultsDocumentUrl: form.value.resultsDocumentUrl || null,
+        weeklyFrequency: form.value.weeklyFrequency,
+        durationWeeks: form.value.durationWeeks,
+        notes: form.value.notes || null,
+        lines: lineRequests,
+      };
+    };
+
+    const handleSave = async () => {
+      saving.value = true;
+      saveError.value = '';
+      try {
+        const request = buildRequest();
+        if (isEditing.value && props.plan) {
+          await plansClient.update(props.plan.id, request);
+        } else {
+          await plansClient.create(request);
+        }
+        emit('saved');
+        emit('close');
+      } catch (e: unknown) {
+        saveError.value = e instanceof Error ? e.message : 'Failed to save treatment plan.';
+      } finally {
+        saving.value = false;
+      }
+    };
+
+    const handleActivate = async () => {
+      if (!props.plan) return;
+      saving.value = true;
+      saveError.value = '';
+      try {
+        await plansClient.activate(props.plan.id);
+        emit('saved');
+        emit('close');
+      } catch (e: unknown) {
+        saveError.value = e instanceof Error ? e.message : 'Failed to activate treatment plan.';
+      } finally {
+        saving.value = false;
+      }
+    };
+
+    const addLine = () => {
+      lines.value.push(emptyLine());
+    };
+
+    const removeLine = (index: number) => {
+      if (lines.value.length > 1) {
+        lines.value.splice(index, 1);
+      }
+    };
+
+    const formatDate = (dateStr: string) => {
+      if (!dateStr) return '';
+      const d = new Date(dateStr);
+      return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+    };
+
+    return {
+      form,
+      lines,
+      isEditing,
+      saving,
+      saveError,
+      treatmentSpecialties,
+      therapistsForLine,
+      DAY_OF_WEEK_LABELS,
+      planStatusBadgeClass,
+      handleSave,
+      handleActivate,
+      addLine,
+      removeLine,
+      formatDate,
+    };
+  },
+});
+</script>

--- a/app-ui/src/components/treatment-plans/TreatmentPlanList.vue
+++ b/app-ui/src/components/treatment-plans/TreatmentPlanList.vue
@@ -1,0 +1,227 @@
+<template>
+  <div class="space-y-4">
+    <!-- Summary Cards -->
+    <div class="grid grid-cols-3 gap-4 mb-6">
+      <div class="bg-slate-100 rounded-xl px-5 py-3">
+        <div class="flex items-center space-x-3">
+          <div class="w-10 h-10 rounded-lg flex items-center justify-center bg-slate-200">
+            <span class="text-lg font-bold text-slate-600">{{ draftCount }}</span>
+          </div>
+          <div>
+            <p class="text-sm font-medium text-slate-700">Draft</p>
+            <p class="text-xs text-slate-400">Pending activation</p>
+          </div>
+        </div>
+      </div>
+      <div class="bg-emerald-100 rounded-xl px-5 py-3">
+        <div class="flex items-center space-x-3">
+          <div class="w-10 h-10 rounded-lg flex items-center justify-center bg-emerald-200">
+            <span class="text-lg font-bold text-emerald-700">{{ activeCount }}</span>
+          </div>
+          <div>
+            <p class="text-sm font-medium text-slate-700">Active</p>
+            <p class="text-xs text-slate-400">In progress</p>
+          </div>
+        </div>
+      </div>
+      <div class="bg-gray-100 rounded-xl px-5 py-3">
+        <div class="flex items-center space-x-3">
+          <div class="w-10 h-10 rounded-lg flex items-center justify-center bg-gray-200">
+            <span class="text-lg font-bold text-gray-600">{{ completedCount }}</span>
+          </div>
+          <div>
+            <p class="text-sm font-medium text-slate-700">Completed</p>
+            <p class="text-xs text-slate-400">Finished</p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Tab bar + Create button -->
+    <div class="flex items-center justify-between mb-4">
+      <div class="inline-flex rounded-lg bg-slate-100 p-0.5">
+        <button
+          v-for="tab in tabs"
+          :key="tab"
+          :class="[
+            'px-4 py-1.5 rounded-md text-sm font-medium transition-colors',
+            activeTab === tab
+              ? 'bg-white text-slate-800 shadow-sm'
+              : 'text-slate-500 hover:text-slate-700',
+          ]"
+          @click="activeTab = tab"
+        >
+          {{ tab }}
+        </button>
+      </div>
+      <button
+        :disabled="!canCreate"
+        :title="!canCreate ? 'Patient needs a completed discovery session first' : 'Create a new treatment plan'"
+        :class="[
+          'flex items-center space-x-2 px-4 py-2 rounded-lg text-sm font-medium transition-colors',
+          canCreate
+            ? 'text-white bg-violet-600 hover:bg-violet-700'
+            : 'text-white bg-violet-300 cursor-not-allowed',
+        ]"
+        @click="canCreate && $emit('create')"
+      >
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+        </svg>
+        <span>Create Treatment Plan</span>
+      </button>
+    </div>
+
+    <!-- Loading state -->
+    <div v-if="loading" class="text-center py-12">
+      <div class="inline-block w-6 h-6 border-2 border-violet-600 border-t-transparent rounded-full animate-spin"></div>
+      <p class="mt-2 text-sm text-slate-500">Loading treatment plans...</p>
+    </div>
+
+    <!-- Error state -->
+    <div v-else-if="error" class="bg-red-50 rounded-xl p-6 text-center">
+      <p class="text-sm text-red-700">{{ error }}</p>
+    </div>
+
+    <!-- Empty state -->
+    <div v-else-if="filteredPlans.length === 0" class="bg-white rounded-xl border border-slate-200 p-12 text-center">
+      <p class="text-sm text-slate-500">No treatment plans found.</p>
+    </div>
+
+    <!-- Plan cards -->
+    <div v-else class="space-y-4">
+      <div
+        v-for="plan in filteredPlans"
+        :key="plan.id"
+        class="bg-white border border-slate-200 rounded-xl p-5"
+      >
+        <!-- Card header -->
+        <div class="flex items-center justify-between">
+          <span class="text-base font-semibold text-slate-800">Plan #{{ plan.id }}</span>
+          <span :class="['inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium', planStatusBadgeClass(plan.planStatus)]">
+            {{ plan.planStatus }}
+          </span>
+        </div>
+
+        <!-- Card body -->
+        <div class="grid grid-cols-2 gap-x-6 gap-y-2 mt-3">
+          <div class="text-sm text-slate-600">
+            <span class="text-slate-400">Discovery:</span>
+            {{ formatDate(plan.discoveryDate) }} &middot; {{ plan.discoverySpecialty }}
+          </div>
+          <div class="text-sm text-slate-600">
+            <span class="text-slate-400">Created by:</span>
+            {{ plan.createdByTherapistName }}
+          </div>
+          <div class="text-sm text-slate-600">
+            <span class="text-slate-400">Frequency:</span>
+            {{ plan.weeklyFrequency }}x/week &middot; {{ plan.durationWeeks }} weeks
+          </div>
+          <div class="text-sm text-slate-600">
+            <span class="text-slate-400">Lines:</span>
+            {{ plan.lines.length }} treatment line{{ plan.lines.length !== 1 ? 's' : '' }}
+          </div>
+        </div>
+
+        <!-- Lines summary -->
+        <div v-if="plan.lines.length > 0" class="mt-3 border-t border-slate-100 pt-3">
+          <div v-for="line in plan.lines" :key="line.id" class="text-xs text-slate-600">
+            &bull; {{ line.specialtyAbbreviation }} &mdash; {{ line.preferredTherapistName || 'Any Qualified' }}
+          </div>
+        </div>
+
+        <!-- Card footer -->
+        <div class="mt-3 pt-3 border-t border-slate-100 flex justify-end space-x-2">
+          <button
+            v-if="plan.planStatus === 'Draft'"
+            class="px-3 py-1.5 rounded-lg text-xs font-medium text-slate-600 hover:bg-slate-100 transition-colors"
+            @click="$emit('edit', plan)"
+          >
+            <svg class="w-3.5 h-3.5 inline mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
+            </svg>
+            Edit
+          </button>
+          <button
+            v-if="plan.planStatus === 'Draft'"
+            class="px-3 py-1.5 rounded-lg text-xs font-medium text-white bg-emerald-600 hover:bg-emerald-700 transition-colors"
+            @click="$emit('activate', plan)"
+          >
+            <svg class="w-3.5 h-3.5 inline mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z" />
+            </svg>
+            Activate
+          </button>
+          <button
+            v-if="plan.planStatus === 'Active'"
+            class="px-3 py-1.5 rounded-lg text-xs font-medium text-white bg-gray-500 hover:bg-gray-600 transition-colors"
+            @click="$emit('complete', plan)"
+          >
+            <svg class="w-3.5 h-3.5 inline mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+            </svg>
+            Complete
+          </button>
+          <button
+            v-if="plan.planStatus === 'Draft' || plan.planStatus === 'Active'"
+            class="px-3 py-1.5 rounded-lg text-xs font-medium text-red-500 hover:bg-red-50 transition-colors"
+            @click="$emit('cancel', plan)"
+          >
+            <svg class="w-3.5 h-3.5 inline mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref, computed, type PropType } from 'vue';
+import type { TreatmentPlan, PlanStatus } from '../../interfaces/TreatmentPlan';
+import { planStatusBadgeClass } from '../../interfaces/TreatmentPlan';
+
+export default defineComponent({
+  name: 'TreatmentPlanList',
+  props: {
+    plans: { type: Array as PropType<TreatmentPlan[]>, required: true },
+    loading: { type: Boolean, default: false },
+    error: { type: String, default: '' },
+    initialTab: { type: String, default: 'All' },
+    canCreate: { type: Boolean, default: true },
+  },
+  emits: ['create', 'edit', 'activate', 'complete', 'cancel'],
+  setup(props) {
+    const tabs = ['All', 'Draft', 'Active', 'Completed', 'Cancelled'];
+    const activeTab = ref(props.initialTab);
+
+    const draftCount = computed(() => props.plans.filter(p => p.planStatus === 'Draft').length);
+    const activeCount = computed(() => props.plans.filter(p => p.planStatus === 'Active').length);
+    const completedCount = computed(() => props.plans.filter(p => p.planStatus === 'Completed').length);
+
+    const filteredPlans = computed(() => {
+      if (activeTab.value === 'All') return props.plans;
+      return props.plans.filter(p => p.planStatus === activeTab.value as PlanStatus);
+    });
+
+    const formatDate = (dateStr: string) => {
+      if (!dateStr) return '';
+      const d = new Date(dateStr);
+      return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+    };
+
+    return {
+      tabs,
+      activeTab,
+      draftCount,
+      activeCount,
+      completedCount,
+      filteredPlans,
+      planStatusBadgeClass,
+      formatDate,
+    };
+  },
+});
+</script>

--- a/app-ui/src/interfaces/Patient.ts
+++ b/app-ui/src/interfaces/Patient.ts
@@ -11,6 +11,7 @@ export interface Patient {
   phoneNumber: string;
   gender: string;
   isActive: boolean;
+  hasCompletedDiscovery: boolean | null;
   createdTimestamp: string;
   caretakers?: PatientCaretakerSummary[];
 }

--- a/app-ui/src/interfaces/TreatmentPlan.ts
+++ b/app-ui/src/interfaces/TreatmentPlan.ts
@@ -1,0 +1,78 @@
+// interfaces/TreatmentPlan.ts
+
+export type PlanStatus = 'Draft' | 'Active' | 'Completed' | 'Cancelled';
+
+export interface TreatmentPlanLine {
+  id: number;
+  treatmentPlanId: number;
+  specialtyTypeId: number;
+  specialtyAbbreviation: string;
+  specialtyName: string;
+  preferredTherapistId: number | null;
+  preferredTherapistName: string | null;
+  dayOfWeek: number | null;
+  preferredTime: string | null;
+  duration: number;
+  sortOrder: number;
+}
+
+export interface TreatmentPlan {
+  id: number;
+  patientId: number;
+  patientName: string;
+  discoverySessionId: number;
+  discoveryDate: string;
+  discoverySpecialty: string;
+  createdByTherapistId: number;
+  createdByTherapistName: string;
+  planStatus: PlanStatus;
+  resultsDocumentUrl: string | null;
+  weeklyFrequency: number;
+  durationWeeks: number;
+  notes: string | null;
+  createdTimestamp: string;
+  lastUpdatedTimestamp: string;
+  lines: TreatmentPlanLine[];
+}
+
+export interface TreatmentPlanLineRequest {
+  specialtyTypeId: number;
+  preferredTherapistId: number | null;
+  dayOfWeek: number | null;
+  preferredTime: string | null;
+  duration: number;
+  sortOrder: number;
+}
+
+export interface TreatmentPlanRequest {
+  patientId: number;
+  discoverySessionId: number;
+  createdByTherapistId: number;
+  resultsDocumentUrl?: string | null;
+  weeklyFrequency: number;
+  durationWeeks: number;
+  notes?: string | null;
+  lines: TreatmentPlanLineRequest[];
+}
+
+export const DAY_OF_WEEK_LABELS: Record<number, string> = {
+  1: 'Monday',
+  2: 'Tuesday',
+  3: 'Wednesday',
+  4: 'Thursday',
+  5: 'Friday',
+  6: 'Saturday',
+};
+
+export function isDiscoverySpecialty(abbreviation: string): boolean {
+  return /^(Obs-|Eval-|Vis-)/.test(abbreviation);
+}
+
+export function planStatusBadgeClass(status: PlanStatus): string {
+  switch (status) {
+    case 'Draft': return 'bg-slate-100 text-slate-600';
+    case 'Active': return 'bg-emerald-100 text-emerald-700';
+    case 'Completed': return 'bg-gray-100 text-gray-600';
+    case 'Cancelled': return 'bg-red-100 text-red-700';
+  }
+}

--- a/app-ui/src/router/index.ts
+++ b/app-ui/src/router/index.ts
@@ -39,6 +39,11 @@ const router = createRouter({
       component: () => import('../views/AppointmentsView.vue'),
     },
     {
+      path: '/treatment-plans',
+      name: 'treatment-plans',
+      component: () => import('../views/TreatmentPlansView.vue'),
+    },
+    {
       path: '/admin',
       name: 'admin',
       component: () => import('../views/AdminView.vue'),

--- a/app-ui/src/services/TreatmentPlansHttpClient.ts
+++ b/app-ui/src/services/TreatmentPlansHttpClient.ts
@@ -1,0 +1,33 @@
+// services/TreatmentPlansHttpClient.ts
+import { HttpClientBase } from './HttpClientBase';
+import type { TreatmentPlan, TreatmentPlanRequest } from '../interfaces/TreatmentPlan';
+
+export class TreatmentPlansHttpClient extends HttpClientBase {
+  async getByPatient(patientId: number): Promise<TreatmentPlan[]> {
+    return this.get<TreatmentPlan[]>(`/api/treatment-plans/patient/${patientId}`);
+  }
+
+  async getById(id: number): Promise<TreatmentPlan> {
+    return this.get<TreatmentPlan>(`/api/treatment-plans/${id}`);
+  }
+
+  async create(data: TreatmentPlanRequest): Promise<TreatmentPlan> {
+    return this.post<TreatmentPlan>('/api/treatment-plans', data);
+  }
+
+  async update(id: number, data: TreatmentPlanRequest): Promise<TreatmentPlan> {
+    return this.putWithResponse<TreatmentPlan>(`/api/treatment-plans/${id}`, data);
+  }
+
+  async activate(id: number): Promise<TreatmentPlan> {
+    return this.putWithResponse<TreatmentPlan>(`/api/treatment-plans/${id}/activate`, {});
+  }
+
+  async complete(id: number): Promise<TreatmentPlan> {
+    return this.putWithResponse<TreatmentPlan>(`/api/treatment-plans/${id}/complete`, {});
+  }
+
+  async cancel(id: number): Promise<TreatmentPlan> {
+    return this.putWithResponse<TreatmentPlan>(`/api/treatment-plans/${id}/cancel`, {});
+  }
+}

--- a/app-ui/src/views/AppointmentsView.vue
+++ b/app-ui/src/views/AppointmentsView.vue
@@ -48,7 +48,8 @@
     <BookingFormModal
       :visible="bookingModalVisible"
       :is-walk-in="isWalkIn"
-      @close="bookingModalVisible = false"
+      :pre-select-patient-id="preSelectPatientId"
+      @close="bookingModalVisible = false; preSelectPatientId = 0"
       @saved="onBookingSaved"
     />
 
@@ -63,6 +64,7 @@
 
 <script lang="ts">
 import { defineComponent, ref, onMounted } from 'vue';
+import { useRoute } from 'vue-router';
 import O2MobileNav from '../components/option02/O2MobileNav.vue';
 import O2Sidebar from '../components/option02/O2Sidebar.vue';
 import O2Header from '../components/option02/O2Header.vue';
@@ -77,6 +79,7 @@ export default defineComponent({
   name: 'AppointmentsView',
   components: { O2MobileNav, O2Sidebar, O2Header, O2Footer, AppointmentsList, BookingFormModal, ActionsPanel },
   setup() {
+    const route = useRoute();
     const client = new SessionsHttpClient();
     const appointments = ref<Appointment[]>([]);
     const loading = ref(false);
@@ -86,6 +89,7 @@ export default defineComponent({
 
     const bookingModalVisible = ref(false);
     const isWalkIn = ref(false);
+    const preSelectPatientId = ref(0);
     const actionsPanelVisible = ref(false);
     const selectedAppointment = ref<Appointment | null>(null);
 
@@ -153,11 +157,19 @@ export default defineComponent({
     const onBookingSaved = () => loadAppointments();
     const onStatusUpdated = () => loadAppointments();
 
-    onMounted(loadAppointments);
+    onMounted(async () => {
+      await loadAppointments();
+      // Auto-open booking modal if deep-linked with bookFor param
+      const bookFor = Number(route.query.bookFor);
+      if (bookFor > 0) {
+        preSelectPatientId.value = bookFor;
+        openBooking(false);
+      }
+    });
 
     return {
       appointments, loading, error, activeFilter, selectedDate,
-      bookingModalVisible, isWalkIn, actionsPanelVisible, selectedAppointment,
+      bookingModalVisible, isWalkIn, preSelectPatientId, actionsPanelVisible, selectedAppointment,
       loadAppointments, setToday, openBooking, openActionsPanel,
       handleQuickStatusChange, onBookingSaved, onStatusUpdated,
     };

--- a/app-ui/src/views/PatientsView.vue
+++ b/app-ui/src/views/PatientsView.vue
@@ -22,6 +22,7 @@
           @retry="loadPatients"
           @tab-change="onTabChange"
           @view-caretakers="viewCaretakers"
+          @view-plans="viewPlans"
           @pay-delinquent="onPayDelinquent"
         />
 
@@ -85,7 +86,7 @@
 
 <script lang="ts">
 import { defineComponent, ref, computed, onMounted } from 'vue';
-import { useRoute } from 'vue-router';
+import { useRoute, useRouter } from 'vue-router';
 import O2MobileNav from '../components/option02/O2MobileNav.vue';
 import O2Sidebar from '../components/option02/O2Sidebar.vue';
 import O2Header from '../components/option02/O2Header.vue';
@@ -104,6 +105,7 @@ export default defineComponent({
   components: { O2MobileNav, O2Sidebar, O2Header, O2Footer, PatientList, PatientFormModal, PatientCaretakerPanel, PaymentFormModal },
   setup() {
     const route = useRoute();
+    const router = useRouter();
     const client = new PatientsHttpClient();
 
     const validTabs = ['all', 'active', 'inactive', 'delinquent'] as const;
@@ -226,6 +228,10 @@ export default defineComponent({
       setTimeout(() => { tempMrnBanner.value = ''; }, 8000);
     };
 
+    const viewPlans = (patient: Patient) => {
+      router.push({ path: '/treatment-plans', query: { patientId: String(patient.patientId) } });
+    };
+
     onMounted(loadPatients);
 
     return {
@@ -251,6 +257,7 @@ export default defineComponent({
       preSelectedCaretakerId,
       onPayDelinquent,
       onPaymentSaved,
+      viewPlans,
     };
   },
 });

--- a/app-ui/src/views/TreatmentPlansView.vue
+++ b/app-ui/src/views/TreatmentPlansView.vue
@@ -1,0 +1,220 @@
+<template>
+  <div class="min-h-screen bg-slate-50 font-sans">
+    <O2MobileNav />
+    <div class="flex flex-1">
+      <O2Sidebar />
+      <div class="flex-1 flex flex-col min-h-screen">
+        <O2Header />
+        <main class="flex-1 max-w-7xl mx-auto w-full px-4 sm:px-6 lg:px-8 py-6">
+          <!-- No patientId error -->
+          <div v-if="!patientId" class="bg-red-50 rounded-xl p-6 text-center">
+            <p class="text-sm text-red-700">No patient selected.</p>
+            <router-link to="/patients" class="mt-2 inline-block text-sm font-medium text-red-600 hover:text-red-800">
+              Back to Patients
+            </router-link>
+          </div>
+
+          <template v-else>
+            <!-- Header -->
+            <div class="mb-6">
+              <button @click="router.push('/patients')" class="text-sm text-violet-600 hover:text-violet-700 mb-2 inline-flex items-center">
+                &larr; Back to Patients
+              </button>
+              <h1 class="text-2xl font-bold text-slate-800">Treatment Plans</h1>
+              <p class="text-sm text-slate-500 mt-1">{{ patientName }}</p>
+            </div>
+
+            <!-- Discovery-first guidance -->
+            <div v-if="hasDiscovery === false" class="bg-amber-50 border border-amber-200 rounded-xl p-4 mb-6">
+              <div class="flex items-start">
+                <svg class="w-5 h-5 text-amber-600 mr-3 mt-0.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                <div>
+                  <p class="text-sm text-amber-800 font-medium">This patient needs a discovery session first.</p>
+                  <p class="text-xs text-amber-600 mt-1">Book a discovery session from the
+                    <router-link :to="bookingLink" class="underline hover:text-amber-800">Appointments page</router-link>
+                    before creating a treatment plan.
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            <TreatmentPlanList
+              :plans="plans"
+              :loading="loading"
+              :error="error"
+              :initial-tab="initialTab"
+              :can-create="hasDiscovery !== false"
+              @create="openCreate"
+              @edit="openEdit"
+              @activate="onActivate"
+              @complete="onComplete"
+              @cancel="onCancel"
+            />
+          </template>
+        </main>
+        <O2Footer />
+      </div>
+    </div>
+
+    <TreatmentPlanFormModal
+      :visible="modalVisible"
+      :plan="editingPlan"
+      :patient-id="patientId"
+      :patient-name="patientName"
+      :discovery-session-id="Number(route.query.discoverySessionId) || 0"
+      @close="modalVisible = false"
+      @saved="onSaved"
+    />
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref, computed, onMounted, watch } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+import O2MobileNav from '../components/option02/O2MobileNav.vue';
+import O2Sidebar from '../components/option02/O2Sidebar.vue';
+import O2Header from '../components/option02/O2Header.vue';
+import O2Footer from '../components/option02/O2Footer.vue';
+import TreatmentPlanList from '../components/treatment-plans/TreatmentPlanList.vue';
+import TreatmentPlanFormModal from '../components/treatment-plans/TreatmentPlanFormModal.vue';
+import { PatientsHttpClient } from '../services/PatientsHttpClient';
+import { TreatmentPlansHttpClient } from '../services/TreatmentPlansHttpClient';
+import type { TreatmentPlan } from '../interfaces/TreatmentPlan';
+
+export default defineComponent({
+  name: 'TreatmentPlansView',
+  components: { O2MobileNav, O2Sidebar, O2Header, O2Footer, TreatmentPlanList, TreatmentPlanFormModal },
+  setup() {
+    const route = useRoute();
+    const router = useRouter();
+    const patientsClient = new PatientsHttpClient();
+    const plansClient = new TreatmentPlansHttpClient();
+
+    const patientId = computed(() => {
+      const raw = route.query.patientId;
+      const parsed = Number(raw);
+      return parsed > 0 ? parsed : 0;
+    });
+
+    const initialTab = computed(() => {
+      const tab = route.query.tab as string | undefined;
+      const validTabs = ['All', 'Draft', 'Active', 'Completed', 'Cancelled'];
+      return tab && validTabs.includes(tab) ? tab : 'All';
+    });
+
+    const patientName = ref('');
+    const bookingLink = computed(() => ({
+      path: '/appointments',
+      query: { bookFor: String(patientId.value) },
+    }));
+    const hasDiscovery = ref<boolean | null>(null);
+    const plans = ref<TreatmentPlan[]>([]);
+    const loading = ref(false);
+    const error = ref('');
+    const modalVisible = ref(false);
+    const editingPlan = ref<TreatmentPlan | null>(null);
+
+    const loadPatient = async () => {
+      if (!patientId.value) return;
+      try {
+        const patient = await patientsClient.getPatient(patientId.value);
+        patientName.value = patient.patientName;
+        hasDiscovery.value = patient.hasCompletedDiscovery ?? null;
+      } catch {
+        patientName.value = 'Unknown Patient';
+      }
+    };
+
+    const loadPlans = async () => {
+      if (!patientId.value) return;
+      loading.value = true;
+      error.value = '';
+      try {
+        plans.value = await plansClient.getByPatient(patientId.value);
+      } catch (e: unknown) {
+        error.value = e instanceof Error ? e.message : 'Failed to load treatment plans.';
+      } finally {
+        loading.value = false;
+      }
+    };
+
+    const openCreate = () => {
+      editingPlan.value = null;
+      modalVisible.value = true;
+    };
+
+    const openEdit = (plan: TreatmentPlan) => {
+      editingPlan.value = plan;
+      modalVisible.value = true;
+    };
+
+    const onActivate = async (plan: TreatmentPlan) => {
+      try {
+        await plansClient.activate(plan.id);
+        await loadPlans();
+      } catch (e: unknown) {
+        error.value = e instanceof Error ? e.message : 'Failed to activate plan.';
+      }
+    };
+
+    const onComplete = async (plan: TreatmentPlan) => {
+      try {
+        await plansClient.complete(plan.id);
+        await loadPlans();
+      } catch (e: unknown) {
+        error.value = e instanceof Error ? e.message : 'Failed to complete plan.';
+      }
+    };
+
+    const onCancel = async (plan: TreatmentPlan) => {
+      try {
+        await plansClient.cancel(plan.id);
+        await loadPlans();
+      } catch (e: unknown) {
+        error.value = e instanceof Error ? e.message : 'Failed to cancel plan.';
+      }
+    };
+
+    const onSaved = () => {
+      loadPlans();
+    };
+
+    onMounted(async () => {
+      await Promise.all([loadPatient(), loadPlans()]);
+      // Auto-open create form if query param is set
+      if (route.query.create === 'true') {
+        openCreate();
+      }
+    });
+
+    // Re-load if patientId changes (query param navigation)
+    watch(patientId, () => {
+      loadPatient();
+      loadPlans();
+    });
+
+    return {
+      route,
+      router,
+      patientId,
+      patientName,
+      hasDiscovery,
+      bookingLink,
+      plans,
+      loading,
+      error,
+      modalVisible,
+      editingPlan,
+      initialTab,
+      openCreate,
+      openEdit,
+      onActivate,
+      onComplete,
+      onCancel,
+      onSaved,
+    };
+  },
+});
+</script>


### PR DESCRIPTION
New Treatment Plans page with tabbed status filtering, plan cards, and form modal with dynamic lines editor. BookingFormModal shows discovery-first banner and filters specialties + therapists when patient needs discovery. ActionsPanel shows discovery badge and create-plan button for completed discovery sessions. Plans icon added to Patient table and Caretaker patient list. Deep-link booking with patient pre-selection from discovery banner. Sidebar renamed Schedule to Appts. Create Plan button disabled when no discovery session exists.