### PR TITLE
WP-10D-C: Treatment plan UX enhancements + ProviderAmount on dashboard

### DIFF
--- a/app-ui/src/components/appointments/AppointmentList.vue
+++ b/app-ui/src/components/appointments/AppointmentList.vue
@@ -8,6 +8,7 @@
           <th>Patient</th>
           <th>Therapy</th>
           <th>Therapist</th>
+          <th>Provider</th>
           <th>Notes</th>
           <th>Paid Off?</th>
           <th>Past Due?</th>
@@ -19,6 +20,7 @@
           <td>{{ appointment.patient }}</td>
           <td>{{ appointment.therapyTypes }}</td>
           <td>{{ appointment.therapist }}</td>
+          <td>${{ appointment.providerAmount.toFixed(2) }}</td>
           <td>{{ appointment.notes }}</td>
           <td>
             <font-awesome-icon 

--- a/app-ui/src/components/option02/O2Appointments.vue
+++ b/app-ui/src/components/option02/O2Appointments.vue
@@ -61,6 +61,8 @@
             <p class="md:hidden text-[10px] mt-0.5 truncate">
               <span class="text-gray-500">{{ formatCurrency(appt.amount) }} billed</span>
               <span class="text-gray-300"> &middot; </span>
+              <span class="text-violet-600">{{ formatCurrency(appt.providerAmount) }} provider</span>
+              <span class="text-gray-300"> &middot; </span>
               <span v-if="appt.isPastDue" class="text-red-600 font-medium">{{ formatCurrency(appt.amountDue) }} due</span>
               <span v-else class="text-green-600 font-medium">{{ formatCurrency(appt.amountPaid) }} paid</span>
             </p>
@@ -71,6 +73,10 @@
             <div class="w-16 text-right">
               <p class="text-xs font-medium text-gray-600">{{ formatCurrency(appt.amount) }}</p>
               <p class="text-[10px] text-gray-400">Billed</p>
+            </div>
+            <div class="w-16 text-right">
+              <p class="text-xs font-medium text-violet-600">{{ formatCurrency(appt.providerAmount) }}</p>
+              <p class="text-[10px] text-gray-400">Provider</p>
             </div>
             <div class="w-16 text-right">
               <p class="text-xs font-medium text-gray-600">-{{ formatCurrency(appt.discount) }}</p>

--- a/app-ui/src/components/option02/O2StatsBar.vue
+++ b/app-ui/src/components/option02/O2StatsBar.vue
@@ -84,6 +84,10 @@
               <span class="text-green-700 font-bold">{{ formatCurrency(settledFinancials.totalPaid) }}</span>
             </div>
           </div>
+          <p v-if="settledFinancials.totalProvider > 0" class="mt-2 text-[10px] text-gray-400 italic">
+            Includes {{ formatCurrency(settledFinancials.totalProvider) }} provider fees
+            ({{ settledFinancials.providerPercent }}% of collected)
+          </p>
         </div>
 
         <!-- Past Due Column -->
@@ -113,6 +117,10 @@
               <span class="text-red-700 font-bold">{{ formatCurrency(pastDueFinancials.totalDue) }}</span>
             </div>
           </div>
+          <p v-if="pastDueFinancials.totalProvider > 0" class="mt-2 text-[10px] text-gray-400 italic">
+            Includes {{ formatCurrency(pastDueFinancials.totalProvider) }} provider fees
+            ({{ pastDueFinancials.providerPercent }}% of outstanding)
+          </p>
         </div>
       </div>
     </div>
@@ -189,23 +197,31 @@ export default defineComponent({
 
     const pastDueFinancials = computed(() => {
       const pastDue = props.appointments.filter((a) => a.isPastDue);
+      const totalDue = pastDue.reduce((sum, a) => sum + a.amountDue, 0);
+      const totalProvider = pastDue.reduce((sum, a) => sum + a.providerAmount, 0);
       return {
         count: pastDue.length,
         totalAmount: pastDue.reduce((sum, a) => sum + a.amount, 0),
         totalDiscount: pastDue.reduce((sum, a) => sum + a.discount, 0),
         totalPaid: pastDue.reduce((sum, a) => sum + a.amountPaid, 0),
-        totalDue: pastDue.reduce((sum, a) => sum + a.amountDue, 0),
+        totalDue,
+        totalProvider,
+        providerPercent: totalDue > 0 ? Math.round((totalProvider / totalDue) * 100) : 0,
       };
     });
 
     const settledFinancials = computed(() => {
       const settled = props.appointments.filter((a) => a.isPaidOff);
+      const totalPaid = settled.reduce((sum, a) => sum + a.amountPaid, 0);
+      const totalProvider = settled.reduce((sum, a) => sum + a.providerAmount, 0);
       return {
         count: settled.length,
         totalAmount: settled.reduce((sum, a) => sum + a.amount, 0),
         totalDiscount: settled.reduce((sum, a) => sum + a.discount, 0),
-        totalPaid: settled.reduce((sum, a) => sum + a.amountPaid, 0),
+        totalPaid,
         totalDue: settled.reduce((sum, a) => sum + a.amountDue, 0),
+        totalProvider,
+        providerPercent: totalPaid > 0 ? Math.round((totalProvider / totalPaid) * 100) : 0,
       };
     });
 

--- a/app-ui/src/components/treatment-plans/TreatmentPlanFormModal.vue
+++ b/app-ui/src/components/treatment-plans/TreatmentPlanFormModal.vue
@@ -34,19 +34,22 @@
                 &mdash; {{ plan.discoverySpecialty }}, {{ formatDate(plan.discoveryDate) }}
               </p>
             </div>
-            <div v-else-if="discoverySessionId > 0">
-              <p class="text-sm text-slate-600">Discovery Session #{{ discoverySessionId }}</p>
-            </div>
             <div v-else>
-              <label class="block text-sm font-medium text-slate-700 mb-1">Discovery Session ID</label>
-              <input
+              <label class="block text-sm font-medium text-slate-700 mb-1">Discovery Session</label>
+              <div v-if="discoverySessionsLoading" class="text-sm text-slate-400">Loading discovery sessions...</div>
+              <div v-else-if="discoverySessions.length === 0" class="text-sm text-amber-600">
+                No completed discovery sessions found for this patient.
+              </div>
+              <select
+                v-else
                 v-model.number="form.discoverySessionId"
-                type="number"
-                min="1"
-                placeholder="Enter the ID of a completed discovery session"
                 class="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-violet-500 focus:border-transparent"
-              />
-              <p class="mt-1 text-xs text-slate-400">Enter the ID of a completed discovery session</p>
+              >
+                <option :value="0" disabled>Select a discovery session...</option>
+                <option v-for="ds in discoverySessions" :key="ds.sessionId" :value="ds.sessionId">
+                  #{{ ds.sessionId }} &mdash; {{ ds.specialtyAbbreviation }} on {{ formatDate(ds.sessionDate) }} with {{ ds.therapistName }}
+                </option>
+              </select>
             </div>
           </div>
 
@@ -202,6 +205,12 @@
 
         <!-- Footer -->
         <div class="px-6 py-4 border-t border-slate-200 space-y-3">
+          <div v-if="lineCountMismatch" class="bg-amber-50 border border-amber-200 rounded-lg p-3">
+            <p class="text-sm text-amber-700">
+              Line count ({{ lines.length }}) does not match sessions per week ({{ form.weeklyFrequency }}).
+              Plan will stay in Draft until this is resolved.
+            </p>
+          </div>
           <div v-if="saveError" class="bg-red-50 border border-red-200 rounded-lg p-3">
             <p class="text-sm text-red-700">{{ saveError }}</p>
           </div>
@@ -215,10 +224,11 @@
             <button
               v-if="isEditing && plan && plan.planStatus === 'Draft'"
               @click="handleActivate"
-              :disabled="saving"
+              :disabled="saving || lineCountMismatch"
+              :title="lineCountMismatch ? 'Line count must match sessions per week before activating' : ''"
               :class="[
                 'px-4 py-2 text-sm font-medium rounded-lg transition-colors',
-                saving
+                saving || lineCountMismatch
                   ? 'bg-emerald-300 text-white cursor-not-allowed'
                   : 'bg-emerald-600 text-white hover:bg-emerald-700',
               ]"
@@ -246,11 +256,12 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, watch, type PropType } from 'vue';
+import { defineComponent, ref, computed, watch, type PropType } from 'vue';
 import { TreatmentPlansHttpClient } from '../../services/TreatmentPlansHttpClient';
 import { LookupHttpClient } from '../../services/LookupHttpClient';
 import { TherapistsHttpClient } from '../../services/TherapistsHttpClient';
-import type { TreatmentPlan, TreatmentPlanRequest, TreatmentPlanLineRequest } from '../../interfaces/TreatmentPlan';
+import { SessionsHttpClient } from '../../services/SessionsHttpClient';
+import type { TreatmentPlan, TreatmentPlanRequest, TreatmentPlanLineRequest, DiscoverySessionSummary } from '../../interfaces/TreatmentPlan';
 import { DAY_OF_WEEK_LABELS, isDiscoverySpecialty, planStatusBadgeClass } from '../../interfaces/TreatmentPlan';
 import type { LookupItem } from '../../interfaces/Lookups';
 import type { Therapist } from '../../interfaces/Therapist';
@@ -277,9 +288,12 @@ export default defineComponent({
     const plansClient = new TreatmentPlansHttpClient();
     const lookupClient = new LookupHttpClient();
     const therapistsClient = new TherapistsHttpClient();
+    const sessionsClient = new SessionsHttpClient();
 
     const specialtyTypes = ref<LookupItem[]>([]);
     const therapists = ref<Therapist[]>([]);
+    const discoverySessions = ref<DiscoverySessionSummary[]>([]);
+    const discoverySessionsLoading = ref(false);
     const saving = ref(false);
     const saveError = ref('');
 
@@ -296,6 +310,26 @@ export default defineComponent({
     const lines = ref<FormLine[]>([]);
 
     const treatmentSpecialties = ref<LookupItem[]>([]);
+
+    const lineCountMismatch = computed(() => {
+      return lines.value.length !== form.value.weeklyFrequency;
+    });
+
+    const loadDiscoverySessions = async () => {
+      if (props.patientId <= 0) return;
+      discoverySessionsLoading.value = true;
+      try {
+        discoverySessions.value = await sessionsClient.getDiscoverySessions(props.patientId);
+        // Auto-select if exactly one discovery session and none is pre-selected
+        if (discoverySessions.value.length === 1 && form.value.discoverySessionId === 0) {
+          form.value.discoverySessionId = discoverySessions.value[0].sessionId;
+        }
+      } catch {
+        discoverySessions.value = [];
+      } finally {
+        discoverySessionsLoading.value = false;
+      }
+    };
 
     const emptyLine = (): FormLine => ({
       specialtyTypeId: 0,
@@ -367,6 +401,7 @@ export default defineComponent({
           populateFromPlan(props.plan);
         } else {
           resetForm();
+          loadDiscoverySessions();
         }
       }
     });
@@ -453,6 +488,9 @@ export default defineComponent({
       isEditing,
       saving,
       saveError,
+      discoverySessions,
+      discoverySessionsLoading,
+      lineCountMismatch,
       treatmentSpecialties,
       therapistsForLine,
       DAY_OF_WEEK_LABELS,

--- a/app-ui/src/components/treatment-plans/TreatmentPlanList.vue
+++ b/app-ui/src/components/treatment-plans/TreatmentPlanList.vue
@@ -120,6 +120,9 @@
           <div class="text-sm text-slate-600">
             <span class="text-slate-400">Lines:</span>
             {{ plan.lines.length }} treatment line{{ plan.lines.length !== 1 ? 's' : '' }}
+            <span v-if="hasLineCountMismatch(plan)" class="text-amber-600 text-xs ml-1" :title="`Expected ${plan.weeklyFrequency} line(s) to match sessions per week`">
+              (mismatch)
+            </span>
           </div>
         </div>
 
@@ -144,7 +147,14 @@
           </button>
           <button
             v-if="plan.planStatus === 'Draft'"
-            class="px-3 py-1.5 rounded-lg text-xs font-medium text-white bg-emerald-600 hover:bg-emerald-700 transition-colors"
+            :disabled="hasLineCountMismatch(plan)"
+            :title="hasLineCountMismatch(plan) ? `Line count (${plan.lines.length}) must match sessions per week (${plan.weeklyFrequency})` : ''"
+            :class="[
+              'px-3 py-1.5 rounded-lg text-xs font-medium transition-colors',
+              hasLineCountMismatch(plan)
+                ? 'text-white bg-emerald-300 cursor-not-allowed'
+                : 'text-white bg-emerald-600 hover:bg-emerald-700',
+            ]"
             @click="$emit('activate', plan)"
           >
             <svg class="w-3.5 h-3.5 inline mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -206,6 +216,10 @@ export default defineComponent({
       return props.plans.filter(p => p.planStatus === activeTab.value as PlanStatus);
     });
 
+    const hasLineCountMismatch = (plan: TreatmentPlan) => {
+      return plan.lines.length !== plan.weeklyFrequency;
+    };
+
     const formatDate = (dateStr: string) => {
       if (!dateStr) return '';
       const d = new Date(dateStr);
@@ -219,6 +233,7 @@ export default defineComponent({
       activeCount,
       completedCount,
       filteredPlans,
+      hasLineCountMismatch,
       planStatusBadgeClass,
       formatDate,
     };

--- a/app-ui/src/interfaces/Appointment.ts
+++ b/app-ui/src/interfaces/Appointment.ts
@@ -25,6 +25,7 @@ export interface Appointment {
     specialtyAbbreviation: string | null;
     specialtyName: string | null;
     isDiscovery: boolean | null;
+    providerAmount: number;
 }
 
 export interface AppointmentStatusInfo {

--- a/app-ui/src/interfaces/TreatmentPlan.ts
+++ b/app-ui/src/interfaces/TreatmentPlan.ts
@@ -55,6 +55,13 @@ export interface TreatmentPlanRequest {
   lines: TreatmentPlanLineRequest[];
 }
 
+export interface DiscoverySessionSummary {
+  sessionId: number;
+  sessionDate: string;
+  specialtyAbbreviation: string;
+  therapistName: string;
+}
+
 export const DAY_OF_WEEK_LABELS: Record<number, string> = {
   1: 'Monday',
   2: 'Tuesday',

--- a/app-ui/src/services/SessionsHttpClient.ts
+++ b/app-ui/src/services/SessionsHttpClient.ts
@@ -1,6 +1,7 @@
 // services/SessionsHttpClient.ts
 import { HttpClientBase } from './HttpClientBase';
 import type { Appointment, AppointmentStatusInfo, SessionEventRequest, ConfirmationRequest, ConfirmationRecord } from '../interfaces/Appointment';
+import type { DiscoverySessionSummary } from '../interfaces/TreatmentPlan';
 
 export class SessionsHttpClient extends HttpClientBase {
   async getSessions(date: string): Promise<Appointment[]> {
@@ -64,6 +65,10 @@ export class SessionsHttpClient extends HttpClientBase {
     if (params?.days !== undefined) query.set('days', params.days.toString());
     const qs = query.toString();
     return this.get<Appointment[]>(`/api/Sessions/upcoming${qs ? '?' + qs : ''}`);
+  }
+
+  async getDiscoverySessions(patientId: number): Promise<DiscoverySessionSummary[]> {
+    return this.get<DiscoverySessionSummary[]>(`/api/Sessions/patient/${patientId}/discovery`);
   }
 
   async getConfirmations(id: number): Promise<ConfirmationRecord[]> {

--- a/app-ui/src/views/TreatmentPlansView.vue
+++ b/app-ui/src/views/TreatmentPlansView.vue
@@ -40,6 +40,30 @@
               </div>
             </div>
 
+            <!-- Discovery Sessions Summary -->
+            <div v-if="discoverySessions.length > 0" class="bg-white border border-slate-200 rounded-xl p-4 mb-6">
+              <h3 class="text-sm font-semibold text-slate-700 mb-3 flex items-center">
+                <svg class="w-4 h-4 mr-2 text-violet-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
+                </svg>
+                Discovery Sessions
+              </h3>
+              <div class="space-y-2">
+                <div
+                  v-for="ds in discoverySessions"
+                  :key="ds.sessionId"
+                  class="flex items-center justify-between bg-slate-50 rounded-lg px-3 py-2"
+                >
+                  <div class="flex items-center space-x-3 text-sm">
+                    <span class="font-medium text-slate-700">#{{ ds.sessionId }}</span>
+                    <span class="text-violet-600 font-medium">{{ ds.specialtyAbbreviation }}</span>
+                    <span class="text-slate-500">{{ formatDiscoveryDate(ds.sessionDate) }}</span>
+                    <span class="text-slate-500">with {{ ds.therapistName }}</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+
             <TreatmentPlanList
               :plans="plans"
               :loading="loading"
@@ -81,7 +105,8 @@ import TreatmentPlanList from '../components/treatment-plans/TreatmentPlanList.v
 import TreatmentPlanFormModal from '../components/treatment-plans/TreatmentPlanFormModal.vue';
 import { PatientsHttpClient } from '../services/PatientsHttpClient';
 import { TreatmentPlansHttpClient } from '../services/TreatmentPlansHttpClient';
-import type { TreatmentPlan } from '../interfaces/TreatmentPlan';
+import { SessionsHttpClient } from '../services/SessionsHttpClient';
+import type { TreatmentPlan, DiscoverySessionSummary } from '../interfaces/TreatmentPlan';
 
 export default defineComponent({
   name: 'TreatmentPlansView',
@@ -91,6 +116,7 @@ export default defineComponent({
     const router = useRouter();
     const patientsClient = new PatientsHttpClient();
     const plansClient = new TreatmentPlansHttpClient();
+    const sessionsClient = new SessionsHttpClient();
 
     const patientId = computed(() => {
       const raw = route.query.patientId;
@@ -111,6 +137,7 @@ export default defineComponent({
     }));
     const hasDiscovery = ref<boolean | null>(null);
     const plans = ref<TreatmentPlan[]>([]);
+    const discoverySessions = ref<DiscoverySessionSummary[]>([]);
     const loading = ref(false);
     const error = ref('');
     const modalVisible = ref(false);
@@ -138,6 +165,21 @@ export default defineComponent({
       } finally {
         loading.value = false;
       }
+    };
+
+    const loadDiscoverySessions = async () => {
+      if (!patientId.value) return;
+      try {
+        discoverySessions.value = await sessionsClient.getDiscoverySessions(patientId.value);
+      } catch {
+        discoverySessions.value = [];
+      }
+    };
+
+    const formatDiscoveryDate = (dateStr: string) => {
+      if (!dateStr) return '';
+      const d = new Date(dateStr);
+      return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
     };
 
     const openCreate = () => {
@@ -182,7 +224,7 @@ export default defineComponent({
     };
 
     onMounted(async () => {
-      await Promise.all([loadPatient(), loadPlans()]);
+      await Promise.all([loadPatient(), loadPlans(), loadDiscoverySessions()]);
       // Auto-open create form if query param is set
       if (route.query.create === 'true') {
         openCreate();
@@ -193,6 +235,7 @@ export default defineComponent({
     watch(patientId, () => {
       loadPatient();
       loadPlans();
+      loadDiscoverySessions();
     });
 
     return {
@@ -202,12 +245,14 @@ export default defineComponent({
       patientName,
       hasDiscovery,
       bookingLink,
+      discoverySessions,
       plans,
       loading,
       error,
       modalVisible,
       editingPlan,
       initialTab,
+      formatDiscoveryDate,
       openCreate,
       openEdit,
       onActivate,


### PR DESCRIPTION
- Replace manual discovery session ID input with auto-select dropdown
- Add discovery sessions summary section on Treatment Plans page
- Show warning when line count != weekly frequency, disable Activate
- Add Provider column to appointment list (O2 + original)
- Add provider fee footnotes to Daily Financial Summary panels