### PR TITLE
Fix WP-11 bugs + UX enhancements from testing

### DIFF
--- a/app-ui/src/components/appointments/BookingFormModal.vue
+++ b/app-ui/src/components/appointments/BookingFormModal.vue
@@ -63,7 +63,7 @@
             </div>
             <div>
               <label class="block text-sm font-medium text-slate-700 mb-1">Time</label>
-              <input v-model="form.sessionTime" type="time" class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:ring-2 focus:ring-violet-500 focus:border-violet-500" />
+              <input v-model="form.sessionTime" type="time" :min="timeMin" :max="timeMax" :step="timeStep" class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:ring-2 focus:ring-violet-500 focus:border-violet-500" />
             </div>
           </div>
 
@@ -147,6 +147,7 @@ import type { Patient } from '../../interfaces/Patient';
 import type { Therapist } from '../../interfaces/Therapist';
 import type { LookupItem } from '../../interfaces/Lookups';
 import { isDiscoverySpecialty } from '../../interfaces/TreatmentPlan';
+import { TIME_MIN, TIME_MAX, TIME_STEP } from '../../utils/timeSlots';
 
 export default defineComponent({
   name: 'BookingFormModal',
@@ -324,7 +325,7 @@ export default defineComponent({
       }
     };
 
-    return { form, patients, filteredTherapists, filteredSpecialties, saving, saveError, caretakerWarning, needsDiscovery, isValid, handleSubmit };
+    return { form, patients, filteredTherapists, filteredSpecialties, saving, saveError, caretakerWarning, needsDiscovery, isValid, handleSubmit, timeMin: TIME_MIN, timeMax: TIME_MAX, timeStep: TIME_STEP };
   },
 });
 </script>

--- a/app-ui/src/components/appointments/TherapistReassignModal.vue
+++ b/app-ui/src/components/appointments/TherapistReassignModal.vue
@@ -1,0 +1,169 @@
+<template>
+  <teleport to="body">
+    <div v-if="visible" class="fixed inset-0 z-50 flex items-center justify-center">
+      <div class="absolute inset-0 bg-black/30" @click="$emit('close')"></div>
+      <div class="relative bg-white rounded-xl shadow-xl w-full max-w-md mx-4">
+        <!-- Header -->
+        <div class="px-5 py-4 border-b border-slate-200">
+          <h3 class="text-sm font-semibold text-slate-800">Reassign Therapist</h3>
+          <p class="text-xs text-slate-500 mt-0.5">
+            {{ session?.patient }} &middot; {{ session?.specialtyAbbreviation || session?.therapyTypes }}
+          </p>
+        </div>
+
+        <!-- Body -->
+        <div class="px-5 py-4 space-y-3">
+          <div>
+            <label class="block text-xs font-medium text-slate-500 mb-1">Current Therapist</label>
+            <p class="text-sm text-slate-700">{{ session?.therapist }}</p>
+          </div>
+          <div>
+            <label class="block text-xs font-medium text-slate-500 mb-1">New Therapist</label>
+            <select
+              v-model.number="selectedTherapistId"
+              class="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-violet-500 focus:border-transparent"
+            >
+              <option :value="0" disabled>Select a therapist...</option>
+              <option
+                v-for="t in eligibleTherapists"
+                :key="t.therapistId"
+                :value="t.therapistId"
+                :disabled="t.therapistId === session?.therapistId"
+              >
+                {{ t.therapistName }}{{ t.therapistId === session?.therapistId ? ' (current)' : '' }}
+              </option>
+            </select>
+            <p v-if="eligibleTherapists.length === 0 && !loading" class="text-xs text-amber-600 mt-1">
+              No therapists found with the required specialty.
+            </p>
+          </div>
+        </div>
+
+        <!-- Footer -->
+        <div class="px-5 py-3 border-t border-slate-200 flex justify-end space-x-2">
+          <button
+            @click="$emit('close')"
+            class="px-4 py-2 rounded-lg text-sm font-medium text-slate-600 hover:bg-slate-100 transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            :disabled="!canSave || saving"
+            :class="[
+              'px-4 py-2 rounded-lg text-sm font-medium transition-colors',
+              canSave && !saving
+                ? 'text-white bg-violet-600 hover:bg-violet-700'
+                : 'text-white bg-violet-300 cursor-not-allowed',
+            ]"
+            @click="handleSave"
+          >
+            {{ saving ? 'Saving...' : 'Reassign' }}
+          </button>
+        </div>
+
+        <!-- Error -->
+        <div v-if="errorMsg" class="px-5 py-2 bg-red-50 border-t border-red-200">
+          <p class="text-xs text-red-700">{{ errorMsg }}</p>
+        </div>
+      </div>
+    </div>
+  </teleport>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref, computed, watch, type PropType } from 'vue';
+import type { Appointment } from '../../interfaces/Appointment';
+import type { Therapist } from '../../interfaces/Therapist';
+import { TherapistsHttpClient } from '../../services/TherapistsHttpClient';
+import { SessionsHttpClient } from '../../services/SessionsHttpClient';
+
+export default defineComponent({
+  name: 'TherapistReassignModal',
+  props: {
+    visible: { type: Boolean, default: false },
+    session: { type: Object as PropType<Appointment | null>, default: null },
+  },
+  emits: ['close', 'saved'],
+  setup(props, { emit }) {
+    const therapistsClient = new TherapistsHttpClient();
+    const sessionsClient = new SessionsHttpClient();
+
+    const allTherapists = ref<Therapist[]>([]);
+    const selectedTherapistId = ref(0);
+    const saving = ref(false);
+    const errorMsg = ref('');
+    const loading = ref(false);
+
+    const eligibleTherapists = computed(() => {
+      const specId = props.session?.specialtyTypeId;
+      if (!specId) return allTherapists.value;
+      return allTherapists.value.filter(t =>
+        t.specialties?.some(s => s.specialtyId === specId)
+      );
+    });
+
+    const canSave = computed(() =>
+      selectedTherapistId.value > 0 &&
+      selectedTherapistId.value !== props.session?.therapistId
+    );
+
+    const loadTherapists = async () => {
+      loading.value = true;
+      try {
+        allTherapists.value = await therapistsClient.getTherapists();
+      } catch {
+        // Non-fatal
+      } finally {
+        loading.value = false;
+      }
+    };
+
+    const handleSave = async () => {
+      if (!props.session || !canSave.value) return;
+      saving.value = true;
+      errorMsg.value = '';
+      try {
+        await sessionsClient.updateSession(props.session.sessionId, {
+          therapistId: selectedTherapistId.value,
+          sessionTime: props.session.sessionTime,
+          therapyType: props.session.therapyTypes || 'N/A',
+          duration: 60,
+          amount: props.session.amount,
+          amountPaid: props.session.amountPaid,
+          discount: props.session.discount,
+          providerAmount: props.session.providerAmount,
+          isPaidOff: props.session.isPaidOff,
+          notes: props.session.notes || '',
+          appointmentStatusId: props.session.appointmentStatusId,
+          siteId: props.session.siteId,
+          specialtyTypeId: props.session.specialtyTypeId,
+        });
+        emit('saved');
+        emit('close');
+      } catch (e: unknown) {
+        errorMsg.value = e instanceof Error ? e.message : 'Failed to reassign therapist.';
+      } finally {
+        saving.value = false;
+      }
+    };
+
+    watch(() => props.visible, (val) => {
+      if (val) {
+        selectedTherapistId.value = 0;
+        errorMsg.value = '';
+        loadTherapists();
+      }
+    });
+
+    return {
+      eligibleTherapists,
+      selectedTherapistId,
+      canSave,
+      saving,
+      errorMsg,
+      loading,
+      handleSave,
+    };
+  },
+});
+</script>

--- a/app-ui/src/components/option02/O2Appointments.vue
+++ b/app-ui/src/components/option02/O2Appointments.vue
@@ -104,6 +104,15 @@
             </div>
           </div>
 
+          <!-- Reassign therapist -->
+          <button
+            class="flex-shrink-0 p-1.5 rounded-lg text-slate-400 hover:text-violet-600 hover:bg-violet-50 transition-colors"
+            title="Reassign therapist"
+            @click.stop="$emit('reassign', appt)"
+          >
+            <font-awesome-icon :icon="['fas', 'user-md']" class="text-xs" />
+          </button>
+
           <!-- Status badge (clickable) -->
           <div class="flex-shrink-0 flex items-center gap-1">
             <button
@@ -167,9 +176,10 @@ import {
   faExclamationCircle,
   faCalendarDay,
   faCreditCard,
+  faUserMd,
 } from '@fortawesome/free-solid-svg-icons';
 
-library.add(faList, faStickyNote, faCheckCircle, faExclamationCircle, faCalendarDay, faCreditCard);
+library.add(faList, faStickyNote, faCheckCircle, faExclamationCircle, faCalendarDay, faCreditCard, faUserMd);
 
 export default defineComponent({
   name: 'O2Appointments',
@@ -188,7 +198,7 @@ export default defineComponent({
       default: 0,
     },
   },
-  emits: ['appointments-loaded', 'view-payments', 'pay'],
+  emits: ['appointments-loaded', 'view-payments', 'pay', 'reassign'],
   setup(props, { emit }) {
     const sessionsHttpClient = new SessionsHttpClient();
     const allAppointments = ref<Appointment[]>([]);

--- a/app-ui/src/components/treatment-plans/PlanProgressCard.vue
+++ b/app-ui/src/components/treatment-plans/PlanProgressCard.vue
@@ -28,19 +28,20 @@
         {{ expanded ? 'Hide' : 'Show' }} {{ progress.sessionsCreated }} session{{ progress.sessionsCreated !== 1 ? 's' : '' }}
       </button>
       <div v-if="expanded" class="mt-2 space-y-1 max-h-48 overflow-y-auto">
-        <div
+        <router-link
           v-for="s in progress.sessions"
           :key="s.sessionId"
-          class="flex items-center justify-between text-xs bg-slate-50 rounded px-2 py-1"
+          :to="{ path: '/', query: { date: s.sessionDate, highlightSession: s.sessionId } }"
+          class="flex items-center justify-between text-xs bg-slate-50 rounded px-2 py-1 hover:bg-violet-50 cursor-pointer transition-colors"
         >
           <div class="flex items-center space-x-2">
             <span class="text-slate-600">{{ formatDate(s.sessionDate) }}</span>
-            <span class="text-slate-400">{{ s.sessionTime }}</span>
+            <span class="text-slate-400">{{ s.sessionTime?.replace(/:00$/, '') }}</span>
             <span class="font-medium text-violet-600">{{ s.specialtyAbbreviation }}</span>
             <span class="text-slate-500">{{ s.therapistName }}</span>
           </div>
           <span :class="statusBadgeClass(s.appointmentStatusId)">{{ s.statusName }}</span>
-        </div>
+        </router-link>
       </div>
     </div>
   </div>

--- a/app-ui/src/components/treatment-plans/SchedulePlanWizard.vue
+++ b/app-ui/src/components/treatment-plans/SchedulePlanWizard.vue
@@ -25,7 +25,7 @@
           <div v-if="step === 1" class="space-y-6">
             <div class="bg-slate-50 rounded-lg p-4">
               <p class="text-sm text-slate-600 mb-1">
-                Plan #{{ plan?.id }} &middot; {{ plan?.patientName }}
+                {{ plan?.displayTitle }} &middot; {{ plan?.patientName }}
               </p>
               <p class="text-sm text-slate-500">
                 {{ plan?.weeklyFrequency }}x/week &middot; {{ plan?.durationWeeks }} weeks &middot; {{ plan?.lines.length }} line(s)
@@ -100,6 +100,9 @@
                   <input
                     type="time"
                     v-model="line.time"
+                    :min="timeMin"
+                    :max="timeMax"
+                    :step="timeStep"
                     class="w-full px-2 py-1.5 border border-slate-200 rounded-lg text-sm"
                   />
                 </div>
@@ -147,15 +150,20 @@
             <!-- Summary banner -->
             <div :class="[
               'rounded-xl p-4',
-              result && result.conflicts.length > 0
+              hasConflicts
                 ? 'bg-amber-50 border border-amber-200'
                 : 'bg-emerald-50 border border-emerald-200',
             ]">
-              <p class="text-sm font-semibold" :class="result && result.conflicts.length > 0 ? 'text-amber-800' : 'text-emerald-800'">
-                {{ result?.sessionsCreated }} session{{ result?.sessionsCreated !== 1 ? 's' : '' }} created
-                <template v-if="result && result.conflicts.length > 0">
-                  &middot; {{ result.conflicts.length }} conflict{{ result.conflicts.length !== 1 ? 's' : '' }}
+              <p class="text-sm font-semibold" :class="hasConflicts ? 'text-amber-800' : 'text-emerald-800'">
+                <template v-if="hasConflicts">
+                  {{ result?.conflicts.length }} conflict{{ result?.conflicts.length !== 1 ? 's' : '' }} found &mdash; no sessions were created
                 </template>
+                <template v-else>
+                  {{ result?.sessionsCreated }} session{{ result?.sessionsCreated !== 1 ? 's' : '' }} created
+                </template>
+              </p>
+              <p v-if="hasConflicts" class="text-xs text-amber-700 mt-1">
+                Select alternatives below, or go back to adjust your schedule.
               </p>
             </div>
 
@@ -187,28 +195,37 @@
               </div>
             </div>
 
-            <!-- Conflicts -->
-            <div v-if="result && result.conflicts.length > 0">
+            <!-- Conflicts with selectable alternatives -->
+            <div v-if="hasConflicts">
               <h3 class="text-sm font-semibold text-amber-700 mb-2">Conflicts</h3>
-              <div class="space-y-2">
+              <div class="space-y-3">
                 <div
-                  v-for="(conflict, ci) in result.conflicts"
+                  v-for="(conflict, ci) in result!.conflicts"
                   :key="ci"
                   class="bg-amber-50 rounded-lg px-3 py-2"
                 >
                   <p class="text-sm text-amber-800">
                     Week {{ conflict.weekNumber }} &middot; {{ formatDate(conflict.date) }}: {{ conflict.reason }}
                   </p>
-                  <div v-if="conflict.suggestedAlternatives.length > 0" class="mt-1 ml-4 space-y-1">
-                    <p v-for="(alt, ai) in conflict.suggestedAlternatives" :key="ai" class="text-xs text-amber-600">
-                      <template v-if="alt.type === 'different-therapist'">
-                        Try {{ alt.therapistName }} at {{ alt.time }}
-                      </template>
-                      <template v-else>
-                        Try {{ alt.therapistName }} at {{ alt.time }}
-                      </template>
-                    </p>
+                  <div v-if="conflict.suggestedAlternatives.length > 0" class="mt-2 ml-4 space-y-1.5">
+                    <label
+                      v-for="(alt, ai) in conflict.suggestedAlternatives"
+                      :key="ai"
+                      class="flex items-center gap-2 cursor-pointer text-xs group"
+                    >
+                      <input
+                        type="checkbox"
+                        :checked="isAlternativeSelected(ci, ai)"
+                        @change="toggleAlternative(ci, ai, conflict.lineId, alt)"
+                        class="rounded border-amber-300 text-violet-600 focus:ring-violet-500"
+                      />
+                      <span :class="isAlternativeSelected(ci, ai) ? 'text-violet-700 font-medium' : 'text-amber-600 group-hover:text-amber-800'">
+                        {{ alt.therapistName }} at {{ alt.time }}
+                        <span class="text-amber-400 ml-1">({{ alt.type === 'different-therapist' ? 'diff. therapist' : 'diff. time' }})</span>
+                      </span>
+                    </label>
                   </div>
+                  <p v-else class="text-xs text-amber-500 mt-1 ml-4">No alternatives available — go back to adjust manually.</p>
                 </div>
               </div>
             </div>
@@ -219,8 +236,8 @@
         <div class="px-6 py-4 border-t border-slate-200 flex items-center justify-between">
           <div>
             <button
-              v-if="step > 1 && step < 3"
-              @click="step--"
+              v-if="step === 2 || (step === 3 && hasConflicts)"
+              @click="goBack"
               class="px-4 py-2 rounded-lg text-sm font-medium text-slate-600 hover:bg-slate-100 transition-colors"
             >
               Back
@@ -231,7 +248,7 @@
               @click="handleClose"
               class="px-4 py-2 rounded-lg text-sm font-medium text-slate-600 hover:bg-slate-100 transition-colors"
             >
-              {{ step === 3 ? 'Close' : 'Cancel' }}
+              {{ step === 3 && !hasConflicts ? 'Close' : 'Cancel' }}
             </button>
             <button
               v-if="step === 1"
@@ -254,6 +271,13 @@
             >
               {{ submitting ? 'Scheduling...' : 'Schedule Sessions' }}
             </button>
+            <button
+              v-if="step === 3 && hasConflicts && selectedAlternatives.size > 0"
+              class="px-4 py-2 rounded-lg text-sm font-medium text-white bg-violet-600 hover:bg-violet-700 transition-colors"
+              @click="applyAlternatives"
+            >
+              Pick These
+            </button>
           </div>
         </div>
 
@@ -268,7 +292,8 @@
 
 <script lang="ts">
 import { defineComponent, ref, computed, watch, type PropType } from 'vue';
-import type { TreatmentPlan, BulkScheduleResult, LineOverride } from '../../interfaces/TreatmentPlan';
+import type { TreatmentPlan, BulkScheduleResult, LineOverride, SuggestedAlternative } from '../../interfaces/TreatmentPlan';
+import { TIME_MIN, TIME_MAX, TIME_STEP } from '../../utils/timeSlots';
 import { DAY_OF_WEEK_LABELS } from '../../interfaces/TreatmentPlan';
 import { TreatmentPlansHttpClient } from '../../services/TreatmentPlansHttpClient';
 import { SitesHttpClient } from '../../services/SitesHttpClient';
@@ -311,6 +336,51 @@ export default defineComponent({
     const errorMsg = ref('');
     const result = ref<BulkScheduleResult | null>(null);
     const dayLabels = DAY_OF_WEEK_LABELS;
+
+    // Alternative selection for conflict resolution
+    // Key: "conflictIdx-altIdx", Value: { lineId, alternative }
+    const selectedAlternatives = ref<Map<string, { lineId: number; alt: SuggestedAlternative }>>(new Map());
+
+    const hasConflicts = computed(() => !!(result.value && result.value.conflicts.length > 0));
+
+    const isAlternativeSelected = (ci: number, ai: number) => selectedAlternatives.value.has(`${ci}-${ai}`);
+
+    const toggleAlternative = (ci: number, ai: number, lineId: number, alt: SuggestedAlternative) => {
+      const key = `${ci}-${ai}`;
+      const updated = new Map(selectedAlternatives.value);
+      if (updated.has(key)) {
+        updated.delete(key);
+      } else {
+        // Deselect other alternatives for the same conflict
+        for (const k of updated.keys()) {
+          if (k.startsWith(`${ci}-`)) updated.delete(k);
+        }
+        updated.set(key, { lineId, alt });
+      }
+      selectedAlternatives.value = updated;
+    };
+
+    const applyAlternatives = () => {
+      // Apply selected alternatives back to lineEdits and go to step 2
+      for (const { lineId, alt } of selectedAlternatives.value.values()) {
+        const edit = lineEdits.value.find(le => le.lineId === lineId);
+        if (edit) {
+          edit.therapistId = alt.therapistId;
+          edit.time = alt.time;
+        }
+      }
+      selectedAlternatives.value = new Map();
+      result.value = null;
+      step.value = 2;
+    };
+
+    const goBack = () => {
+      if (step.value === 3) {
+        selectedAlternatives.value = new Map();
+        result.value = null;
+      }
+      step.value--;
+    };
 
     const canProceedStep1 = computed(() => startDate.value !== '' && siteId.value > 0);
 
@@ -361,6 +431,7 @@ export default defineComponent({
       siteId.value = 0;
       errorMsg.value = '';
       result.value = null;
+      selectedAlternatives.value = new Map();
       submitting.value = false;
 
       if (props.plan) {
@@ -456,6 +527,15 @@ export default defineComponent({
       formatDate,
       submitSchedule,
       handleClose,
+      timeMin: TIME_MIN,
+      timeMax: TIME_MAX,
+      timeStep: TIME_STEP,
+      hasConflicts,
+      selectedAlternatives,
+      isAlternativeSelected,
+      toggleAlternative,
+      applyAlternatives,
+      goBack,
     };
   },
 });

--- a/app-ui/src/components/treatment-plans/TreatmentPlanFormModal.vue
+++ b/app-ui/src/components/treatment-plans/TreatmentPlanFormModal.vue
@@ -184,6 +184,9 @@
                     <input
                       v-model="line.preferredTime"
                       type="time"
+                      :min="timeMin"
+                      :max="timeMax"
+                      :step="timeStep"
                       class="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-violet-500 focus:border-transparent"
                     />
                   </div>
@@ -265,6 +268,7 @@ import type { TreatmentPlan, TreatmentPlanRequest, TreatmentPlanLineRequest, Dis
 import { DAY_OF_WEEK_LABELS, isDiscoverySpecialty, planStatusBadgeClass } from '../../interfaces/TreatmentPlan';
 import type { LookupItem } from '../../interfaces/Lookups';
 import type { Therapist } from '../../interfaces/Therapist';
+import { TIME_MIN, TIME_MAX, TIME_STEP } from '../../utils/timeSlots';
 
 interface FormLine {
   specialtyTypeId: number;
@@ -500,6 +504,9 @@ export default defineComponent({
       addLine,
       removeLine,
       formatDate,
+      timeMin: TIME_MIN,
+      timeMax: TIME_MAX,
+      timeStep: TIME_STEP,
     };
   },
 });

--- a/app-ui/src/components/treatment-plans/TreatmentPlanList.vue
+++ b/app-ui/src/components/treatment-plans/TreatmentPlanList.vue
@@ -97,7 +97,7 @@
       >
         <!-- Card header -->
         <div class="flex items-center justify-between">
-          <span class="text-base font-semibold text-slate-800">Plan #{{ plan.id }}</span>
+          <span class="text-base font-semibold text-slate-800">{{ plan.displayTitle }}</span>
           <span :class="['inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium', planStatusBadgeClass(plan.planStatus)]">
             {{ plan.planStatus }}
           </span>
@@ -130,11 +130,14 @@
         <div v-if="plan.lines.length > 0" class="mt-3 border-t border-slate-100 pt-3">
           <div v-for="line in plan.lines" :key="line.id" class="text-xs text-slate-600">
             &bull; {{ line.specialtyAbbreviation }} &mdash; {{ line.preferredTherapistName || 'Any Qualified' }}
+            <span v-if="line.dayOfWeek || line.preferredTime || line.duration" class="text-slate-400">
+              ({{ line.dayOfWeek ? dayOfWeekLabel(line.dayOfWeek) : '' }}{{ line.dayOfWeek && line.preferredTime ? ' ' : '' }}{{ line.preferredTime ? formatTime(line.preferredTime) : '' }}{{ line.duration ? `, ${line.duration}min` : '' }})
+            </span>
           </div>
         </div>
 
-        <!-- Plan progress (Active plans) -->
-        <PlanProgressCard v-if="plan.planStatus === 'Active'" :plan-id="plan.id" />
+        <!-- Plan progress (Active + Completed plans) -->
+        <PlanProgressCard v-if="plan.planStatus === 'Active' || plan.planStatus === 'Completed'" :plan-id="plan.id" />
 
         <!-- Card footer -->
         <div class="mt-3 pt-3 border-t border-slate-100 flex justify-end space-x-2">
@@ -204,7 +207,7 @@
 <script lang="ts">
 import { defineComponent, ref, computed, type PropType } from 'vue';
 import type { TreatmentPlan, PlanStatus } from '../../interfaces/TreatmentPlan';
-import { planStatusBadgeClass } from '../../interfaces/TreatmentPlan';
+import { planStatusBadgeClass, DAY_OF_WEEK_LABELS } from '../../interfaces/TreatmentPlan';
 import PlanProgressCard from './PlanProgressCard.vue';
 
 export default defineComponent({
@@ -251,6 +254,8 @@ export default defineComponent({
       hasLineCountMismatch,
       planStatusBadgeClass,
       formatDate,
+      dayOfWeekLabel: (dow: number) => DAY_OF_WEEK_LABELS[dow] ?? '',
+      formatTime: (time: string) => time?.replace(/:00$/, '') ?? '',
     };
   },
 });

--- a/app-ui/src/interfaces/TreatmentPlan.ts
+++ b/app-ui/src/interfaces/TreatmentPlan.ts
@@ -18,6 +18,7 @@ export interface TreatmentPlanLine {
 
 export interface TreatmentPlan {
   id: number;
+  displayTitle: string;
   patientId: number;
   patientName: string;
   discoverySessionId: number;

--- a/app-ui/src/services/SessionsHttpClient.ts
+++ b/app-ui/src/services/SessionsHttpClient.ts
@@ -10,7 +10,8 @@ export class SessionsHttpClient extends HttpClientBase {
       throw new Error("Invalid date format.");
     }
     const url = `/api/Sessions/${formattedDate}/all`;
-    return this.get<Appointment[]>(url);
+    const appointments = await this.get<Appointment[]>(url);
+    return appointments.map(a => ({ ...a, time: a.sessionTime || '' }));
   }
 
   async createSession(data: SessionEventRequest): Promise<Appointment> {

--- a/app-ui/src/utils/timeSlots.ts
+++ b/app-ui/src/utils/timeSlots.ts
@@ -1,0 +1,4 @@
+/** Time picker constraints for clinic working hours */
+export const TIME_MIN = '08:00';
+export const TIME_MAX = '17:00';
+export const TIME_STEP = 900; // 15 minutes in seconds

--- a/app-ui/src/views/Option02View.vue
+++ b/app-ui/src/views/Option02View.vue
@@ -34,6 +34,7 @@
                 @appointments-loaded="onAppointmentsLoaded"
                 @view-payments="onViewPayments"
                 @pay="onPay"
+                @reassign="onReassign"
               />
             </div>
           </div>
@@ -55,6 +56,13 @@
       @close="payFormVisible = false"
       @saved="onPaymentSaved"
     />
+
+    <TherapistReassignModal
+      :visible="reassignModalVisible"
+      :session="reassignModalSession"
+      @close="reassignModalVisible = false"
+      @saved="onReassignSaved"
+    />
   </div>
 </template>
 
@@ -71,6 +79,7 @@ import O2Appointments from '../components/option02/O2Appointments.vue';
 import O2Footer from '../components/option02/O2Footer.vue';
 import SessionPaymentsModal from '../components/payments/SessionPaymentsModal.vue';
 import PaymentFormModal from '../components/payments/PaymentFormModal.vue';
+import TherapistReassignModal from '../components/appointments/TherapistReassignModal.vue';
 import { PatientsHttpClient } from '../services/PatientsHttpClient';
 
 export default defineComponent({
@@ -85,6 +94,7 @@ export default defineComponent({
     O2Footer,
     SessionPaymentsModal,
     PaymentFormModal,
+    TherapistReassignModal,
   },
   setup() {
     const route = useRoute();
@@ -102,6 +112,10 @@ export default defineComponent({
 
     // Refresh key to force O2Appointments re-fetch
     const appointmentRefreshKey = ref(0);
+
+    // Therapist reassign modal state
+    const reassignModalVisible = ref(false);
+    const reassignModalSession = ref<Appointment | null>(null);
 
     const highlightedSessionId = computed(() => {
       const val = route.query.highlightSession;
@@ -157,6 +171,15 @@ export default defineComponent({
       appointmentRefreshKey.value++;
     };
 
+    const onReassign = (appt: Appointment) => {
+      reassignModalSession.value = appt;
+      reassignModalVisible.value = true;
+    };
+
+    const onReassignSaved = () => {
+      appointmentRefreshKey.value++;
+    };
+
     return {
       selectedDate,
       allAppointments,
@@ -172,6 +195,10 @@ export default defineComponent({
       payFormVisible,
       preSelectedCaretakerId,
       appointmentRefreshKey,
+      reassignModalVisible,
+      reassignModalSession,
+      onReassign,
+      onReassignSaved,
     };
   },
 });


### PR DESCRIPTION
Bug fixes:
- Dashboard time display: map sessionTime to time field for all design options
- Time pickers: native input with 15-min steps, 8am-5pm, working hours only

UX enhancements:
- Treatment plan title: display API-generated "TP | LastName, F. | Date | Freq"
- Plan lines: show day/time/duration details, strip seconds from time display
- Completed plans: show session list with progress card
- Session rows: link to dashboard date + highlight from plan progress cards
- Collision step: Back button, selectable alternatives with Pick These action
- Therapist reassign modal: change therapist filtered by specialty on any session