### PR TITLE
WP-13C: Therapist Statement UI + Statements tab refactor

### DIFF
--- a/app-ui/src/components/statements/CaretakerStatementControls.vue
+++ b/app-ui/src/components/statements/CaretakerStatementControls.vue
@@ -1,0 +1,96 @@
+<template>
+  <div class="bg-white rounded-xl shadow-sm border border-slate-200 px-6 py-4 print:hidden">
+    <div class="flex flex-col sm:flex-row sm:items-end gap-4">
+      <!-- Caretaker Select -->
+      <div class="flex-1">
+        <label class="block text-sm font-medium text-slate-700 mb-1">Caretaker</label>
+        <select
+          v-model="selectedCaretakerId"
+          class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+        >
+          <option :value="null" disabled>Select a caretaker...</option>
+          <option
+            v-for="ct in caretakers"
+            :key="ct.caretakerId"
+            :value="ct.caretakerId"
+          >
+            {{ ct.caretakerName }}
+          </option>
+        </select>
+      </div>
+
+      <!-- From Date -->
+      <div>
+        <label class="block text-sm font-medium text-slate-700 mb-1">From</label>
+        <input
+          v-model="fromDate"
+          type="date"
+          class="rounded-lg border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+        />
+      </div>
+
+      <!-- To Date -->
+      <div>
+        <label class="block text-sm font-medium text-slate-700 mb-1">To</label>
+        <input
+          v-model="toDate"
+          type="date"
+          class="rounded-lg border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+        />
+      </div>
+
+      <!-- Generate Button -->
+      <div>
+        <button
+          :disabled="!selectedCaretakerId || loading"
+          class="inline-flex items-center px-4 py-2 rounded-lg text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+          @click="onGenerate"
+        >
+          <svg v-if="loading" class="animate-spin -ml-1 mr-2 h-4 w-4 text-white" fill="none" viewBox="0 0 24 24">
+            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+          </svg>
+          Generate Statement
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref, type PropType } from 'vue';
+
+interface CaretakerOption {
+  caretakerId: number
+  caretakerName: string
+}
+
+export default defineComponent({
+  name: 'CaretakerStatementControls',
+  props: {
+    caretakers: { type: Array as PropType<CaretakerOption[]>, required: true },
+    loading: { type: Boolean, default: false },
+  },
+  emits: ['generate'],
+  setup(_, { emit }) {
+    const selectedCaretakerId = ref<number | null>(null);
+
+    // Default: 90 days ago to today
+    const today = new Date();
+    const ninetyDaysAgo = new Date(today);
+    ninetyDaysAgo.setDate(ninetyDaysAgo.getDate() - 90);
+
+    const toIso = (d: Date) => d.toISOString().split('T')[0];
+    const fromDate = ref(toIso(ninetyDaysAgo));
+    const toDate = ref(toIso(today));
+
+    const onGenerate = () => {
+      if (selectedCaretakerId.value) {
+        emit('generate', selectedCaretakerId.value, fromDate.value, toDate.value);
+      }
+    };
+
+    return { selectedCaretakerId, fromDate, toDate, onGenerate };
+  },
+});
+</script>

--- a/app-ui/src/components/statements/CaretakerStatementScreen.vue
+++ b/app-ui/src/components/statements/CaretakerStatementScreen.vue
@@ -198,7 +198,7 @@ import { defineComponent, type PropType } from 'vue';
 import type { AccountStatement } from '../../interfaces/Statement';
 
 export default defineComponent({
-  name: 'StatementScreen',
+  name: 'CaretakerStatementScreen',
   props: {
     statement: { type: Object as PropType<AccountStatement>, required: true },
   },

--- a/app-ui/src/components/statements/TherapistStatementControls.vue
+++ b/app-ui/src/components/statements/TherapistStatementControls.vue
@@ -1,20 +1,20 @@
 <template>
   <div class="bg-white rounded-xl shadow-sm border border-slate-200 px-6 py-4 print:hidden">
     <div class="flex flex-col sm:flex-row sm:items-end gap-4">
-      <!-- Caretaker Select -->
+      <!-- Therapist Select -->
       <div class="flex-1">
-        <label class="block text-sm font-medium text-slate-700 mb-1">Caretaker</label>
+        <label class="block text-sm font-medium text-slate-700 mb-1">Therapist</label>
         <select
-          v-model="selectedCaretakerId"
+          v-model="selectedTherapistId"
           class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
         >
-          <option :value="null" disabled>Select a caretaker...</option>
+          <option :value="null" disabled>Select a therapist...</option>
           <option
-            v-for="ct in caretakers"
-            :key="ct.caretakerId"
-            :value="ct.caretakerId"
+            v-for="t in therapists"
+            :key="t.therapistId"
+            :value="t.therapistId"
           >
-            {{ ct.caretakerName }}
+            {{ t.therapistName }}
           </option>
         </select>
       </div>
@@ -42,7 +42,7 @@
       <!-- Generate Button -->
       <div>
         <button
-          :disabled="!selectedCaretakerId || loading"
+          :disabled="!selectedTherapistId || loading"
           class="inline-flex items-center px-4 py-2 rounded-lg text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
           @click="onGenerate"
         >
@@ -60,22 +60,22 @@
 <script lang="ts">
 import { defineComponent, ref, type PropType } from 'vue';
 
-interface CaretakerOption {
-  caretakerId: number
-  caretakerName: string
+interface TherapistOption {
+  therapistId: number
+  therapistName: string
 }
 
 export default defineComponent({
-  name: 'StatementControls',
+  name: 'TherapistStatementControls',
   props: {
-    caretakers: { type: Array as PropType<CaretakerOption[]>, required: true },
+    therapists: { type: Array as PropType<TherapistOption[]>, required: true },
     loading: { type: Boolean, default: false },
   },
   emits: ['generate'],
   setup(_, { emit }) {
-    const selectedCaretakerId = ref<number | null>(null);
+    const selectedTherapistId = ref<number | null>(null);
 
-    // Default: 90 days ago to today
+    // Default: 90 days ago to today (matches Caretaker pattern)
     const today = new Date();
     const ninetyDaysAgo = new Date(today);
     ninetyDaysAgo.setDate(ninetyDaysAgo.getDate() - 90);
@@ -85,12 +85,12 @@ export default defineComponent({
     const toDate = ref(toIso(today));
 
     const onGenerate = () => {
-      if (selectedCaretakerId.value) {
-        emit('generate', selectedCaretakerId.value, fromDate.value, toDate.value);
+      if (selectedTherapistId.value) {
+        emit('generate', selectedTherapistId.value, fromDate.value, toDate.value);
       }
     };
 
-    return { selectedCaretakerId, fromDate, toDate, onGenerate };
+    return { selectedTherapistId, fromDate, toDate, onGenerate };
   },
 });
 </script>

--- a/app-ui/src/components/statements/TherapistStatementScreen.vue
+++ b/app-ui/src/components/statements/TherapistStatementScreen.vue
@@ -1,0 +1,237 @@
+<template>
+  <div>
+    <!-- Print-only header -->
+    <div class="hidden print:block text-center mb-6">
+      <h1 class="text-2xl font-bold text-slate-900">NeuroCorp Therapy Center</h1>
+      <h2 class="text-lg font-semibold text-slate-700 mt-1">Therapist Statement</h2>
+      <p class="text-sm text-slate-500 mt-1">{{ formatDate(statement.statementDate) }}</p>
+    </div>
+
+    <!-- Pro-forma banner (also visible in print) -->
+    <div
+      v-if="statement.isProForma"
+      class="mb-6 rounded-lg border border-amber-400 bg-amber-100 text-amber-900 px-4 py-3"
+    >
+      <div class="flex items-start gap-2">
+        <svg class="w-5 h-5 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+        </svg>
+        <p class="text-sm font-medium">
+          Estimated &mdash; Service Payments not yet tracked. This report shows gross amount due based on completed sessions.
+        </p>
+      </div>
+    </div>
+
+    <!-- Statement Header -->
+    <div class="bg-white rounded-lg shadow-sm border border-slate-200 p-6 mb-6 print:shadow-none print:border-none">
+      <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
+        <div>
+          <h2 class="text-lg font-semibold text-slate-900">{{ statement.therapistName }}</h2>
+          <p class="text-sm text-slate-500 mt-1">
+            Period: {{ formatDate(statement.periodStart) }} &mdash; {{ formatDate(statement.periodEnd) }}
+          </p>
+          <p class="text-sm text-slate-500">
+            Statement Date: {{ formatDate(statement.statementDate) }}
+          </p>
+        </div>
+        <div v-if="statement.patients.length > 0">
+          <h3 class="text-xs font-medium text-slate-500 uppercase tracking-wider mb-1">Patients</h3>
+          <ul class="space-y-0.5">
+            <li v-for="p in statement.patients" :key="p.patientId" class="text-sm text-slate-700">
+              {{ p.patientName }}
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+
+    <!-- Empty state -->
+    <div
+      v-if="statement.patients.length === 0"
+      class="bg-white rounded-lg shadow-sm border border-slate-200 p-8 mb-6 text-center print:shadow-none print:border-none"
+    >
+      <svg class="mx-auto h-10 w-10 text-slate-300 mb-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 17v-2a4 4 0 014-4h6m-3-3l3 3m0 0l-3 3m3-3H9" />
+      </svg>
+      <p class="text-sm text-slate-500">No sessions in this period.</p>
+    </div>
+
+    <!-- Patient blocks -->
+    <div
+      v-for="patient in statement.patients"
+      :key="patient.patientId"
+      class="bg-white rounded-lg shadow-sm border border-slate-200 mb-6 print:shadow-none print:border-none print:break-inside-avoid"
+    >
+      <div class="px-6 py-4 border-b border-slate-200">
+        <h3 class="text-base font-semibold text-slate-800">{{ patient.patientName }}</h3>
+      </div>
+      <div class="overflow-x-auto">
+        <table class="min-w-full divide-y divide-slate-200">
+          <thead class="bg-slate-50">
+            <tr>
+              <th class="px-4 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Date</th>
+              <th class="px-4 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Time</th>
+              <th class="px-4 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Therapy Type</th>
+              <th class="px-4 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Status</th>
+              <th class="px-4 py-3 text-right text-xs font-medium text-slate-500 uppercase tracking-wider">Fee</th>
+              <th class="px-4 py-3 text-right text-xs font-medium text-slate-500 uppercase tracking-wider">Discount</th>
+              <th class="px-4 py-3 text-right text-xs font-medium text-slate-500 uppercase tracking-wider">Provider Amount</th>
+            </tr>
+          </thead>
+          <tbody class="bg-white divide-y divide-slate-200">
+            <tr
+              v-for="session in patient.sessions"
+              :key="session.sessionId"
+              :class="session.isBillable ? 'hover:bg-slate-50' : 'bg-slate-50/40 hover:bg-slate-100/60'"
+            >
+              <td class="px-4 py-3 whitespace-nowrap text-sm text-slate-900">{{ formatDate(session.sessionDate) }}</td>
+              <td class="px-4 py-3 whitespace-nowrap text-sm text-slate-900">{{ session.sessionTime }}</td>
+              <td class="px-4 py-3 whitespace-nowrap text-sm text-slate-900">{{ session.therapyType }}</td>
+              <td class="px-4 py-3 whitespace-nowrap text-sm">
+                <span
+                  :class="session.isBillable
+                    ? 'inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800'
+                    : 'inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-slate-200 text-slate-600'"
+                >
+                  {{ session.statusName }}
+                </span>
+              </td>
+              <td class="px-4 py-3 whitespace-nowrap text-sm text-slate-900 text-right">{{ formatCurrency(session.amount) }}</td>
+              <td class="px-4 py-3 whitespace-nowrap text-sm text-slate-900 text-right">{{ formatCurrency(session.discountAmount) }}</td>
+              <td
+                class="px-4 py-3 whitespace-nowrap text-sm text-right font-medium"
+                :class="session.isBillable ? 'text-slate-900' : 'text-slate-400'"
+                :title="session.isBillable ? undefined : `Non-billable: ${session.statusName}`"
+              >
+                {{ formatCurrency(session.providerAmount) }}
+              </td>
+            </tr>
+            <!-- Subtotal row -->
+            <tr class="bg-slate-50 font-medium">
+              <td colspan="3" class="px-4 py-3 text-sm text-slate-700">
+                Subtotal &mdash;
+                {{ patient.completedCount }} completed, {{ patient.nonBillableCount }} non-billable
+              </td>
+              <td class="px-4 py-3"></td>
+              <td class="px-4 py-3 whitespace-nowrap text-sm text-slate-900 text-right">{{ formatCurrency(patient.subtotalFee) }}</td>
+              <td class="px-4 py-3 whitespace-nowrap text-sm text-slate-900 text-right">{{ formatCurrency(patient.subtotalDiscount) }}</td>
+              <td class="px-4 py-3 whitespace-nowrap text-sm text-slate-900 text-right">{{ formatCurrency(patient.subtotalProviderAmount) }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <!-- Service Payments section (always empty in WP-13B; v-if guard for forward-compat) -->
+    <div class="bg-white rounded-lg shadow-sm border border-slate-200 mb-6 print:shadow-none print:border-none">
+      <div class="px-6 py-4 border-b border-slate-200">
+        <h3 class="text-base font-semibold text-slate-800">Service Payments</h3>
+      </div>
+      <div v-if="statement.servicePayments.length === 0" class="px-6 py-6 text-center text-sm text-slate-400">
+        No service payments recorded for this period.
+      </div>
+      <div v-else class="overflow-x-auto">
+        <table class="min-w-full divide-y divide-slate-200">
+          <thead class="bg-slate-50">
+            <tr>
+              <th class="px-4 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Date</th>
+              <th class="px-4 py-3 text-right text-xs font-medium text-slate-500 uppercase tracking-wider">Amount</th>
+              <th class="px-4 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Type</th>
+              <th class="px-4 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Reference</th>
+              <th class="px-4 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Allocations</th>
+            </tr>
+          </thead>
+          <tbody class="bg-white divide-y divide-slate-200">
+            <tr v-for="sp in statement.servicePayments" :key="sp.servicePaymentId" class="hover:bg-slate-50">
+              <td class="px-4 py-3 whitespace-nowrap text-sm text-slate-900">{{ formatDate(sp.paymentDate) }}</td>
+              <td class="px-4 py-3 whitespace-nowrap text-sm text-slate-900 text-right font-medium">{{ formatCurrency(sp.amount) }}</td>
+              <td class="px-4 py-3 whitespace-nowrap text-sm text-slate-900">{{ sp.paymentTypeName }}</td>
+              <td class="px-4 py-3 whitespace-nowrap text-sm text-slate-900">{{ sp.referenceNumber || '—' }}</td>
+              <td class="px-4 py-3 text-sm text-slate-900">
+                {{ sp.allocations.length }} session{{ sp.allocations.length !== 1 ? 's' : '' }}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <!-- Summary Box -->
+    <div class="bg-white rounded-lg shadow-sm border border-slate-200 p-6 mb-6 print:shadow-none print:border-none print:break-inside-avoid">
+      <h3 class="text-base font-semibold text-slate-800 mb-4">Statement Summary</h3>
+      <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-4 mb-4">
+        <div>
+          <p class="text-xs font-medium text-slate-500 uppercase tracking-wider">Completed</p>
+          <p class="text-lg font-semibold text-slate-900 mt-1">{{ statement.summary.totalCompletedSessions }}</p>
+        </div>
+        <div>
+          <p class="text-xs font-medium text-slate-500 uppercase tracking-wider">Non-billable</p>
+          <p class="text-lg font-semibold text-slate-900 mt-1">{{ statement.summary.totalNonBillableSessions }}</p>
+        </div>
+        <div>
+          <p class="text-xs font-medium text-slate-500 uppercase tracking-wider">Total Fee</p>
+          <p class="text-lg font-semibold text-slate-900 mt-1">{{ formatCurrency(statement.summary.totalFee) }}</p>
+        </div>
+        <div>
+          <p class="text-xs font-medium text-slate-500 uppercase tracking-wider">Total Discount</p>
+          <p class="text-lg font-semibold text-slate-900 mt-1">{{ formatCurrency(statement.summary.totalDiscount) }}</p>
+        </div>
+        <div>
+          <p class="text-xs font-medium text-slate-500 uppercase tracking-wider">Provider Amount</p>
+          <p class="text-lg font-semibold text-slate-900 mt-1">{{ formatCurrency(statement.summary.totalProviderAmount) }}</p>
+        </div>
+        <div>
+          <p class="text-xs font-medium text-slate-500 uppercase tracking-wider">Service Payments</p>
+          <p class="text-lg font-semibold text-slate-900 mt-1">{{ formatCurrency(statement.summary.totalServicePaymentsApplied) }}</p>
+        </div>
+      </div>
+      <div class="border-t border-slate-200 pt-4">
+        <div class="flex items-center justify-between">
+          <p class="text-sm font-medium text-slate-700">Estimated Amount Due</p>
+          <p class="text-3xl font-bold text-blue-700">
+            {{ formatCurrency(statement.summary.estimatedAmountDue) }}
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <!-- Print Button -->
+    <div class="flex justify-end print:hidden">
+      <button
+        class="inline-flex items-center px-4 py-2 rounded-lg text-sm font-medium text-white bg-blue-600 hover:bg-blue-700"
+        @click="printStatement"
+      >
+        <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V5a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z" />
+        </svg>
+        Print Statement
+      </button>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, type PropType } from 'vue';
+import type { TherapistStatement } from '../../interfaces/TherapistStatement';
+
+export default defineComponent({
+  name: 'TherapistStatementScreen',
+  props: {
+    statement: { type: Object as PropType<TherapistStatement>, required: true },
+  },
+  setup() {
+    const formatCurrency = (value: number) => `$${value.toFixed(2)}`;
+
+    const formatDate = (dateStr: string) => {
+      const d = new Date(dateStr);
+      return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+    };
+
+    const printStatement = () => {
+      window.print();
+    };
+
+    return { formatCurrency, formatDate, printStatement };
+  },
+});
+</script>

--- a/app-ui/src/interfaces/TherapistStatement.ts
+++ b/app-ui/src/interfaces/TherapistStatement.ts
@@ -1,0 +1,65 @@
+// interfaces/TherapistStatement.ts
+//
+// Mirrors the API DTO from `_contracts/therapists-api.md` (WP-13B).
+// JSON serialization is camelCase (matches the Caretaker AccountStatement pattern).
+
+export interface TherapistStatementSession {
+  sessionId: number
+  sessionDate: string
+  sessionTime: string         // HH:mm
+  therapyType: string         // resolved server-side: SpecialtyType.Name → TherapyTypes → "N/A"
+  amount: number
+  discountAmount: number
+  providerAmount: number      // 0 for Cancelled/NoShow (server-side)
+  statusName: string          // AppointmentStatus.Name
+  isBillable: boolean         // true only when statusName === "Completed"
+}
+
+export interface TherapistStatementPatient {
+  patientId: number
+  patientName: string
+  sessions: TherapistStatementSession[]
+  subtotalFee: number
+  subtotalDiscount: number
+  subtotalProviderAmount: number  // Completed only
+  completedCount: number
+  nonBillableCount: number        // Cancelled + NoShow
+}
+
+// Reserved for the Therapist Payroll WP (WP-14). Always empty in WP-13B.
+export interface ServicePaymentAllocation {
+  sessionId: number
+  amountApplied: number
+}
+
+export interface ServicePaymentItem {
+  servicePaymentId: number
+  paymentDate: string
+  amount: number
+  paymentTypeName: string
+  referenceNumber: string
+  notes: string
+  allocations: ServicePaymentAllocation[]
+}
+
+export interface TherapistStatementSummary {
+  totalCompletedSessions: number
+  totalNonBillableSessions: number    // Cancelled + NoShow
+  totalFee: number
+  totalDiscount: number
+  totalProviderAmount: number         // billable only
+  totalServicePaymentsApplied: number // 0 in WP-13B
+  estimatedAmountDue: number          // = totalProviderAmount - totalServicePaymentsApplied
+}
+
+export interface TherapistStatement {
+  therapistId: number
+  therapistName: string
+  statementDate: string               // yyyy-MM-dd
+  periodStart: string
+  periodEnd: string
+  isProForma: boolean                 // true until WP-14 ships
+  patients: TherapistStatementPatient[]
+  servicePayments: ServicePaymentItem[]  // always [] in WP-13B
+  summary: TherapistStatementSummary
+}

--- a/app-ui/src/services/StatementsHttpClient.ts
+++ b/app-ui/src/services/StatementsHttpClient.ts
@@ -1,6 +1,7 @@
 // services/StatementsHttpClient.ts
 import { HttpClientBase } from './HttpClientBase';
 import type { AccountStatement } from '../interfaces/Statement';
+import type { TherapistStatement } from '../interfaces/TherapistStatement';
 
 export class StatementsHttpClient extends HttpClientBase {
   async getStatement(caretakerId: number, from?: string, to?: string): Promise<AccountStatement> {
@@ -10,5 +11,14 @@ export class StatementsHttpClient extends HttpClientBase {
     const query = params.toString();
     const url = `/api/caretakers/${caretakerId}/statement${query ? `?${query}` : ''}`;
     return this.get<AccountStatement>(url);
+  }
+
+  async getTherapistStatement(therapistId: number, from?: string, to?: string): Promise<TherapistStatement> {
+    const params = new URLSearchParams();
+    if (from) params.append('from', from);
+    if (to) params.append('to', to);
+    const query = params.toString();
+    const url = `/api/therapists/${therapistId}/statement${query ? `?${query}` : ''}`;
+    return this.get<TherapistStatement>(url);
   }
 }

--- a/app-ui/src/views/StatementView.vue
+++ b/app-ui/src/views/StatementView.vue
@@ -8,30 +8,82 @@
         <main class="flex-1 max-w-7xl mx-auto w-full px-4 sm:px-6 lg:px-8 py-6">
           <div class="mb-6 print:hidden">
             <h1 class="text-2xl font-bold text-slate-800">Statements</h1>
-            <p class="text-sm text-slate-500 mt-1">Generate account statements for caretakers</p>
+            <p class="text-sm text-slate-500 mt-1">Generate account statements for caretakers and therapists</p>
           </div>
 
-          <!-- Selection controls (hidden when statement is displayed) -->
-          <div v-if="!statement && !loading" class="mb-6">
-            <StatementControls
-              :caretakers="caretakers"
-              :loading="loading"
-              @generate="onGenerate"
-            />
+          <!-- Tab bar (hidden in print) -->
+          <div class="mb-6 print:hidden border-b border-slate-200">
+            <nav class="-mb-px flex gap-6" aria-label="Statement tabs">
+              <button
+                type="button"
+                class="py-3 px-1 border-b-2 text-sm font-medium transition-colors"
+                :class="activeTab === 'caretaker'
+                  ? 'border-blue-600 text-blue-600'
+                  : 'border-transparent text-slate-500 hover:text-slate-700 hover:border-slate-300'"
+                @click="setTab('caretaker')"
+              >
+                Caretaker
+              </button>
+              <button
+                type="button"
+                class="py-3 px-1 border-b-2 text-sm font-medium transition-colors"
+                :class="activeTab === 'therapist'
+                  ? 'border-blue-600 text-blue-600'
+                  : 'border-transparent text-slate-500 hover:text-slate-700 hover:border-slate-300'"
+                @click="setTab('therapist')"
+              >
+                Therapist
+              </button>
+            </nav>
           </div>
 
-          <!-- Back bar (shown when statement is displayed) -->
-          <div v-if="(statement || loading) && !error" class="mb-6 print:hidden">
-            <div class="bg-white rounded-xl shadow-sm border border-slate-200 px-6 py-3 flex items-center justify-between">
-              <div class="flex items-center gap-3">
-                <span v-if="statement" class="text-sm text-slate-600">
-                  Viewing statement for <span class="font-semibold text-slate-900">{{ statement.caretakerName }}</span>
-                </span>
-                <span v-else class="text-sm text-slate-500">Generating statement...</span>
+          <!-- Caretaker Tab -->
+          <div v-show="activeTab === 'caretaker'">
+            <!-- Selection controls (hidden when statement is displayed) -->
+            <div v-if="!caretakerStatement && !caretakerLoading" class="mb-6">
+              <CaretakerStatementControls
+                :caretakers="caretakers"
+                :loading="caretakerLoading"
+                @generate="onCaretakerGenerate"
+              />
+            </div>
+
+            <!-- Back bar -->
+            <div v-if="(caretakerStatement || caretakerLoading) && !caretakerError" class="mb-6 print:hidden">
+              <div class="bg-white rounded-xl shadow-sm border border-slate-200 px-6 py-3 flex items-center justify-between">
+                <div class="flex items-center gap-3">
+                  <span v-if="caretakerStatement" class="text-sm text-slate-600">
+                    Viewing statement for <span class="font-semibold text-slate-900">{{ caretakerStatement.caretakerName }}</span>
+                  </span>
+                  <span v-else class="text-sm text-slate-500">Generating statement...</span>
+                </div>
+                <button
+                  class="inline-flex items-center px-3 py-1.5 rounded-lg text-sm font-medium text-slate-700 bg-slate-100 hover:bg-slate-200"
+                  @click="onCaretakerBack"
+                >
+                  <svg class="w-4 h-4 mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
+                  </svg>
+                  Back
+                </button>
+              </div>
+            </div>
+
+            <div v-if="caretakerLoading" class="px-6 py-12 text-center text-sm text-slate-400">
+              <svg class="animate-spin mx-auto h-8 w-8 text-blue-500 mb-3" fill="none" viewBox="0 0 24 24">
+                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+              </svg>
+              Generating statement...
+            </div>
+
+            <div v-if="caretakerError" class="mb-6">
+              <div class="bg-red-50 border border-red-200 rounded-lg p-4">
+                <p class="text-sm text-red-700">{{ caretakerError }}</p>
               </div>
               <button
-                class="inline-flex items-center px-3 py-1.5 rounded-lg text-sm font-medium text-slate-700 bg-slate-100 hover:bg-slate-200"
-                @click="onBack"
+                class="mt-3 inline-flex items-center px-3 py-1.5 rounded-lg text-sm font-medium text-slate-700 bg-slate-100 hover:bg-slate-200"
+                @click="onCaretakerBack"
               >
                 <svg class="w-4 h-4 mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
@@ -39,35 +91,65 @@
                 Back
               </button>
             </div>
+
+            <CaretakerStatementScreen v-if="caretakerStatement && !caretakerLoading" :statement="caretakerStatement" />
           </div>
 
-          <!-- Loading -->
-          <div v-if="loading" class="px-6 py-12 text-center text-sm text-slate-400">
-            <svg class="animate-spin mx-auto h-8 w-8 text-blue-500 mb-3" fill="none" viewBox="0 0 24 24">
-              <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
-              <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
-            </svg>
-            Generating statement...
-          </div>
-
-          <!-- Error -->
-          <div v-if="error" class="mb-6">
-            <div class="bg-red-50 border border-red-200 rounded-lg p-4">
-              <p class="text-sm text-red-700">{{ error }}</p>
+          <!-- Therapist Tab -->
+          <div v-show="activeTab === 'therapist'">
+            <div v-if="!therapistStatement && !therapistLoading" class="mb-6">
+              <TherapistStatementControls
+                :therapists="therapists"
+                :loading="therapistLoading"
+                @generate="onTherapistGenerate"
+              />
             </div>
-            <button
-              class="mt-3 inline-flex items-center px-3 py-1.5 rounded-lg text-sm font-medium text-slate-700 bg-slate-100 hover:bg-slate-200"
-              @click="onBack"
-            >
-              <svg class="w-4 h-4 mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
-              </svg>
-              Back
-            </button>
-          </div>
 
-          <!-- Statement -->
-          <StatementScreen v-if="statement && !loading" :statement="statement" />
+            <div v-if="(therapistStatement || therapistLoading) && !therapistError" class="mb-6 print:hidden">
+              <div class="bg-white rounded-xl shadow-sm border border-slate-200 px-6 py-3 flex items-center justify-between">
+                <div class="flex items-center gap-3">
+                  <span v-if="therapistStatement" class="text-sm text-slate-600">
+                    Viewing statement for <span class="font-semibold text-slate-900">{{ therapistStatement.therapistName }}</span>
+                  </span>
+                  <span v-else class="text-sm text-slate-500">Generating statement...</span>
+                </div>
+                <button
+                  class="inline-flex items-center px-3 py-1.5 rounded-lg text-sm font-medium text-slate-700 bg-slate-100 hover:bg-slate-200"
+                  @click="onTherapistBack"
+                >
+                  <svg class="w-4 h-4 mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
+                  </svg>
+                  Back
+                </button>
+              </div>
+            </div>
+
+            <div v-if="therapistLoading" class="px-6 py-12 text-center text-sm text-slate-400">
+              <svg class="animate-spin mx-auto h-8 w-8 text-blue-500 mb-3" fill="none" viewBox="0 0 24 24">
+                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+              </svg>
+              Generating statement...
+            </div>
+
+            <div v-if="therapistError" class="mb-6">
+              <div class="bg-red-50 border border-red-200 rounded-lg p-4">
+                <p class="text-sm text-red-700">{{ therapistError }}</p>
+              </div>
+              <button
+                class="mt-3 inline-flex items-center px-3 py-1.5 rounded-lg text-sm font-medium text-slate-700 bg-slate-100 hover:bg-slate-200"
+                @click="onTherapistBack"
+              >
+                <svg class="w-4 h-4 mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
+                </svg>
+                Back
+              </button>
+            </div>
+
+            <TherapistStatementScreen v-if="therapistStatement && !therapistLoading" :statement="therapistStatement" />
+          </div>
         </main>
         <O2Footer class="print:hidden" />
       </div>
@@ -81,28 +163,62 @@ import O2MobileNav from '../components/option02/O2MobileNav.vue';
 import O2Sidebar from '../components/option02/O2Sidebar.vue';
 import O2Header from '../components/option02/O2Header.vue';
 import O2Footer from '../components/option02/O2Footer.vue';
-import StatementControls from '../components/statements/StatementControls.vue';
-import StatementScreen from '../components/statements/StatementScreen.vue';
+import CaretakerStatementControls from '../components/statements/CaretakerStatementControls.vue';
+import CaretakerStatementScreen from '../components/statements/CaretakerStatementScreen.vue';
+import TherapistStatementControls from '../components/statements/TherapistStatementControls.vue';
+import TherapistStatementScreen from '../components/statements/TherapistStatementScreen.vue';
 import { CaretakersHttpClient } from '../services/CaretakersHttpClient';
+import { TherapistsHttpClient } from '../services/TherapistsHttpClient';
 import { StatementsHttpClient } from '../services/StatementsHttpClient';
 import type { AccountStatement } from '../interfaces/Statement';
+import type { TherapistStatement } from '../interfaces/TherapistStatement';
 
 interface CaretakerOption {
   caretakerId: number
   caretakerName: string
 }
 
+interface TherapistOption {
+  therapistId: number
+  therapistName: string
+}
+
+type TabKey = 'caretaker' | 'therapist';
+
 export default defineComponent({
   name: 'StatementView',
-  components: { O2MobileNav, O2Sidebar, O2Header, O2Footer, StatementControls, StatementScreen },
+  components: {
+    O2MobileNav,
+    O2Sidebar,
+    O2Header,
+    O2Footer,
+    CaretakerStatementControls,
+    CaretakerStatementScreen,
+    TherapistStatementControls,
+    TherapistStatementScreen,
+  },
   setup() {
     const caretakersClient = new CaretakersHttpClient();
+    const therapistsClient = new TherapistsHttpClient();
     const statementsClient = new StatementsHttpClient();
 
+    // Tab state — Caretaker is the default
+    const activeTab = ref<TabKey>('caretaker');
+    const setTab = (tab: TabKey) => {
+      activeTab.value = tab;
+    };
+
+    // Caretaker tab state (preserves the original flow verbatim)
     const caretakers = ref<CaretakerOption[]>([]);
-    const statement = ref<AccountStatement | null>(null);
-    const loading = ref(false);
-    const error = ref('');
+    const caretakerStatement = ref<AccountStatement | null>(null);
+    const caretakerLoading = ref(false);
+    const caretakerError = ref('');
+
+    // Therapist tab state
+    const therapists = ref<TherapistOption[]>([]);
+    const therapistStatement = ref<TherapistStatement | null>(null);
+    const therapistLoading = ref(false);
+    const therapistError = ref('');
 
     const loadCaretakers = async () => {
       try {
@@ -114,32 +230,83 @@ export default defineComponent({
           }))
           .sort((a, b) => a.caretakerName.localeCompare(b.caretakerName));
       } catch (e: unknown) {
-        error.value = e instanceof Error ? e.message : 'Failed to load caretakers.';
+        caretakerError.value = e instanceof Error ? e.message : 'Failed to load caretakers.';
       }
     };
 
-    const onGenerate = async (caretakerId: number, from: string, to: string) => {
-      loading.value = true;
-      error.value = '';
-      statement.value = null;
+    const loadTherapists = async () => {
       try {
-        statement.value = await statementsClient.getStatement(caretakerId, from, to);
+        const list = await therapistsClient.getTherapists();
+        therapists.value = list
+          .map((t) => ({
+            therapistId: t.therapistId,
+            therapistName: t.therapistName,
+          }))
+          .sort((a, b) => a.therapistName.localeCompare(b.therapistName));
       } catch (e: unknown) {
-        error.value = e instanceof Error ? e.message : 'Failed to generate statement.';
-      } finally {
-        loading.value = false;
+        therapistError.value = e instanceof Error ? e.message : 'Failed to load therapists.';
       }
     };
 
-    const onBack = () => {
-      statement.value = null;
-      error.value = '';
-      loading.value = false;
+    const onCaretakerGenerate = async (caretakerId: number, from: string, to: string) => {
+      caretakerLoading.value = true;
+      caretakerError.value = '';
+      caretakerStatement.value = null;
+      try {
+        caretakerStatement.value = await statementsClient.getStatement(caretakerId, from, to);
+      } catch (e: unknown) {
+        caretakerError.value = e instanceof Error ? e.message : 'Failed to generate statement.';
+      } finally {
+        caretakerLoading.value = false;
+      }
     };
 
-    onMounted(loadCaretakers);
+    const onCaretakerBack = () => {
+      caretakerStatement.value = null;
+      caretakerError.value = '';
+      caretakerLoading.value = false;
+    };
 
-    return { caretakers, statement, loading, error, onGenerate, onBack };
+    const onTherapistGenerate = async (therapistId: number, from: string, to: string) => {
+      therapistLoading.value = true;
+      therapistError.value = '';
+      therapistStatement.value = null;
+      try {
+        therapistStatement.value = await statementsClient.getTherapistStatement(therapistId, from, to);
+      } catch (e: unknown) {
+        therapistError.value = e instanceof Error ? e.message : 'Failed to generate statement.';
+      } finally {
+        therapistLoading.value = false;
+      }
+    };
+
+    const onTherapistBack = () => {
+      therapistStatement.value = null;
+      therapistError.value = '';
+      therapistLoading.value = false;
+    };
+
+    onMounted(() => {
+      loadCaretakers();
+      loadTherapists();
+    });
+
+    return {
+      activeTab,
+      setTab,
+      caretakers,
+      caretakerStatement,
+      caretakerLoading,
+      caretakerError,
+      onCaretakerGenerate,
+      onCaretakerBack,
+      therapists,
+      therapistStatement,
+      therapistLoading,
+      therapistError,
+      onTherapistGenerate,
+      onTherapistBack,
+    };
   },
 });
 </script>

--- a/test-scenarios/wp-13c-therapist-statement.md
+++ b/test-scenarios/wp-13c-therapist-statement.md
@@ -1,0 +1,110 @@
+# WP-13C — Therapist Statement UI: User Test Scenarios
+
+**Branch:** `feature/wp-13c-therapist-statement-ui`
+**Companion plan:** `patient-care-super/planning/active/wp-13-therapist-statement.md`
+**API dependency:** WP-13B on branch `feature/wp-13b-therapist-statement-api`
+
+These are end-to-end scenarios the clinic owner (Anibal) should walk through to validate the
+Therapist tab + tab refactor. The Caretaker tab regression scenario is included to confirm
+that the rename and tab restructure did not break the existing Caretaker statement flow.
+
+---
+
+## Scenario 1 — Generate a therapist statement
+
+**As an owner**, navigate to **Statements** → click the **Therapist** tab → pick a therapist from the
+dropdown → leave the default 90-day range → click **Generate Statement**.
+
+**Expected:**
+- Per-patient blocks render (one block per patient that the selected therapist treated in the period).
+- Each block shows session rows with Date · Time · Therapy Type · Status · Fee · Discount · Provider Amount.
+- Each block has a Subtotal row showing per-patient totals.
+- Summary box at the bottom shows totals for completed sessions, non-billable sessions, fee, discount, provider amount, service payments, and a large/bold Estimated Amount Due.
+- Estimated Amount Due is greater than zero if the therapist had any Completed sessions in the range.
+- Pro-forma amber banner is visible at the top of the report.
+
+---
+
+## Scenario 2 — Custom date range
+
+Same as Scenario 1, but **set a 14-day range** matching a quincena window (e.g., the 1st through the 15th of the current month).
+
+**Expected:**
+- Only sessions whose `sessionDate` falls within that 14-day window appear.
+- Subtotals and summary reflect the narrower window.
+- The period display in the report header shows the chosen From / To dates.
+
+---
+
+## Scenario 3 — Mixed statuses (Completed + Cancelled + NoShow)
+
+Pick a therapist who had at least one **Cancelled** and one **NoShow** session in the range.
+
+**Expected:**
+- Cancelled and NoShow rows are visible alongside Completed rows.
+- Cancelled / NoShow rows show their Provider Amount as `$0.00`.
+- Hovering the `$0.00` cell reveals a tooltip: `Non-billable: Cancelled` (or `Non-billable: NoShow`).
+- The status badge for non-billable rows is gray (vs. green for Completed).
+- The Estimated Amount Due in the summary equals the Total Provider Amount, which sums **only** the Completed rows.
+- The patient subtotal row shows the per-patient `completedCount` and `nonBillableCount` next to "Subtotal —".
+
+---
+
+## Scenario 4 — Print / PDF export
+
+With a generated report on screen, click **Print Statement** (or `Ctrl+P`).
+
+**Expected:**
+- Print preview shows the report cleanly: clinic name header, therapist name, period.
+- Pro-forma amber banner is **visible in the print preview** (it must follow the report into PDF).
+- All patient blocks, subtotals, the Service Payments placeholder, and the Summary box are present.
+- No UI chrome (sidebar, top bar, mobile nav, tab bar, Back button, Print button) appears in the print preview.
+- Patient blocks and the summary box do not split awkwardly across pages where avoidable.
+
+---
+
+## Scenario 5 — Empty range
+
+Pick a therapist plus a date range during which the therapist had no sessions
+(e.g., a date range entirely before the therapist was hired, or a vacation week).
+
+**Expected:**
+- A friendly "No sessions in this period." empty-state message appears in place of patient blocks.
+- The Summary box shows all zeros (0 completed, 0 non-billable, $0.00 totals).
+- The pro-forma amber banner is still visible.
+- Print Statement still works and produces a clean (but mostly empty) report.
+
+---
+
+## Scenario 6 — Caretaker tab regression
+
+Switch to the **Caretaker** tab.
+
+**Expected:**
+- The existing Caretaker statement flow works **identically** to before the WP-13C refactor:
+  - Caretaker dropdown loads.
+  - From / To date pickers default to 90 days ago and today.
+  - Generate Statement produces the existing Caretaker statement layout (charges table, payments table, account summary, past-due callout).
+  - Print works as before.
+- No regressions, layout shifts, or console errors.
+
+---
+
+## Scenario 7 — Therapy Type fallback
+
+Pick a therapist whose data includes sessions where `SpecialtyTypeId` is null but the
+legacy `TherapyTypes` text column on `TherapySession` is set, **and** at least one row where both
+are null/empty.
+
+**Expected:**
+- For sessions with a non-null FK, the Therapy Type column shows `SpecialtyType.Name`.
+- For sessions where the FK is null but legacy text exists, the column shows the legacy text verbatim.
+- For sessions where both are null/empty, the column shows `N/A`.
+- The fallback is applied **server-side** (the UI just renders the `therapyType` string the API returns); no client-side coercion is needed.
+
+---
+
+## Notes / known limitations
+
+- **Pro-forma flag is hard-wired to `true`** in WP-13B and `servicePayments[]` is always `[]`. The Service Payments section will always render the "No service payments recorded for this period." placeholder until WP-14 (Therapist Payroll) ships and starts flipping the flag.
+- The endpoint excludes future-dated `Scheduled` / `Confirmed` sessions deliberately — this is a retrospective payroll-style report.


### PR DESCRIPTION
Refactor StatementView into a two-tab host (Caretaker default, Therapist) and add the Therapist statement flow against the WP-13B endpoint.

Renames (mechanical, no logic change):
- StatementControls.vue   -> CaretakerStatementControls.vue
- StatementScreen.vue     -> CaretakerStatementScreen.vue

New components:
- TherapistStatementControls.vue (therapist dropdown + 90d-default date range + Generate button, mirroring the Caretaker pattern).
- TherapistStatementScreen.vue with persistent amber pro-forma banner (also visible in print), per-patient blocks (Date / Time / Therapy Type / Status / Fee / Discount / Provider Amount with subtotal row), Service Payments placeholder (v-if guard for forward-compat with WP-14), summary box with large/bold EstimatedAmountDue, Print button, and empty state.

Other:
- StatementsHttpClient gains getTherapistStatement(...).
- TherapistStatement.ts interfaces match the API DTO 1:1 (camelCase, including isProForma and the empty servicePayments[]/ServicePaymentItem shape).
- StatementView retains the Caretaker flow verbatim — only its imports were updated for the renamed components.
- Tab bar is hidden in print so neither tab's chrome leaks into the PDF output.

Test scenarios: test-scenarios/wp-13c-therapist-statement.md (7 scenarios, including a Caretaker tab regression check).

Verification: vue-tsc and ESLint both pass with zero output. Live browser smoke-test was partial — the API requires the home-lab MySQL host which is off-LAN from the implementation environment, so end-to-end clicks against live data are pending; Vite dev-server confirmed all renamed/new modules compile and the SPA shell on /statements returns 200.