### PR TITLE
Remediation 2026 Chunk 3B: centralized UI error handling (references)

### DIFF
--- a/app-ui/src/App.vue
+++ b/app-ui/src/App.vue
@@ -1,11 +1,14 @@
 <template>
   <router-view />
+  <GlobalErrorToast />
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue';
+import GlobalErrorToast from './components/shared/GlobalErrorToast.vue';
 
 export default defineComponent({
   name: 'App',
+  components: { GlobalErrorToast },
 });
 </script>

--- a/app-ui/src/components/patients/PatientFormModal.vue
+++ b/app-ui/src/components/patients/PatientFormModal.vue
@@ -160,9 +160,7 @@
 
         <!-- Footer -->
         <div class="px-6 py-4 border-t border-slate-200 space-y-3">
-          <div v-if="error" class="rounded-lg bg-red-50 p-3 text-sm text-red-700">
-            {{ error }}
-          </div>
+          <FormErrorBanner :message="error" />
           <div class="flex items-center justify-end space-x-3">
             <button
               type="button"
@@ -173,7 +171,7 @@
             </button>
             <button
               type="button"
-              :disabled="saving || !!error"
+              :disabled="saving || hasError"
               class="px-4 py-2 rounded-lg text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 disabled:opacity-50"
               @click="handleSubmit"
             >
@@ -190,6 +188,8 @@
 import { defineComponent, reactive, ref, computed, watch, type PropType } from 'vue';
 import type { Patient } from '../../interfaces/Patient';
 import { isTemporaryMrn } from '../../interfaces/Patient';
+import { useFormError } from '../../composables/useFormError';
+import FormErrorBanner from '../shared/FormErrorBanner.vue';
 
 function parseName(patientName: string) {
   const [last, rest] = patientName.split(', ');
@@ -222,6 +222,7 @@ function formatDobForApi(dob: string): string {
 
 export default defineComponent({
   name: 'PatientFormModal',
+  components: { FormErrorBanner },
   props: {
     visible: { type: Boolean, required: true },
     patient: { type: Object as PropType<Patient | null>, default: null },
@@ -229,7 +230,7 @@ export default defineComponent({
   emits: ['close', 'saved', 'created-temp-mrn'],
   setup(props, { emit }) {
     const saving = ref(false);
-    const error = ref('');
+    const { message: error, hasError, setError, setFromException, clear: clearError } = useFormError();
 
     const form = reactive({
       firstName: '',
@@ -248,13 +249,13 @@ export default defineComponent({
     const hasTemporaryMrn = computed(() => isEdit.value && isTemporaryMrn(form.medicalRecordNumber));
     const cannotActivate = computed(() => hasTemporaryMrn.value && !form.activeStatus);
 
-    watch(form, () => { error.value = ''; }, { deep: true });
+    watch(form, () => clearError(), { deep: true });
 
     watch(
       () => props.visible,
       (val) => {
         if (!val) return;
-        error.value = '';
+        clearError();
         if (props.patient) {
           isEdit.value = true;
           const parsed = parseName(props.patient.patientName);
@@ -284,16 +285,16 @@ export default defineComponent({
 
     const handleSubmit = async () => {
       if (!form.firstName || !form.lastName || !form.dateOfBirth || !form.email || !form.phoneNumber || !form.gender) {
-        error.value = 'Please fill in all required fields.';
+        setError('Please fill in all required fields.');
         return;
       }
       saving.value = true;
-      error.value = '';
+      clearError();
       try {
         if (isEdit.value && props.patient) {
           // Validate: cannot activate with temporary MRN still in place
           if (form.activeStatus && isTemporaryMrn(form.medicalRecordNumber)) {
-            error.value = 'Cannot activate a patient with a temporary MRN. Assign a permanent MRN first.';
+            setError('Cannot activate a patient with a temporary MRN. Assign a permanent MRN first.');
             saving.value = false;
             return;
           }
@@ -349,13 +350,13 @@ export default defineComponent({
         emit('saved');
         emit('close');
       } catch (e: unknown) {
-        error.value = e instanceof Error ? e.message : 'An error occurred while saving.';
+        setFromException(e, 'An error occurred while saving.');
       } finally {
         saving.value = false;
       }
     };
 
-    return { form, isEdit, saving, error, hasTemporaryMrn, cannotActivate, handleSubmit };
+    return { form, isEdit, saving, error, hasError, hasTemporaryMrn, cannotActivate, handleSubmit };
   },
 });
 </script>

--- a/app-ui/src/components/shared/FormErrorBanner.vue
+++ b/app-ui/src/components/shared/FormErrorBanner.vue
@@ -1,0 +1,18 @@
+<template>
+  <div v-if="message" class="rounded-lg bg-red-50 p-3 text-sm text-red-700" role="alert">
+    {{ message }}
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+
+// Shared inline form-error banner — the standard red box used in modal/view footers. Pairs with
+// useFormError(): <FormErrorBanner :message="error" />. Renders nothing when message is empty.
+export default defineComponent({
+  name: 'FormErrorBanner',
+  props: {
+    message: { type: String, default: '' },
+  },
+});
+</script>

--- a/app-ui/src/components/shared/GlobalErrorToast.vue
+++ b/app-ui/src/components/shared/GlobalErrorToast.vue
@@ -1,0 +1,62 @@
+<template>
+  <div class="fixed top-4 right-4 z-[100] w-80 max-w-[90vw] space-y-2">
+    <transition-group name="toast">
+      <div
+        v-for="n in items"
+        :key="n.id"
+        :class="['flex items-start gap-2 rounded-lg px-4 py-3 text-sm shadow-md', kindClass(n.kind)]"
+        role="alert"
+      >
+        <span class="flex-1">{{ n.message }}</span>
+        <button
+          class="shrink-0 opacity-70 hover:opacity-100"
+          aria-label="Dismiss"
+          @click="dismiss(n.id)"
+        >
+          &times;
+        </button>
+      </div>
+    </transition-group>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { storeToRefs } from 'pinia';
+import { useNotificationsStore, type NotificationKind } from '../../stores/notifications';
+
+// Mounted once in App.vue. Renders the notifications store as stacked, auto-dismissing toasts.
+export default defineComponent({
+  name: 'GlobalErrorToast',
+  setup() {
+    const store = useNotificationsStore();
+    const { items } = storeToRefs(store);
+
+    const kindClass = (kind: NotificationKind): string => {
+      switch (kind) {
+        case 'success':
+          return 'bg-green-600 text-white';
+        case 'info':
+          return 'bg-slate-800 text-white';
+        case 'error':
+        default:
+          return 'bg-red-600 text-white';
+      }
+    };
+
+    return { items, dismiss: store.dismiss, kindClass };
+  },
+});
+</script>
+
+<style scoped>
+.toast-enter-active,
+.toast-leave-active {
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+.toast-enter-from,
+.toast-leave-to {
+  opacity: 0;
+  transform: translateX(1rem);
+}
+</style>

--- a/app-ui/src/composables/useFormError.ts
+++ b/app-ui/src/composables/useFormError.ts
@@ -1,0 +1,35 @@
+// composables/useFormError.ts
+//
+// Centralizes the per-form error pattern that was duplicated across ~35 views and modals:
+//   const error = ref('')
+//   try { ... } catch (e) { error.value = e instanceof Error ? e.message : 'fallback' }
+//   <div v-if="error" class="...red banner...">{{ error }}</div>
+//   :disabled="saving || !!error"
+//
+// Error state stays LOCAL to each form (two open modals must not share one error). This only
+// removes the boilerplate. Pair with <FormErrorBanner :message="error" /> for the display.
+// API messages already arrive as Error.message (HttpClientBase surfaces ProblemDetails detail/title
+// from Chunk 3A), so setFromException just needs the Error→string + fallback handling.
+
+import { computed, ref } from 'vue';
+
+export function useFormError() {
+  const message = ref('');
+  const hasError = computed(() => message.value.length > 0);
+
+  /** Set an explicit, app-authored message (e.g. client-side validation). */
+  function setError(text: string): void {
+    message.value = text;
+  }
+
+  /** Set the message from a caught error, falling back when it isn't an Error. */
+  function setFromException(error: unknown, fallback = 'An unexpected error occurred.'): void {
+    message.value = error instanceof Error && error.message ? error.message : fallback;
+  }
+
+  function clear(): void {
+    message.value = '';
+  }
+
+  return { message, hasError, setError, setFromException, clear };
+}

--- a/app-ui/src/main.ts
+++ b/app-ui/src/main.ts
@@ -3,6 +3,7 @@ import { createPinia } from 'pinia';
 import App from './App.vue';
 import router from './router';
 import { useAuthStore } from './stores/auth';
+import { useNotificationsStore } from './stores/notifications';
 import { authBridge } from './services/authBridge';
 import './assets/styles.css';
 import './tailwind.css';
@@ -15,12 +16,18 @@ app.use(router);
 // Wire the low-level HTTP client (via authBridge) to the auth store + router. Done here, where
 // both are available, to keep HttpClientBase free of store/router imports (avoids an import cycle).
 const auth = useAuthStore(pinia);
+const notifications = useNotificationsStore(pinia);
 authBridge.setAccessTokenGetter(() => auth.accessToken);
 authBridge.setRefreshFn(() => auth.refresh());
 authBridge.setOnUnauthorized(() => {
+  const wasAuthenticated = auth.isAuthenticated;
   auth.logout();
   if (router.currentRoute.value.name !== 'login') {
     router.push({ name: 'login', query: { redirect: router.currentRoute.value.fullPath } });
+  }
+  // Only message a real session expiry — not a failed login attempt on the login page.
+  if (wasAuthenticated) {
+    notifications.error('Your session has expired. Please sign in again.');
   }
 });
 authBridge.setOnForbidden((code) => {

--- a/app-ui/src/stores/notifications.ts
+++ b/app-ui/src/stores/notifications.ts
@@ -1,0 +1,53 @@
+// stores/notifications.ts
+//
+// App-level transient notifications (toasts) for errors/messages that aren't tied to a single form —
+// e.g. "your session has expired" on logout, or background failures. Form-field errors stay local
+// via useFormError(); this store is for cross-cutting, ephemeral messages surfaced by <GlobalErrorToast>.
+
+import { defineStore } from 'pinia';
+import { ref } from 'vue';
+
+export type NotificationKind = 'error' | 'success' | 'info';
+
+export interface AppNotification {
+  id: number;
+  kind: NotificationKind;
+  message: string;
+}
+
+const DEFAULT_DURATION_MS = 6000;
+
+export const useNotificationsStore = defineStore('notifications', () => {
+  const items = ref<AppNotification[]>([]);
+  let nextId = 0;
+
+  /** Add a notification; auto-dismisses after durationMs (pass 0 to make it sticky). Returns its id. */
+  function push(kind: NotificationKind, message: string, durationMs: number = DEFAULT_DURATION_MS): number {
+    const id = ++nextId;
+    items.value.push({ id, kind, message });
+    if (durationMs > 0) {
+      setTimeout(() => dismiss(id), durationMs);
+    }
+    return id;
+  }
+
+  function error(message: string, durationMs?: number): number {
+    return push('error', message, durationMs);
+  }
+  function success(message: string, durationMs?: number): number {
+    return push('success', message, durationMs);
+  }
+  function info(message: string, durationMs?: number): number {
+    return push('info', message, durationMs);
+  }
+
+  function dismiss(id: number): void {
+    items.value = items.value.filter((n) => n.id !== id);
+  }
+
+  function clear(): void {
+    items.value = [];
+  }
+
+  return { items, push, error, success, info, dismiss, clear };
+});

--- a/app-ui/src/views/PatientsView.vue
+++ b/app-ui/src/views/PatientsView.vue
@@ -99,6 +99,7 @@ import { PatientsHttpClient } from '../services/PatientsHttpClient';
 import type { Patient } from '../interfaces/Patient';
 import { isTemporaryMrn } from '../interfaces/Patient';
 import type { DelinquentPatient } from '../interfaces/Delinquency';
+import { useFormError } from '../composables/useFormError';
 
 export default defineComponent({
   name: 'PatientsView',
@@ -116,7 +117,7 @@ export default defineComponent({
     });
     const patients = ref<Patient[]>([]);
     const loading = ref(false);
-    const error = ref('');
+    const { message: error, setError, setFromException, clear: clearError } = useFormError();
     const modalVisible = ref(false);
     const editingPatient = ref<Patient | null>(null);
     const tempMrnBanner = ref('');
@@ -128,11 +129,11 @@ export default defineComponent({
 
     const loadPatients = async () => {
       loading.value = true;
-      error.value = '';
+      clearError();
       try {
         patients.value = await client.getPatients();
       } catch (e: unknown) {
-        error.value = e instanceof Error ? e.message : 'Failed to load patients.';
+        setFromException(e, 'Failed to load patients.');
       } finally {
         loading.value = false;
       }
@@ -151,7 +152,7 @@ export default defineComponent({
     const toggleActive = async (patient: Patient) => {
       // Guard: cannot activate a patient with a temporary MRN
       if (!patient.isActive && isTemporaryMrn(patient.medicalRecordNumber)) {
-        error.value = 'Cannot activate a patient with a temporary MRN. Edit the patient to assign a permanent MRN first.';
+        setError('Cannot activate a patient with a temporary MRN. Edit the patient to assign a permanent MRN first.');
         return;
       }
       try {
@@ -169,7 +170,7 @@ export default defineComponent({
         await loadPatients();
         pastDueLoaded.value = false;
       } catch (e: unknown) {
-        error.value = e instanceof Error ? e.message : 'Failed to update patient status.';
+        setFromException(e, 'Failed to update patient status.');
       }
     };
 
@@ -179,7 +180,7 @@ export default defineComponent({
         pastDuePatients.value = await client.getPastDuePatients();
         pastDueLoaded.value = true;
       } catch (e: unknown) {
-        error.value = e instanceof Error ? e.message : 'Failed to load delinquent patients.';
+        setFromException(e, 'Failed to load delinquent patients.');
       }
     };
 

--- a/test-scenarios/remediation-3b-ui-errors.md
+++ b/test-scenarios/remediation-3b-ui-errors.md
@@ -1,0 +1,52 @@
+# Test Scenarios — Remediation 2026 Chunk 3B (UI Centralized Error Handling)
+
+Branch: `feature/remediation-2026-3b-ui-errors`
+
+## What changed
+- **`useFormError()` composable** + **`<FormErrorBanner>`** — centralizes the per-form error pattern
+  (local `error` ref + `e.message` extraction + red banner + "disable save while error"). Forms keep
+  their own local error state; only the boilerplate is shared.
+- **`notifications` Pinia store** + **`<GlobalErrorToast>`** (mounted once in `App.vue`) — app-level
+  transient toasts for cross-cutting messages.
+- **Auth integration**: a real session expiry (401 with no recoverable refresh) now shows a global
+  toast "Your session has expired. Please sign in again." on redirect to login.
+- **Reference migrations**: `PatientFormModal` (modal) and `PatientsView` (view) now use the new
+  mechanism — with **identical UX** to before (same inline red banner, same disable-save behavior).
+
+## Prerequisites
+- API (1B/3A) on `http://neurocorp.k3s:30000`; UI dev server `npm run dev` → `http://localhost:8080`.
+- Logged in (see 1C scenarios).
+
+## Scenarios
+
+### 1. Form error banner still works (PatientFormModal) — no UX regression
+1. Patients → Add Patient. Submit with a required field blank.
+2. **Expect:** red banner "Please fill in all required fields." in the modal footer; **Save disabled**
+   while the banner shows; editing a field clears it. (Same as before — now powered by `useFormError`.)
+
+### 2. API error surfaces in the form banner
+1. Trigger a server-side rejection (e.g. duplicate email on create).
+2. **Expect:** the banner shows the API's `ProblemDetails.detail` message (via `HttpClientBase` →
+   `e.message` → `setFromException`). Save disabled until corrected.
+
+### 3. View-level error (PatientsView)
+1. Stop the API (or simulate a failed load) and open Patients.
+2. **Expect:** the existing inline error surface shows "Failed to load patients." (now via
+   `useFormError`, same display).
+
+### 4. Global toast on session expiry
+1. While logged in, invalidate the session (clear `pc_refresh_token` in localStorage and let the
+   access token expire, or stop the API key) and trigger any API call.
+2. **Expect:** redirect to `/login` **and** a red toast top-right: "Your session has expired. Please
+   sign in again.", auto-dismissing after a few seconds (dismissable via ×).
+3. A failed **login attempt** (wrong password) must **not** trigger the global toast (only the login
+   form's own error) — the toast is for expiry of an *authenticated* session.
+
+## Automated checks
+- `npx vue-tsc --noEmit` — clean.
+- `npm run lint` — clean.
+- `npm run build` — succeeds.
+
+## Not in scope (tracked follow-up)
+The remaining ~33 views/modals still use local `error` refs. Migrating them to `useFormError` /
+`<FormErrorBanner>` is a tracked follow-up sweep (see the 3B sub-plan Completion section).


### PR DESCRIPTION
Introduce shared error-handling infrastructure and migrate one modal + one view as reference implementations (per-chunk scope; remaining components tracked as a follow-up sweep).

- useFormError() composable + <FormErrorBanner>: centralizes the per-form pattern (local error ref + Error->message extraction + red banner + disable-save). Forms keep local error state (two modals must not share one error); only boilerplate is shared. Consumes 3A's ProblemDetails via HttpClientBase's Error.message.
- notifications Pinia store + <GlobalErrorToast> (mounted in App.vue): app-level transient toasts for cross-cutting messages.
- Auth integration: a real session expiry (401) now surfaces a global toast "Your session has expired..." on redirect to login — wiring authBridge's onUnauthorized through the store (only when previously authenticated, so a failed login attempt does not toast).
- Reference migrations: PatientFormModal + PatientsView, with identical UX.

Verification: test-scenarios/remediation-3b-ui-errors.md. vue-tsc / lint / build all clean.