### PR TITLE
Remediation 2026 Chunk 6: shared form-modal infrastructure (useModalF…

### DIFF
--- a/app-ui/src/components/caretakers/CaretakerFormModal.vue
+++ b/app-ui/src/components/caretakers/CaretakerFormModal.vue
@@ -107,9 +107,7 @@
 
         <!-- Footer -->
         <div class="px-6 py-4 border-t border-slate-200 space-y-3">
-          <div v-if="error" class="rounded-lg bg-red-50 p-3 text-sm text-red-700">
-            {{ error }}
-          </div>
+          <FormErrorBanner :message="error" />
           <div class="flex items-center justify-end space-x-3">
             <button
               type="button"
@@ -120,7 +118,7 @@
             </button>
             <button
               type="button"
-              :disabled="saving || !!error"
+              :disabled="saving || hasError"
               class="px-4 py-2 rounded-lg text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 disabled:opacity-50"
               @click="handleSubmit"
             >
@@ -136,6 +134,9 @@
 <script lang="ts">
 import { defineComponent, reactive, ref, watch, type PropType } from 'vue';
 import type { Caretaker } from '../../interfaces/Caretaker';
+import { CaretakersHttpClient } from '../../services/CaretakersHttpClient';
+import { useModalForm } from '../../composables/useModalForm';
+import FormErrorBanner from '../shared/FormErrorBanner.vue';
 
 function parseName(caretakerName: string) {
   const [last, rest] = caretakerName.split(', ');
@@ -145,14 +146,14 @@ function parseName(caretakerName: string) {
 
 export default defineComponent({
   name: 'CaretakerFormModal',
+  components: { FormErrorBanner },
   props: {
     visible: { type: Boolean, required: true },
     caretaker: { type: Object as PropType<Caretaker | null>, default: null },
   },
   emits: ['close', 'saved'],
   setup(props, { emit }) {
-    const saving = ref(false);
-    const error = ref('');
+    const { error, hasError, saving, setError, clearError, submit } = useModalForm();
 
     const form = reactive({
       firstName: '',
@@ -166,13 +167,13 @@ export default defineComponent({
 
     const isEdit = ref(false);
 
-    watch(form, () => { error.value = ''; }, { deep: true });
+    watch(form, () => clearError(), { deep: true });
 
     watch(
       () => props.visible,
       (val) => {
         if (!val) return;
-        error.value = '';
+        clearError();
         if (props.caretaker) {
           isEdit.value = true;
           const parsed = parseName(props.caretaker.caretakerName);
@@ -196,15 +197,12 @@ export default defineComponent({
       }
     );
 
-    const handleSubmit = async () => {
+    const handleSubmit = () => {
       if (!form.firstName || !form.lastName || !form.email || !form.phoneNumber) {
-        error.value = 'Please fill in all required fields.';
+        setError('Please fill in all required fields.');
         return;
       }
-      saving.value = true;
-      error.value = '';
-      try {
-        const { CaretakersHttpClient } = await import('../../services/CaretakersHttpClient');
+      return submit(async () => {
         const client = new CaretakersHttpClient();
         if (isEdit.value && props.caretaker) {
           await client.updateCaretaker(props.caretaker.caretakerId, {
@@ -229,14 +227,10 @@ export default defineComponent({
         }
         emit('saved');
         emit('close');
-      } catch (e: unknown) {
-        error.value = e instanceof Error ? e.message : 'An error occurred while saving.';
-      } finally {
-        saving.value = false;
-      }
+      });
     };
 
-    return { form, isEdit, saving, error, handleSubmit };
+    return { form, isEdit, saving, error, hasError, handleSubmit };
   },
 });
 </script>

--- a/app-ui/src/components/patients/PatientFormModal.vue
+++ b/app-ui/src/components/patients/PatientFormModal.vue
@@ -188,8 +188,9 @@
 import { defineComponent, reactive, ref, computed, watch, type PropType } from 'vue';
 import type { Patient } from '../../interfaces/Patient';
 import { isTemporaryMrn } from '../../interfaces/Patient';
-import { useFormError } from '../../composables/useFormError';
+import { useModalForm } from '../../composables/useModalForm';
 import FormErrorBanner from '../shared/FormErrorBanner.vue';
+import { PatientsHttpClient } from '../../services/PatientsHttpClient';
 
 function parseName(patientName: string) {
   const [last, rest] = patientName.split(', ');
@@ -229,8 +230,7 @@ export default defineComponent({
   },
   emits: ['close', 'saved', 'created-temp-mrn'],
   setup(props, { emit }) {
-    const saving = ref(false);
-    const { message: error, hasError, setError, setFromException, clear: clearError } = useFormError();
+    const { error, hasError, saving, setError, clearError, submit } = useModalForm();
 
     const form = reactive({
       firstName: '',
@@ -283,23 +283,19 @@ export default defineComponent({
       }
     );
 
-    const handleSubmit = async () => {
+    const handleSubmit = () => {
       if (!form.firstName || !form.lastName || !form.dateOfBirth || !form.email || !form.phoneNumber || !form.gender) {
         setError('Please fill in all required fields.');
         return;
       }
-      saving.value = true;
-      clearError();
-      try {
+      // Cannot activate a patient while a temporary MRN is still in place.
+      if (isEdit.value && props.patient && form.activeStatus && isTemporaryMrn(form.medicalRecordNumber)) {
+        setError('Cannot activate a patient with a temporary MRN. Assign a permanent MRN first.');
+        return;
+      }
+      return submit(async () => {
+        const client = new PatientsHttpClient();
         if (isEdit.value && props.patient) {
-          // Validate: cannot activate with temporary MRN still in place
-          if (form.activeStatus && isTemporaryMrn(form.medicalRecordNumber)) {
-            setError('Cannot activate a patient with a temporary MRN. Assign a permanent MRN first.');
-            saving.value = false;
-            return;
-          }
-          const { PatientsHttpClient } = await import('../../services/PatientsHttpClient');
-          const client = new PatientsHttpClient();
           const originalMrn = props.patient.medicalRecordNumber || '';
           const assigningPermanentMrn = isTemporaryMrn(originalMrn) && form.medicalRecordNumber && !isTemporaryMrn(form.medicalRecordNumber);
           const baseFields = {
@@ -331,8 +327,6 @@ export default defineComponent({
             });
           }
         } else {
-          const { PatientsHttpClient } = await import('../../services/PatientsHttpClient');
-          const client = new PatientsHttpClient();
           const created = await client.createPatient({
             firstName: form.firstName,
             middleName: form.middleName || undefined,
@@ -349,11 +343,7 @@ export default defineComponent({
         }
         emit('saved');
         emit('close');
-      } catch (e: unknown) {
-        setFromException(e, 'An error occurred while saving.');
-      } finally {
-        saving.value = false;
-      }
+      });
     };
 
     return { form, isEdit, saving, error, hasError, hasTemporaryMrn, cannotActivate, handleSubmit };

--- a/app-ui/src/components/therapists/TherapistFormModal.vue
+++ b/app-ui/src/components/therapists/TherapistFormModal.vue
@@ -199,9 +199,7 @@
 
         <!-- Footer -->
         <div class="px-6 py-4 border-t border-slate-200 space-y-3">
-          <div v-if="error" class="rounded-lg bg-red-50 p-3 text-sm text-red-700">
-            {{ error }}
-          </div>
+          <FormErrorBanner :message="error" />
           <div class="flex items-center justify-end space-x-3">
             <button
               type="button"
@@ -212,7 +210,7 @@
             </button>
             <button
               type="button"
-              :disabled="saving || !!error"
+              :disabled="saving || hasError"
               class="px-4 py-2 rounded-lg text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 disabled:opacity-50"
               @click="handleSubmit"
             >
@@ -229,6 +227,10 @@
 import { defineComponent, reactive, ref, watch, type PropType } from 'vue';
 import type { Therapist } from '../../interfaces/Therapist';
 import type { LookupItem } from '../../interfaces/Lookups';
+import { TherapistsHttpClient } from '../../services/TherapistsHttpClient';
+import { LookupHttpClient } from '../../services/LookupHttpClient';
+import { useModalForm } from '../../composables/useModalForm';
+import FormErrorBanner from '../shared/FormErrorBanner.vue';
 
 function parseName(therapistName: string) {
   const [last, rest] = therapistName.split(', ');
@@ -238,14 +240,14 @@ function parseName(therapistName: string) {
 
 export default defineComponent({
   name: 'TherapistFormModal',
+  components: { FormErrorBanner },
   props: {
     visible: { type: Boolean, required: true },
     therapist: { type: Object as PropType<Therapist | null>, default: null },
   },
   emits: ['close', 'saved'],
   setup(props, { emit }) {
-    const saving = ref(false);
-    const error = ref('');
+    const { error, hasError, saving, setError, clearError, submit } = useModalForm();
     const specialtyError = ref('');
 
     const profileSectionOpen = ref(true);
@@ -284,7 +286,6 @@ export default defineComponent({
     const loadSpecialtyOptions = async () => {
       loadingSpecialties.value = true;
       try {
-        const { LookupHttpClient } = await import('../../services/LookupHttpClient');
         const client = new LookupHttpClient();
         specialtyOptions.value = await client.getAll('specialty-types');
       } catch {
@@ -294,14 +295,14 @@ export default defineComponent({
       }
     };
 
-    watch(form, () => { error.value = ''; }, { deep: true });
-    watch(selectedSpecialtyIds, () => { error.value = ''; specialtyError.value = ''; }, { deep: true });
+    watch(form, () => clearError(), { deep: true });
+    watch(selectedSpecialtyIds, () => { clearError(); specialtyError.value = ''; }, { deep: true });
 
     watch(
       () => props.visible,
       (val) => {
         if (!val) return;
-        error.value = '';
+        clearError();
         specialtyError.value = '';
         profileSectionOpen.value = true;
         specialtiesSectionOpen.value = true;
@@ -337,20 +338,17 @@ export default defineComponent({
       }
     );
 
-    const handleSubmit = async () => {
+    const handleSubmit = () => {
       if (!form.firstName || !form.lastName || !form.email || !form.phoneNumber) {
-        error.value = 'Please fill in all required fields.';
+        setError('Please fill in all required fields.');
         return;
       }
       if (selectedSpecialtyIds.value.size === 0) {
         specialtyError.value = 'At least one specialty is required.';
         return;
       }
-      saving.value = true;
-      error.value = '';
       specialtyError.value = '';
-      try {
-        const { TherapistsHttpClient } = await import('../../services/TherapistsHttpClient');
+      return submit(async () => {
         const client = new TherapistsHttpClient();
         const specialtyIds = Array.from(selectedSpecialtyIds.value);
         if (isEdit.value && props.therapist) {
@@ -379,11 +377,7 @@ export default defineComponent({
         }
         emit('saved');
         emit('close');
-      } catch (e: unknown) {
-        error.value = e instanceof Error ? e.message : 'An error occurred while saving.';
-      } finally {
-        saving.value = false;
-      }
+      });
     };
 
     return {
@@ -391,6 +385,7 @@ export default defineComponent({
       isEdit,
       saving,
       error,
+      hasError,
       specialtyError,
       profileSectionOpen,
       specialtiesSectionOpen,

--- a/app-ui/src/composables/useModalForm.ts
+++ b/app-ui/src/composables/useModalForm.ts
@@ -1,0 +1,40 @@
+// composables/useModalForm.ts
+//
+// Shared form-modal plumbing (Chunk 6). Wraps useFormError (Chunk 3B) plus the `saving` flag and the
+// repetitive submit flow that every form modal had:
+//   saving=true → clear error → try { ...save... } catch → setFromException → finally saving=false
+//
+// Usage:
+//   const { error, hasError, saving, setError, clearError, submit } = useModalForm();
+//   const handleSubmit = () => {
+//     if (!valid) { setError('Please fill in all required fields.'); return; }   // validate first
+//     return submit(async () => {
+//       await client.save(...);           // static-imported client
+//       emit('saved'); emit('close');
+//     });
+//   };
+// Pair with <FormErrorBanner :message="error" /> and :disabled="saving || hasError".
+
+import { ref } from 'vue';
+import { useFormError } from './useFormError';
+
+export function useModalForm() {
+  const { message: error, hasError, setError, setFromException, clear } = useFormError();
+  const saving = ref(false);
+
+  /** Run a save action inside the standard modal flow. Re-entrant calls while saving are ignored. */
+  async function submit(action: () => Promise<void>, fallback = 'An error occurred while saving.'): Promise<void> {
+    if (saving.value) return;
+    clear();
+    saving.value = true;
+    try {
+      await action();
+    } catch (e) {
+      setFromException(e, fallback);
+    } finally {
+      saving.value = false;
+    }
+  }
+
+  return { error, hasError, saving, setError, clearError: clear, submit };
+}

--- a/test-scenarios/remediation-6-ui-cleanup.md
+++ b/test-scenarios/remediation-6-ui-cleanup.md
@@ -1,0 +1,45 @@
+# Test Scenarios — Remediation 2026 Chunk 6 (UI Structural Cleanup)
+
+Branch: `feature/remediation-2026-6-ui-cleanup`
+
+## What changed
+- **`useModalForm()` composable** — wraps `useFormError` (3B) + a `saving` flag + a `submit(action)`
+  helper that runs the standard modal save flow (clear error → saving=true → try action → catch →
+  `setFromException` → finally saving=false). Removes the repetitive try/catch/finally boilerplate.
+- **Static HTTP-client imports** — all 5 dynamic `await import('../../services/XxxHttpClient')` calls
+  inside submit handlers (and the Therapist specialty loader) replaced with top-of-file static imports.
+- **Reference migrations:** `PatientFormModal`, `TherapistFormModal`, `CaretakerFormModal` now use
+  `useModalForm` + `<FormErrorBanner>` + static imports — **identical UX** to before.
+
+## Scenarios (no UX regression expected)
+
+### 1. Caretaker add/edit
+1. Caretakers → Add Caretaker; submit with a required field blank → red banner "Please fill in all
+   required fields.", **Save disabled** while shown; editing a field clears it.
+2. Fill valid data → saves, modal closes, list refreshes. Edit an existing caretaker → same.
+3. Trigger a server error (e.g. duplicate email) → banner shows the API message (`ProblemDetails.detail`).
+
+### 2. Patient add/edit (incl. the temp-MRN guard)
+1. Add/edit a patient → same banner + disable-save behavior.
+2. Edit a patient with a **temporary MRN** and toggle Active on → banner "Cannot activate a patient
+   with a temporary MRN…" appears **without** hitting the API (pre-submit validation).
+3. Assign a permanent MRN + activate → two-step update still works (no behavior change).
+
+### 3. Therapist add/edit (incl. specialty validation)
+1. Add a therapist with no specialty selected → "At least one specialty is required." under the
+   specialty section; selecting one clears it.
+2. Required-field-blank → main banner. Valid → saves; specialty options still load on open
+   (now via static `LookupHttpClient`).
+
+### 4. Save button + concurrency
+- In all three, the Save button is disabled while `saving` or while an error banner is shown; a
+  double-click cannot fire two saves (`submit()` ignores re-entrant calls while saving).
+
+## Automated checks
+- `npx vue-tsc --noEmit` — clean.
+- `npm run lint` — clean.
+- `npm run build` — succeeds; **no `await import()` of HTTP clients** remains in the migrated modals.
+
+## Not in scope (tracked follow-up)
+The remaining 5 form modals (`Site`, `Payment`, `TreatmentPlan`, `Booking`, `Lookup`) still use local
+form state. Migrating them to `useModalForm` is a tracked follow-up sweep (see the Chunk 6 sub-plan).


### PR DESCRIPTION
…orm)

Reduce form-modal duplication and eliminate dynamic HTTP-client imports (references).

- useModalForm() composable: wraps useFormError (3B) + a saving flag + a submit(action) helper running the standard flow (clear error -> saving=true -> try -> catch setFromException -> finally saving=false). Modals shrink to validate -> submit(...).
- Replace all 5 dynamic `await import('../../services/XxxHttpClient')` calls with static top-of-file imports.
- Reference migrations (the 3 modals that had dynamic imports): PatientFormModal, TherapistFormModal, CaretakerFormModal -> useModalForm + <FormErrorBanner> + static imports. Identical UX (validate-before-saving, disable-save, error-in-footer); the Patient temp-MRN activation guard moved to pre-submit validation (equivalent behavior).
- Composable over a BaseFormModal component (evolutionary, preserves each modal's template).

Scope: references only (3 of 8 modals). Remaining 5 (Site/Payment/TreatmentPlan/Booking/ Lookup) tracked as a follow-up sweep. Verification: test-scenarios/remediation-6-ui-cleanup.md. vue-tsc / lint / build all clean; no dynamic HTTP-client imports remain in the migrated modals.