### PR TITLE
fix(tsconfig): drop deprecated baseUrl; use relative paths mapping

### DIFF
--- a/app-ui/tsconfig.json
+++ b/app-ui/tsconfig.json
@@ -10,9 +10,8 @@
     "skipLibCheck": true,
     "allowSyntheticDefaultImports": true,
     "sourceMap": true,
-    "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["./src/*"]
     },
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "types": ["vite/client"]


### PR DESCRIPTION
Under moduleResolution: "bundler" (TS 5.x), `paths` resolve relative to the tsconfig without `baseUrl`, which the editor flagged as deprecated. Remove `baseUrl` and make the `@/*` mapping relative (./src/*). The `@` alias is also defined in vite.config.ts for runtime resolution; no `@/` imports exist in the codebase today, so this is zero-risk. vue-tsc --noEmit passes clean.