### PR TITLE
Chunk 6 follow-up: modal sweep — migrate Site/Payment/Lookup to share…

### DIFF
--- a/app-ui/src/components/admin/LookupFormModal.vue
+++ b/app-ui/src/components/admin/LookupFormModal.vue
@@ -45,9 +45,7 @@
 
         <!-- Footer -->
         <div class="px-6 py-4 border-t border-slate-200 space-y-3">
-          <div v-if="error" class="rounded-lg bg-red-50 p-3 text-sm text-red-700">
-            {{ error }}
-          </div>
+          <FormErrorBanner :message="error" />
           <div class="flex items-center justify-end space-x-3">
             <button
               type="button"
@@ -58,7 +56,7 @@
             </button>
             <button
               type="button"
-              :disabled="saving || !!error"
+              :disabled="saving || hasError"
               class="px-4 py-2 rounded-lg text-sm font-medium text-white bg-violet-600 hover:bg-violet-700 disabled:opacity-50"
               @click="handleSubmit"
             >
@@ -73,6 +71,8 @@
 
 <script lang="ts">
 import { defineComponent, reactive, ref, watch, type PropType } from 'vue';
+import { useFormError } from '../../composables/useFormError';
+import FormErrorBanner from '../shared/FormErrorBanner.vue';
 
 export interface FieldDef {
   key: string;
@@ -82,8 +82,11 @@ export interface FieldDef {
   type?: string;
 }
 
+// This modal delegates the actual save to its parent via emit('submit', …), so it doesn't do its own
+// async call — hence useFormError (validation + shared banner) rather than the full useModalForm.
 export default defineComponent({
   name: 'LookupFormModal',
+  components: { FormErrorBanner },
   props: {
     visible: { type: Boolean, required: true },
     title: { type: String, required: true },
@@ -94,50 +97,45 @@ export default defineComponent({
   emits: ['close', 'submit'],
   setup(props, { emit }) {
     const saving = ref(false);
-    const error = ref('');
+    const { message: error, hasError, setError, clear: clearError } = useFormError();
     const formData = reactive<Record<string, string | number>>({});
 
-    watch(formData, () => { error.value = ''; }, { deep: true });
+    watch(formData, () => clearError(), { deep: true });
 
     watch(
       () => props.visible,
       (val) => {
         if (!val) return;
-        error.value = '';
+        clearError();
         for (const field of props.fields) {
           formData[field.key] = props.initialValues?.[field.key] ?? '';
         }
       }
     );
 
-    const handleSubmit = async () => {
+    const handleSubmit = () => {
       // Validate required fields
       for (const field of props.fields) {
         const val = formData[field.key];
         if (field.required && (val === undefined || val === null || String(val).trim() === '')) {
-          error.value = `${field.label} is required.`;
+          setError(`${field.label} is required.`);
           return;
         }
       }
 
       saving.value = true;
-      error.value = '';
-      try {
-        const data: Record<string, string | number> = {};
-        for (const field of props.fields) {
-          const val = formData[field.key];
-          if (val === undefined || val === null || String(val).trim() === '') continue;
-          data[field.key] = field.type === 'number' ? Number(val) : String(val).trim();
-        }
-        emit('submit', data);
-      } catch (e: unknown) {
-        error.value = e instanceof Error ? e.message : 'An error occurred while saving.';
-      } finally {
-        saving.value = false;
+      clearError();
+      const data: Record<string, string | number> = {};
+      for (const field of props.fields) {
+        const val = formData[field.key];
+        if (val === undefined || val === null || String(val).trim() === '') continue;
+        data[field.key] = field.type === 'number' ? Number(val) : String(val).trim();
       }
+      emit('submit', data);
+      saving.value = false;
     };
 
-    return { formData, saving, error, handleSubmit };
+    return { formData, saving, error, hasError, handleSubmit };
   },
 });
 </script>

--- a/app-ui/src/components/payments/PaymentFormModal.vue
+++ b/app-ui/src/components/payments/PaymentFormModal.vue
@@ -187,9 +187,7 @@
 
         <!-- Footer -->
         <div class="px-6 py-4 border-t border-slate-200 space-y-3">
-          <div v-if="error" class="rounded-lg bg-red-50 p-3 text-sm text-red-700">
-            {{ error }}
-          </div>
+          <FormErrorBanner :message="error" />
           <div class="flex items-center justify-between">
           <div>
             <button
@@ -220,7 +218,7 @@
             <button
               v-if="step === 2"
               type="button"
-              :disabled="saving || !isFullyAllocated || !!error"
+              :disabled="saving || !isFullyAllocated || hasError"
               class="px-4 py-2 rounded-lg text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 disabled:opacity-50"
               :title="!isFullyAllocated ? 'Payment must be fully allocated before saving' : ''"
               @click="handleSubmit"
@@ -241,9 +239,12 @@ import type { PaymentRecord, PaymentTypeInfo, UnpaidSessionSummary, SessionAlloc
 import type { Caretaker } from '../../interfaces/Caretaker';
 import { PaymentsHttpClient } from '../../services/PaymentsHttpClient';
 import { CaretakersHttpClient } from '../../services/CaretakersHttpClient';
+import { useModalForm } from '../../composables/useModalForm';
+import FormErrorBanner from '../shared/FormErrorBanner.vue';
 
 export default defineComponent({
   name: 'PaymentFormModal',
+  components: { FormErrorBanner },
   props: {
     visible: { type: Boolean, required: true },
     payment: { type: Object as PropType<PaymentRecord | null>, default: null },
@@ -255,8 +256,7 @@ export default defineComponent({
     const caretakersClient = new CaretakersHttpClient();
 
     const step = ref(1);
-    const saving = ref(false);
-    const error = ref('');
+    const { error, hasError, saving, setError, setFromException, clearError, submit } = useModalForm();
     const loadingSessions = ref(false);
 
     const caretakers = ref<Caretaker[]>([]);
@@ -334,7 +334,7 @@ export default defineComponent({
         caretakers.value = cts.sort((a, b) => a.caretakerName.localeCompare(b.caretakerName));
         paymentTypes.value = pts;
       } catch (e: unknown) {
-        error.value = e instanceof Error ? e.message : 'Failed to load reference data.';
+        setFromException(e, 'Failed to load reference data.');
       }
     };
 
@@ -344,7 +344,7 @@ export default defineComponent({
       try {
         unpaidSessions.value = await paymentsClient.getUnpaidSessions(form.caretakerId);
       } catch (e: unknown) {
-        error.value = e instanceof Error ? e.message : 'Failed to load unpaid sessions.';
+        setFromException(e, 'Failed to load unpaid sessions.');
       } finally {
         loadingSessions.value = false;
       }
@@ -359,28 +359,26 @@ export default defineComponent({
     };
 
     const goToStep2 = () => {
-      error.value = '';
+      clearError();
       if (!form.caretakerId) {
-        error.value = 'Please select a caretaker.';
+        setError('Please select a caretaker.');
         return;
       }
       if (form.amount <= 0) {
-        error.value = 'Amount must be greater than zero.';
+        setError('Amount must be greater than zero.');
         return;
       }
       if (!form.paymentTypeId) {
-        error.value = 'Please select a payment type.';
+        setError('Please select a payment type.');
         return;
       }
       step.value = 2;
       loadUnpaidSessions();
     };
 
-    const handleSubmit = async () => {
-      error.value = '';
-
+    const handleSubmit = () => {
       if (!isFullyAllocated.value) {
-        error.value = `Payment must be fully allocated. Allocated: $${totalAllocated.value.toFixed(2)}, Payment: $${form.amount.toFixed(2)}.`;
+        setError(`Payment must be fully allocated. Allocated: $${totalAllocated.value.toFixed(2)}, Payment: $${form.amount.toFixed(2)}.`);
         return;
       }
 
@@ -391,8 +389,7 @@ export default defineComponent({
           amountAllocated: amount,
         }));
 
-      saving.value = true;
-      try {
+      return submit(async () => {
         const requestData = {
           amount: form.amount,
           paymentDate: new Date(form.paymentDate).toISOString(),
@@ -409,20 +406,16 @@ export default defineComponent({
         }
         emit('saved');
         emit('close');
-      } catch (e: unknown) {
-        error.value = e instanceof Error ? e.message : 'An error occurred while saving.';
-      } finally {
-        saving.value = false;
-      }
+      });
     };
 
-    watch(form, () => { error.value = ''; }, { deep: true });
+    watch(form, () => clearError(), { deep: true });
 
     watch(
       () => props.visible,
       (val) => {
         if (!val) return;
-        error.value = '';
+        clearError();
         step.value = 1;
 
         // Clear allocations
@@ -458,6 +451,7 @@ export default defineComponent({
       step,
       saving,
       error,
+      hasError,
       loadingSessions,
       caretakers,
       paymentTypes,

--- a/app-ui/src/components/sites/SiteFormModal.vue
+++ b/app-ui/src/components/sites/SiteFormModal.vue
@@ -90,9 +90,7 @@
 
         <!-- Footer -->
         <div class="px-6 py-4 border-t border-slate-200 space-y-3">
-          <div v-if="error" class="rounded-lg bg-red-50 p-3 text-sm text-red-700">
-            {{ error }}
-          </div>
+          <FormErrorBanner :message="error" />
           <div class="flex items-center justify-end space-x-3">
             <button
               type="button"
@@ -103,7 +101,7 @@
             </button>
             <button
               type="button"
-              :disabled="saving || !!error"
+              :disabled="saving || hasError"
               class="px-4 py-2 rounded-lg text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 disabled:opacity-50"
               @click="handleSubmit"
             >
@@ -120,6 +118,8 @@
 import { defineComponent, reactive, ref, watch, type PropType } from 'vue';
 import type { Site } from '../../interfaces/Site';
 import { SitesHttpClient } from '../../services/SitesHttpClient';
+import { useModalForm } from '../../composables/useModalForm';
+import FormErrorBanner from '../shared/FormErrorBanner.vue';
 
 function formatDateForInput(dateStr: string): string {
   if (!dateStr) return '';
@@ -133,14 +133,14 @@ function formatDateForInput(dateStr: string): string {
 
 export default defineComponent({
   name: 'SiteFormModal',
+  components: { FormErrorBanner },
   props: {
     visible: { type: Boolean, required: true },
     site: { type: Object as PropType<Site | null>, default: null },
   },
   emits: ['close', 'saved'],
   setup(props, { emit }) {
-    const saving = ref(false);
-    const error = ref('');
+    const { error, hasError, saving, setError, clearError, submit } = useModalForm();
     const client = new SitesHttpClient();
 
     const form = reactive({
@@ -154,13 +154,13 @@ export default defineComponent({
 
     const isEdit = ref(false);
 
-    watch(form, () => { error.value = ''; }, { deep: true });
+    watch(form, () => clearError(), { deep: true });
 
     watch(
       () => props.visible,
       (val) => {
         if (!val) return;
-        error.value = '';
+        clearError();
         if (props.site) {
           isEdit.value = true;
           form.siteName = props.site.siteName;
@@ -181,14 +181,12 @@ export default defineComponent({
       }
     );
 
-    const handleSubmit = async () => {
+    const handleSubmit = () => {
       if (!form.siteName || !form.inceptionDate) {
-        error.value = 'Please fill in all required fields.';
+        setError('Please fill in all required fields.');
         return;
       }
-      saving.value = true;
-      error.value = '';
-      try {
+      return submit(async () => {
         const data = {
           siteName: form.siteName,
           ruc: form.ruc || undefined,
@@ -205,14 +203,10 @@ export default defineComponent({
         }
         emit('saved');
         emit('close');
-      } catch (e: unknown) {
-        error.value = e instanceof Error ? e.message : 'An error occurred while saving.';
-      } finally {
-        saving.value = false;
-      }
+      });
     };
 
-    return { form, isEdit, saving, error, handleSubmit };
+    return { form, isEdit, saving, error, hasError, handleSubmit };
   },
 });
 </script>

--- a/app-ui/src/composables/useModalForm.ts
+++ b/app-ui/src/composables/useModalForm.ts
@@ -36,5 +36,5 @@ export function useModalForm() {
     }
   }
 
-  return { error, hasError, saving, setError, clearError: clear, submit };
+  return { error, hasError, saving, setError, setFromException, clearError: clear, submit };
 }

--- a/test-scenarios/remediation-6b-modal-sweep.md
+++ b/test-scenarios/remediation-6b-modal-sweep.md
@@ -1,0 +1,33 @@
+# Test Scenarios — Chunk 6 follow-up: modal sweep
+
+Branch: `feature/remediation-2026-6b-modal-sweep`
+
+Consolidates remaining form modals onto the shared error/form infrastructure (no UX change). Note:
+none of these had dynamic HTTP-client imports (those were all removed in Chunk 6), so this is purely
+boilerplate/error-display consolidation.
+
+## Migrated
+- **`SiteFormModal`** → `useModalForm` + `<FormErrorBanner>` (standard async-save modal).
+- **`PaymentFormModal`** → `useModalForm` + `<FormErrorBanner>`; preserved the 2-step wizard, the
+  `isFullyAllocated` save gate, and the allocation summary bar (which also uses `bg-red-50` for
+  over-allocation — left untouched, it is not the error banner).
+- **`LookupFormModal`** → `useFormError` + `<FormErrorBanner>` only (it delegates the save to its
+  parent via `emit('submit', …)`, so the full `useModalForm.submit()` wrapper doesn't apply).
+
+## Deferred (documented)
+- **`BookingFormModal`**, **`TreatmentPlanFormModal`** — these use a differently-named `saveError`
+  ref and a **different banner style** (`bg-red-50 border border-red-200` + nested `<p>`). Migrating
+  would change their appearance (UX regression risk) for no functional gain. Left as-is.
+
+## Scenarios (no UX change expected)
+1. **Site** add/edit → required-field blank shows the red banner; Save disabled while shown; valid save closes + refreshes.
+2. **Lookup** (Admin → a lookup table) add/edit → required-field validation banner; submit delegates to parent (saves) and closes.
+3. **Payment** (Billing → Record Payment):
+   - Step 1 validation (caretaker / amount > 0 / type) shows the banner; Next advances only when valid.
+   - Step 2: Save is disabled until **fully allocated**; over-allocation summary bar still turns red;
+     a server error on save shows in the footer banner; successful save closes + refreshes.
+
+## Automated checks
+- `npx vue-tsc --noEmit` — clean.
+- `npm run lint` — clean.
+- `npm run build` — succeeds.


### PR DESCRIPTION
…d form infra

Consolidate remaining form modals onto useModalForm/useFormError + <FormErrorBanner> (no UX change; none had dynamic imports — those were removed in Chunk 6).

- SiteFormModal -> useModalForm + FormErrorBanner.
- PaymentFormModal -> useModalForm + FormErrorBanner; preserved the 2-step wizard, the isFullyAllocated save gate, the allocation summary bar, and data-load error reporting (setFromException). useModalForm now also re-exposes setFromException for such non-submit error paths.
- LookupFormModal -> useFormError + FormErrorBanner only (it delegates save via emit, so the submit() wrapper doesn't apply).

Deferred (documented): BookingFormModal + TreatmentPlanFormModal use a differently-named saveError ref and a different banner style (border + nested <p>); migrating would change their appearance for no functional gain.

Verification: test-scenarios/remediation-6b-modal-sweep.md. vue-tsc / lint / build clean.