### PR TITLE
WP-17D: gate access-control drift + Vitest in UI PR validation

### DIFF
--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -30,3 +30,13 @@ jobs:
       - name: Lint
         working-directory: app-ui
         run: npm run lint
+
+      - name: Unit tests (Vitest — incl. claim-gating + codegen no-drift)
+        working-directory: app-ui
+        run: npm test
+
+      # WP-17D: access-control drift tripwire. Regenerates permissions.ts from the
+      # vendored manifest and fails if it differs from the committed file. Cross-repo
+      # reconciliation against the canonical super manifest runs in patient-care-super.
+      - name: Access-control codegen drift check
+        run: bash tools/generate-ui-permissions.sh --check


### PR DESCRIPTION
Wire the 17C drift tripwire into CI. PR validation now also:
  - runs the Vitest suite (npm test) — the 17C claim-gating + codegen no-drift tests were not gated in CI before this; and
  - runs `bash tools/generate-ui-permissions.sh --check`, failing the PR if permissions.ts drifts from the vendored manifest.

Invoked via `bash` because the generator is tracked mode 100644 (no +x). Cross-repo reconciliation against the canonical super manifest lives in patient-care-super (WP-17D Leg B).