### PR TITLE
WP-17: providerAmount optional on Appointment + refresh stale 17C notes

### DIFF
--- a/app-ui/src/components/option02/O2Appointments.vue
+++ b/app-ui/src/components/option02/O2Appointments.vue
@@ -60,10 +60,12 @@
             <!-- Mobile financial summary -->
             <p class="md:hidden text-[10px] mt-0.5 truncate">
               <span class="text-gray-500">{{ formatCurrency(appt.amount) }} billed</span>
-              <!-- WP-17C: cosmetic only — the API still returns ProviderAmount to anyone with Dashboard.View; true field-level enforcement needs API response-shaping (deferred). -->
+              <!-- WP-17: enforced both ways — the API omits ProviderAmount for callers lacking
+                   Appointments.ProviderAmount (ProviderAmountResultFilter), and this gate hides the
+                   widget; Dashboard.ProviderAmount has the same grants (MGR/AM), so they stay consistent. -->
               <template v-if="hasClaim('Permission', Permissions.DashboardProviderAmount)">
                 <span class="text-gray-300"> &middot; </span>
-                <span class="text-violet-600">{{ formatCurrency(appt.providerAmount) }} provider</span>
+                <span class="text-violet-600">{{ formatCurrency(appt.providerAmount ?? 0) }} provider</span>
               </template>
               <span class="text-gray-300"> &middot; </span>
               <span v-if="appt.isPastDue" class="text-red-600 font-medium">{{ formatCurrency(appt.amountDue) }} due</span>
@@ -77,9 +79,10 @@
               <p class="text-xs font-medium text-gray-600">{{ formatCurrency(appt.amount) }}</p>
               <p class="text-[10px] text-gray-400">Billed</p>
             </div>
-            <!-- WP-17C: cosmetic only — the API still returns ProviderAmount to anyone with Dashboard.View; true field-level enforcement needs API response-shaping (deferred). -->
+            <!-- WP-17: enforced server-side now (API omits ProviderAmount without the claim); this gate
+                 hides the column. Dashboard.ProviderAmount and Appointments.ProviderAmount share grants. -->
             <div v-if="hasClaim('Permission', Permissions.DashboardProviderAmount)" class="w-16 text-right">
-              <p class="text-xs font-medium text-violet-600">{{ formatCurrency(appt.providerAmount) }}</p>
+              <p class="text-xs font-medium text-violet-600">{{ formatCurrency(appt.providerAmount ?? 0) }}</p>
               <p class="text-[10px] text-gray-400">Provider</p>
             </div>
             <div class="w-16 text-right">

--- a/app-ui/src/components/option02/O2StatsBar.vue
+++ b/app-ui/src/components/option02/O2StatsBar.vue
@@ -202,7 +202,8 @@ export default defineComponent({
     const pastDueFinancials = computed(() => {
       const pastDue = props.appointments.filter((a) => a.isPastDue);
       const totalDue = pastDue.reduce((sum, a) => sum + a.amountDue, 0);
-      const totalProvider = pastDue.reduce((sum, a) => sum + a.providerAmount, 0);
+      // WP-17: providerAmount is optional (API omits it for callers lacking the claim) — treat absent as 0.
+      const totalProvider = pastDue.reduce((sum, a) => sum + (a.providerAmount ?? 0), 0);
       return {
         count: pastDue.length,
         totalAmount: pastDue.reduce((sum, a) => sum + a.amount, 0),
@@ -217,7 +218,8 @@ export default defineComponent({
     const settledFinancials = computed(() => {
       const settled = props.appointments.filter((a) => a.isPaidOff);
       const totalPaid = settled.reduce((sum, a) => sum + a.amountPaid, 0);
-      const totalProvider = settled.reduce((sum, a) => sum + a.providerAmount, 0);
+      // WP-17: providerAmount is optional (API omits it for callers lacking the claim) — treat absent as 0.
+      const totalProvider = settled.reduce((sum, a) => sum + (a.providerAmount ?? 0), 0);
       return {
         count: settled.length,
         totalAmount: settled.reduce((sum, a) => sum + a.amount, 0),

--- a/app-ui/src/interfaces/Appointment.ts
+++ b/app-ui/src/interfaces/Appointment.ts
@@ -25,7 +25,9 @@ export interface Appointment {
     specialtyAbbreviation: string | null;
     specialtyName: string | null;
     isDiscovery: boolean | null;
-    providerAmount: number;
+    // WP-17: confidential (matrix grants Appointments.ProviderAmount to MGR/AM only). The API omits
+    // this field from the response for callers lacking the claim (e.g. FrontDesk), so it is optional.
+    providerAmount?: number;
 }
 
 export interface SessionEventRequest {


### PR DESCRIPTION
Pairs with the API ProviderAmount response-shaping: the API now omits providerAmount from SessionEvent responses for callers lacking Appointments.ProviderAmount (FrontDesk), so the Appointment response interface marks it optional (providerAmount?: number). SessionEventRequest (the booking payload the user fills in) stays required.

Read sites made null-safe (?? 0): O2Appointments display + O2StatsBar provider totals. Refreshed the now-inaccurate O2Appointments comments that called the gating "cosmetic / enforcement deferred" — enforcement is now real server-side.

vue-tsc + lint + 20 Vitest tests green.