### PR TITLE
WP-14C: Service Payments (therapist payroll) UI

### DIFF
--- a/app-ui/src/components/option02/O2Sidebar.vue
+++ b/app-ui/src/components/option02/O2Sidebar.vue
@@ -65,9 +65,10 @@ import {
   faGear,
   faArrowLeft,
   faCalendarWeek,
+  faMoneyBillTransfer,
 } from '@fortawesome/free-solid-svg-icons';
 
-library.add(faChartPie, faUsers, faUserMd, faHandHoldingHeart, faCalendarCheck, faCalendarWeek, faCreditCard, faFileAlt, faGear, faArrowLeft);
+library.add(faChartPie, faUsers, faUserMd, faHandHoldingHeart, faCalendarCheck, faCalendarWeek, faCreditCard, faFileAlt, faMoneyBillTransfer, faGear, faArrowLeft);
 
 export default defineComponent({
   name: 'O2Sidebar',
@@ -88,6 +89,7 @@ export default defineComponent({
       { label: 'Schedule', icon: 'calendar-week', to: '/schedule', title: 'Weekly Schedule', claim: ['Permission', Permissions.ScheduleView] },
       { label: 'Billing', icon: 'credit-card', to: '/payments', claim: ['Permission', Permissions.PaymentsView] },
       { label: 'Statements', icon: 'file-alt', to: '/statements', claim: ['Permission', Permissions.StatementsView] },
+      { label: 'Payroll', icon: 'money-bill-transfer', to: '/service-payments', title: 'Service Payments', claim: ['Permission', Permissions.ServicePaymentsView] },
     ];
 
     const visibleNavItems = computed(() =>

--- a/app-ui/src/components/service-payments/PayTherapistWizard.vue
+++ b/app-ui/src/components/service-payments/PayTherapistWizard.vue
@@ -1,0 +1,289 @@
+<template>
+  <div class="space-y-6">
+    <!-- Selection controls -->
+    <div class="bg-white rounded-xl shadow-sm border border-slate-200 px-6 py-4">
+      <div class="flex flex-col sm:flex-row sm:items-end gap-4">
+        <div class="flex-1">
+          <label class="block text-sm font-medium text-slate-700 mb-1">Therapist</label>
+          <select
+            v-model="selectedTherapistId"
+            class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+          >
+            <option :value="null" disabled>Select a therapist...</option>
+            <option v-for="t in therapists" :key="t.therapistId" :value="t.therapistId">{{ t.therapistName }}</option>
+          </select>
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-slate-700 mb-1">From</label>
+          <input v-model="fromDate" type="date" class="rounded-lg border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-slate-700 mb-1">To</label>
+          <input v-model="toDate" type="date" class="rounded-lg border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
+        </div>
+        <div>
+          <button
+            :disabled="!selectedTherapistId || loading"
+            class="inline-flex items-center px-4 py-2 rounded-lg text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+            @click="loadSessions"
+          >
+            <svg v-if="loading" class="animate-spin -ml-1 mr-2 h-4 w-4 text-white" fill="none" viewBox="0 0 24 24">
+              <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+              <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+            </svg>
+            Find Unpaid Sessions
+          </button>
+        </div>
+      </div>
+      <p class="text-xs text-slate-400 mt-2">Date range defaults to the current quincena (1st–15th or 16th–end of month). Override freely.</p>
+    </div>
+
+    <div v-if="error" class="bg-red-50 border border-red-200 rounded-lg p-4">
+      <p class="text-sm text-red-700">{{ error }}</p>
+    </div>
+
+    <!-- Success confirmation -->
+    <div v-if="successRecord" class="bg-green-50 border border-green-200 rounded-lg p-6">
+      <div class="flex items-start gap-3">
+        <svg class="w-6 h-6 text-green-600 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+        </svg>
+        <div class="flex-1">
+          <p class="text-sm font-semibold text-green-900">
+            Service payment of {{ formatCurrency(successRecord.amount) }} recorded for {{ successRecord.therapistName }}.
+          </p>
+          <p class="text-sm text-green-800 mt-1">
+            {{ successRecord.allocations.length }} session{{ successRecord.allocations.length !== 1 ? 's' : '' }} paid.
+            The therapist statement for this period is now authoritative.
+          </p>
+          <div class="mt-3 flex gap-3">
+            <router-link to="/statements" class="inline-flex items-center px-3 py-1.5 rounded-lg text-sm font-medium text-white bg-green-600 hover:bg-green-700">
+              View Statement
+            </router-link>
+            <button class="inline-flex items-center px-3 py-1.5 rounded-lg text-sm font-medium text-slate-700 bg-white border border-slate-300 hover:bg-slate-50" @click="resetForNext">
+              Record Another
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Unpaid sessions + payment form -->
+    <template v-if="loaded && !successRecord">
+      <div v-if="sessions.length === 0" class="bg-white rounded-lg shadow-sm border border-slate-200 p-8 text-center">
+        <p class="text-sm text-slate-500">No unpaid completed sessions for this therapist in the selected period.</p>
+      </div>
+
+      <div v-else class="bg-white rounded-lg shadow-sm border border-slate-200">
+        <div class="px-6 py-4 border-b border-slate-200 flex items-center justify-between">
+          <h3 class="text-base font-semibold text-slate-800">Unpaid Sessions</h3>
+          <div class="flex items-center gap-3 text-sm">
+            <button class="text-blue-600 hover:underline" @click="selectAll(true)">Select all</button>
+            <button class="text-slate-500 hover:underline" @click="selectAll(false)">Clear</button>
+          </div>
+        </div>
+        <div class="overflow-x-auto">
+          <table class="min-w-full divide-y divide-slate-200">
+            <thead class="bg-slate-50">
+              <tr>
+                <th class="px-4 py-3 w-10"></th>
+                <th class="px-4 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Date</th>
+                <th class="px-4 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Time</th>
+                <th class="px-4 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Patient</th>
+                <th class="px-4 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Therapy Type</th>
+                <th class="px-4 py-3 text-right text-xs font-medium text-slate-500 uppercase tracking-wider">Provider Amount</th>
+              </tr>
+            </thead>
+            <tbody class="bg-white divide-y divide-slate-200">
+              <tr v-for="s in sessions" :key="s.sessionId" class="hover:bg-slate-50" :class="selected[s.sessionId] ? '' : 'opacity-50'">
+                <td class="px-4 py-3">
+                  <input type="checkbox" v-model="selected[s.sessionId]" class="rounded border-slate-300 text-blue-600 focus:ring-blue-500" />
+                </td>
+                <td class="px-4 py-3 whitespace-nowrap text-sm text-slate-900">{{ formatDate(s.sessionDate) }}</td>
+                <td class="px-4 py-3 whitespace-nowrap text-sm text-slate-900">{{ s.sessionTime }}</td>
+                <td class="px-4 py-3 whitespace-nowrap text-sm text-slate-900">{{ s.patientName }}</td>
+                <td class="px-4 py-3 whitespace-nowrap text-sm text-slate-900">{{ s.therapyType }}</td>
+                <td class="px-4 py-3 whitespace-nowrap text-sm text-right font-medium text-slate-900">{{ formatCurrency(s.remainingProviderAmount) }}</td>
+              </tr>
+              <tr class="bg-slate-50 font-medium">
+                <td class="px-4 py-3" colspan="5">
+                  <span class="text-sm text-slate-700">{{ selectedCount }} session{{ selectedCount !== 1 ? 's' : '' }} selected</span>
+                </td>
+                <td class="px-4 py-3 whitespace-nowrap text-sm text-right text-slate-900">{{ formatCurrency(selectedTotal) }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <!-- Payment details -->
+      <div v-if="sessions.length > 0" class="bg-white rounded-lg shadow-sm border border-slate-200 p-6">
+        <h3 class="text-base font-semibold text-slate-800 mb-4">Payment Details</h3>
+        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+          <div>
+            <label class="block text-sm font-medium text-slate-700 mb-1">Payment Date</label>
+            <input v-model="paymentDate" type="date" class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-slate-700 mb-1">Payment Method</label>
+            <select v-model="paymentTypeId" class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
+              <option :value="null" disabled>Select...</option>
+              <option v-for="pt in paymentTypes" :key="pt.paymentTypeId" :value="pt.paymentTypeId">{{ pt.name }}</option>
+            </select>
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-slate-700 mb-1">Reference #</label>
+            <input v-model="referenceNumber" type="text" placeholder="Check / transfer ref" class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-slate-700 mb-1">Notes</label>
+            <input v-model="notes" type="text" placeholder="Optional" class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
+          </div>
+        </div>
+        <div class="mt-6 flex items-center justify-between border-t border-slate-200 pt-4">
+          <div>
+            <span class="text-sm text-slate-600">Total to pay</span>
+            <span class="ml-2 text-2xl font-bold text-blue-700">{{ formatCurrency(selectedTotal) }}</span>
+          </div>
+          <button
+            :disabled="!canSubmit || submitting"
+            class="inline-flex items-center px-5 py-2.5 rounded-lg text-sm font-semibold text-white bg-blue-600 hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+            @click="submit"
+          >
+            <svg v-if="submitting" class="animate-spin -ml-1 mr-2 h-4 w-4 text-white" fill="none" viewBox="0 0 24 24">
+              <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+              <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+            </svg>
+            Issue Payment
+          </button>
+        </div>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref, reactive, computed, onMounted, type PropType } from 'vue';
+import { ServicePaymentsHttpClient } from '../../services/ServicePaymentsHttpClient';
+import type { PaymentTypeInfo } from '../../interfaces/Payment';
+import type { ServicePaymentRecord, UnpaidProviderSessionSummary } from '../../interfaces/ServicePayment';
+
+interface TherapistOption {
+  therapistId: number
+  therapistName: string
+}
+
+export default defineComponent({
+  name: 'PayTherapistWizard',
+  props: {
+    therapists: { type: Array as PropType<TherapistOption[]>, required: true },
+    paymentTypes: { type: Array as PropType<PaymentTypeInfo[]>, required: true },
+  },
+  emits: ['created'],
+  setup(props, { emit }) {
+    const client = new ServicePaymentsHttpClient();
+
+    const selectedTherapistId = ref<number | null>(null);
+    const toIso = (d: Date) => d.toISOString().split('T')[0];
+    const fromDate = ref(toIso(new Date()));
+    const toDate = ref(toIso(new Date()));
+    const paymentDate = ref(toIso(new Date()));
+    const paymentTypeId = ref<number | null>(null);
+    const referenceNumber = ref('');
+    const notes = ref('');
+
+    const sessions = ref<UnpaidProviderSessionSummary[]>([]);
+    const selected = reactive<Record<number, boolean>>({});
+    const loaded = ref(false);
+    const loading = ref(false);
+    const submitting = ref(false);
+    const error = ref('');
+    const successRecord = ref<ServicePaymentRecord | null>(null);
+
+    const selectedSessions = computed(() => sessions.value.filter((s) => selected[s.sessionId]));
+    const selectedCount = computed(() => selectedSessions.value.length);
+    const selectedTotal = computed(() => selectedSessions.value.reduce((sum, s) => sum + s.remainingProviderAmount, 0));
+    const canSubmit = computed(() => !!selectedTherapistId.value && !!paymentTypeId.value && selectedTotal.value > 0);
+
+    const formatCurrency = (v: number) => `$${v.toFixed(2)}`;
+    const formatDate = (dateStr: string) => new Date(dateStr).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+
+    const selectAll = (value: boolean) => {
+      sessions.value.forEach((s) => { selected[s.sessionId] = value; });
+    };
+
+    const loadSessions = async () => {
+      if (!selectedTherapistId.value) return;
+      loading.value = true;
+      error.value = '';
+      successRecord.value = null;
+      try {
+        const list = await client.getUnpaidSessions(selectedTherapistId.value, fromDate.value, toDate.value);
+        sessions.value = list;
+        Object.keys(selected).forEach((k) => delete selected[Number(k)]);
+        list.forEach((s) => { selected[s.sessionId] = true; });
+        loaded.value = true;
+      } catch (e: unknown) {
+        error.value = e instanceof Error ? e.message : 'Failed to load unpaid sessions.';
+      } finally {
+        loading.value = false;
+      }
+    };
+
+    const submit = async () => {
+      if (!selectedTherapistId.value || !paymentTypeId.value) return;
+      submitting.value = true;
+      error.value = '';
+      try {
+        const record = await client.createServicePayment({
+          therapistId: selectedTherapistId.value,
+          paymentDate: paymentDate.value,
+          amount: selectedTotal.value,
+          paymentTypeId: paymentTypeId.value,
+          referenceNumber: referenceNumber.value || null,
+          notes: notes.value || null,
+          sessionAllocations: selectedSessions.value.map((s) => ({
+            sessionId: s.sessionId,
+            amountApplied: s.remainingProviderAmount,
+          })),
+        });
+        successRecord.value = record;
+        loaded.value = false;
+        sessions.value = [];
+        emit('created', record);
+      } catch (e: unknown) {
+        error.value = e instanceof Error ? e.message : 'Failed to issue payment.';
+      } finally {
+        submitting.value = false;
+      }
+    };
+
+    const resetForNext = () => {
+      successRecord.value = null;
+      referenceNumber.value = '';
+      notes.value = '';
+    };
+
+    onMounted(async () => {
+      // Default the date range to the current quincena, and pre-select a payment method.
+      try {
+        const window = await client.getQuincena();
+        fromDate.value = window.from;
+        toDate.value = window.to;
+      } catch {
+        // Non-fatal: keep today/today defaults if the helper is unreachable.
+      }
+      if (props.paymentTypes.length > 0) {
+        paymentTypeId.value = props.paymentTypes[0].paymentTypeId;
+      }
+    });
+
+    return {
+      selectedTherapistId, fromDate, toDate, paymentDate, paymentTypeId, referenceNumber, notes,
+      sessions, selected, loaded, loading, submitting, error, successRecord,
+      selectedCount, selectedTotal, canSubmit,
+      formatCurrency, formatDate, selectAll, loadSessions, submit, resetForNext,
+    };
+  },
+});
+</script>

--- a/app-ui/src/components/service-payments/ServicePaymentsList.vue
+++ b/app-ui/src/components/service-payments/ServicePaymentsList.vue
@@ -1,0 +1,126 @@
+<template>
+  <div class="space-y-6">
+    <div class="bg-white rounded-xl shadow-sm border border-slate-200 px-6 py-4">
+      <div class="flex flex-col sm:flex-row sm:items-end gap-4">
+        <div class="flex-1">
+          <label class="block text-sm font-medium text-slate-700 mb-1">Therapist</label>
+          <select
+            v-model="selectedTherapistId"
+            class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          >
+            <option :value="null" disabled>Select a therapist...</option>
+            <option v-for="t in therapists" :key="t.therapistId" :value="t.therapistId">{{ t.therapistName }}</option>
+          </select>
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-slate-700 mb-1">From</label>
+          <input v-model="fromDate" type="date" class="rounded-lg border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-slate-700 mb-1">To</label>
+          <input v-model="toDate" type="date" class="rounded-lg border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
+        </div>
+        <div>
+          <button
+            :disabled="!selectedTherapistId || loading"
+            class="inline-flex items-center px-4 py-2 rounded-lg text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+            @click="load"
+          >
+            <svg v-if="loading" class="animate-spin -ml-1 mr-2 h-4 w-4 text-white" fill="none" viewBox="0 0 24 24">
+              <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+              <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+            </svg>
+            View History
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <div v-if="error" class="bg-red-50 border border-red-200 rounded-lg p-4">
+      <p class="text-sm text-red-700">{{ error }}</p>
+    </div>
+
+    <div v-if="loaded" class="bg-white rounded-lg shadow-sm border border-slate-200">
+      <div v-if="payments.length === 0" class="p-8 text-center text-sm text-slate-500">
+        No service payments recorded for this therapist in the selected period.
+      </div>
+      <div v-else class="overflow-x-auto">
+        <table class="min-w-full divide-y divide-slate-200">
+          <thead class="bg-slate-50">
+            <tr>
+              <th class="px-4 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Date</th>
+              <th class="px-4 py-3 text-right text-xs font-medium text-slate-500 uppercase tracking-wider">Amount</th>
+              <th class="px-4 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Method</th>
+              <th class="px-4 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Reference</th>
+              <th class="px-4 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Sessions</th>
+              <th class="px-4 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Notes</th>
+            </tr>
+          </thead>
+          <tbody class="bg-white divide-y divide-slate-200">
+            <tr v-for="p in payments" :key="p.servicePaymentId" class="hover:bg-slate-50">
+              <td class="px-4 py-3 whitespace-nowrap text-sm text-slate-900">{{ formatDate(p.paymentDate) }}</td>
+              <td class="px-4 py-3 whitespace-nowrap text-sm text-right font-medium text-slate-900">{{ formatCurrency(p.amount) }}</td>
+              <td class="px-4 py-3 whitespace-nowrap text-sm text-slate-900">{{ p.paymentType?.name || '—' }}</td>
+              <td class="px-4 py-3 whitespace-nowrap text-sm text-slate-900">{{ p.referenceNumber || '—' }}</td>
+              <td class="px-4 py-3 whitespace-nowrap text-sm text-slate-900">{{ p.allocations.length }}</td>
+              <td class="px-4 py-3 text-sm text-slate-600">{{ p.notes || '—' }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref, type PropType } from 'vue';
+import { ServicePaymentsHttpClient } from '../../services/ServicePaymentsHttpClient';
+import type { ServicePaymentRecord } from '../../interfaces/ServicePayment';
+
+interface TherapistOption {
+  therapistId: number
+  therapistName: string
+}
+
+export default defineComponent({
+  name: 'ServicePaymentsList',
+  props: {
+    therapists: { type: Array as PropType<TherapistOption[]>, required: true },
+  },
+  setup() {
+    const client = new ServicePaymentsHttpClient();
+
+    const selectedTherapistId = ref<number | null>(null);
+    const toIso = (d: Date) => d.toISOString().split('T')[0];
+    const today = new Date();
+    const ninetyDaysAgo = new Date(today);
+    ninetyDaysAgo.setDate(ninetyDaysAgo.getDate() - 90);
+    const fromDate = ref(toIso(ninetyDaysAgo));
+    const toDate = ref(toIso(today));
+
+    const payments = ref<ServicePaymentRecord[]>([]);
+    const loaded = ref(false);
+    const loading = ref(false);
+    const error = ref('');
+
+    const formatCurrency = (v: number) => `$${v.toFixed(2)}`;
+    const formatDate = (dateStr: string) => new Date(dateStr).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+
+    const load = async () => {
+      if (!selectedTherapistId.value) return;
+      loading.value = true;
+      error.value = '';
+      try {
+        payments.value = await client.getServicePayments(selectedTherapistId.value, fromDate.value, toDate.value);
+        loaded.value = true;
+      } catch (e: unknown) {
+        error.value = e instanceof Error ? e.message : 'Failed to load service payments.';
+      } finally {
+        loading.value = false;
+      }
+    };
+
+    return { selectedTherapistId, fromDate, toDate, payments, loaded, loading, error, formatCurrency, formatDate, load };
+  },
+});
+</script>

--- a/app-ui/src/generated/access-control-matrix.json
+++ b/app-ui/src/generated/access-control-matrix.json
@@ -1,9 +1,9 @@
 {
   "_meta": {
-    "generatedAt": "2026-06-13T10:13:43-05:00",
+    "generatedAt": "2026-06-20T14:20:39-05:00",
     "generator": "tools/generate-access-manifest.sh",
     "hashScope": "sha256 (first 12 hex) of canonical JSON {claims:[{claim,grants}]}, claims+grants sorted; wildcard/restricted cells and all metadata excluded",
-    "semanticHash": "b88f98dc47d7",
+    "semanticHash": "b10682734edf",
     "source": "access-control-matrix.md"
   },
   "claims": [
@@ -246,6 +246,19 @@
       "grants": [
         "AM",
         "FD",
+        "MGR"
+      ]
+    },
+    {
+      "claim": "ServicePayments.Record",
+      "grants": [
+        "MGR"
+      ]
+    },
+    {
+      "claim": "ServicePayments.View",
+      "grants": [
+        "AM",
         "MGR"
       ]
     },

--- a/app-ui/src/generated/permissions.ts
+++ b/app-ui/src/generated/permissions.ts
@@ -8,7 +8,7 @@
 //   app-ui/src/generated/access-control-matrix.json, then re-run
 //   tools/generate-ui-permissions.sh.
 //
-//   Access-control manifest semantic hash: b88f98dc47d7
+//   Access-control manifest semantic hash: b10682734edf
 // </auto-generated>
 
 /**
@@ -56,6 +56,8 @@ export const Permissions = {
   ScheduleBook: 'Schedule.Book',
   ScheduleRebook: 'Schedule.Rebook',
   ScheduleView: 'Schedule.View',
+  ServicePaymentsRecord: 'ServicePayments.Record',
+  ServicePaymentsView: 'ServicePayments.View',
   StatementsCaretakerView: 'Statements.Caretaker.View',
   StatementsTherapistView: 'Statements.Therapist.View',
   StatementsView: 'Statements.View',
@@ -73,4 +75,4 @@ export const Permissions = {
 export type Permission = (typeof Permissions)[keyof typeof Permissions];
 
 /** Access-control manifest semantic hash this module was generated from (WP-17 anchor). */
-export const ACCESS_CONTROL_MANIFEST_HASH = 'b88f98dc47d7';
+export const ACCESS_CONTROL_MANIFEST_HASH = 'b10682734edf';

--- a/app-ui/src/interfaces/ServicePayment.ts
+++ b/app-ui/src/interfaces/ServicePayment.ts
@@ -1,0 +1,60 @@
+// interfaces/ServicePayment.ts
+//
+// Mirrors the API DTOs from `_contracts/service-payments-api.md` (WP-14). Therapist payroll —
+// the direction-flipped mirror of the Caretaker Payment interfaces. JSON is camelCase.
+
+import type { PaymentTypeInfo } from './Payment';
+
+export interface SessionServiceAllocationItem {
+  sessionId: number
+  amountApplied: number
+}
+
+export interface ServicePaymentCreateRequest {
+  therapistId: number
+  paymentDate: string                 // ISO date (yyyy-MM-dd) or date-time
+  amount: number
+  paymentTypeId: number
+  referenceNumber?: string | null
+  notes?: string | null
+  sessionAllocations: SessionServiceAllocationItem[]
+}
+
+export interface ServiceAllocationDetail {
+  sessionServicePaymentId: number
+  sessionId: number
+  sessionDate: string
+  patientName: string
+  amountApplied: number
+}
+
+export interface ServicePaymentRecord {
+  servicePaymentId: number
+  therapistId: number
+  therapistName: string
+  paymentDate: string
+  amount: number
+  paymentType: PaymentTypeInfo
+  referenceNumber: string | null
+  notes: string | null
+  allocations: ServiceAllocationDetail[]
+  totalApplied: number
+  unallocatedAmount: number
+}
+
+export interface UnpaidProviderSessionSummary {
+  sessionId: number
+  sessionDate: string
+  sessionTime: string
+  patientId: number
+  patientName: string
+  therapyType: string
+  providerAmount: number
+  alreadyApplied: number
+  remainingProviderAmount: number
+}
+
+export interface QuincenaWindow {
+  from: string
+  to: string
+}

--- a/app-ui/src/interfaces/TherapistStatement.ts
+++ b/app-ui/src/interfaces/TherapistStatement.ts
@@ -26,7 +26,7 @@ export interface TherapistStatementPatient {
   nonBillableCount: number        // Cancelled + NoShow
 }
 
-// Reserved for the Therapist Payroll WP (WP-14). Always empty in WP-13B.
+// Therapist Payroll (WP-14). Populated once service payments touch in-range sessions.
 export interface ServicePaymentAllocation {
   sessionId: number
   amountApplied: number
@@ -48,7 +48,7 @@ export interface TherapistStatementSummary {
   totalFee: number
   totalDiscount: number
   totalProviderAmount: number         // billable only
-  totalServicePaymentsApplied: number // 0 in WP-13B
+  totalServicePaymentsApplied: number // sum of in-range service-payment allocations (WP-14)
   estimatedAmountDue: number          // = totalProviderAmount - totalServicePaymentsApplied
 }
 
@@ -58,8 +58,8 @@ export interface TherapistStatement {
   statementDate: string               // yyyy-MM-dd
   periodStart: string
   periodEnd: string
-  isProForma: boolean                 // true until WP-14 ships
+  isProForma: boolean                 // false once any service payment touches an in-range session (WP-14)
   patients: TherapistStatementPatient[]
-  servicePayments: ServicePaymentItem[]  // always [] in WP-13B
+  servicePayments: ServicePaymentItem[]  // populated since WP-14
   summary: TherapistStatementSummary
 }

--- a/app-ui/src/router/index.ts
+++ b/app-ui/src/router/index.ts
@@ -68,6 +68,12 @@ const router = createRouter({
       meta: { permission: Permissions.StatementsView },
     },
     {
+      path: '/service-payments',
+      name: 'service-payments',
+      component: () => import('../views/ServicePaymentsView.vue'),
+      meta: { permission: Permissions.ServicePaymentsView },
+    },
+    {
       path: '/appointments',
       name: 'appointments',
       component: () => import('../views/AppointmentsView.vue'),

--- a/app-ui/src/services/ServicePaymentsHttpClient.ts
+++ b/app-ui/src/services/ServicePaymentsHttpClient.ts
@@ -1,0 +1,39 @@
+// services/ServicePaymentsHttpClient.ts
+import { HttpClientBase } from './HttpClientBase';
+import type {
+  ServicePaymentRecord,
+  ServicePaymentCreateRequest,
+  UnpaidProviderSessionSummary,
+  QuincenaWindow,
+} from '../interfaces/ServicePayment';
+
+export class ServicePaymentsHttpClient extends HttpClientBase {
+  async getServicePayments(therapistId: number, from?: string, to?: string): Promise<ServicePaymentRecord[]> {
+    const params = new URLSearchParams();
+    params.append('therapistId', String(therapistId));
+    if (from) params.append('from', from);
+    if (to) params.append('to', to);
+    return this.get<ServicePaymentRecord[]>(`/api/service-payments?${params.toString()}`);
+  }
+
+  async getServicePayment(id: number): Promise<ServicePaymentRecord> {
+    return this.get<ServicePaymentRecord>(`/api/service-payments/${id}`);
+  }
+
+  async getUnpaidSessions(therapistId: number, from?: string, to?: string): Promise<UnpaidProviderSessionSummary[]> {
+    const params = new URLSearchParams();
+    params.append('therapistId', String(therapistId));
+    if (from) params.append('from', from);
+    if (to) params.append('to', to);
+    return this.get<UnpaidProviderSessionSummary[]>(`/api/service-payments/unpaid-sessions?${params.toString()}`);
+  }
+
+  async getQuincena(date?: string): Promise<QuincenaWindow> {
+    const query = date ? `?date=${date}` : '';
+    return this.get<QuincenaWindow>(`/api/service-payments/quincena${query}`);
+  }
+
+  async createServicePayment(data: ServicePaymentCreateRequest): Promise<ServicePaymentRecord> {
+    return this.post<ServicePaymentRecord>('/api/service-payments', data);
+  }
+}

--- a/app-ui/src/views/ServicePaymentsView.vue
+++ b/app-ui/src/views/ServicePaymentsView.vue
@@ -1,0 +1,112 @@
+<template>
+  <div class="min-h-screen bg-slate-50 font-sans">
+    <O2MobileNav />
+    <div class="flex flex-1">
+      <O2Sidebar />
+      <div class="flex-1 flex flex-col">
+        <O2Header />
+        <main class="flex-1 max-w-7xl mx-auto w-full px-4 sm:px-6 lg:px-8 py-6">
+          <div class="mb-6">
+            <h1 class="text-2xl font-bold text-slate-800">Service Payments</h1>
+            <p class="text-sm text-slate-500 mt-1">Issue and review disbursements to therapists (payroll)</p>
+          </div>
+
+          <!-- Tab bar -->
+          <div class="mb-6 border-b border-slate-200">
+            <nav class="-mb-px flex gap-6" aria-label="Service payment tabs">
+              <button
+                v-if="canRecord"
+                type="button"
+                class="py-3 px-1 border-b-2 text-sm font-medium transition-colors"
+                :class="activeTab === 'issue' ? 'border-blue-600 text-blue-600' : 'border-transparent text-slate-500 hover:text-slate-700 hover:border-slate-300'"
+                @click="activeTab = 'issue'"
+              >
+                Pay Therapist
+              </button>
+              <button
+                type="button"
+                class="py-3 px-1 border-b-2 text-sm font-medium transition-colors"
+                :class="activeTab === 'history' ? 'border-blue-600 text-blue-600' : 'border-transparent text-slate-500 hover:text-slate-700 hover:border-slate-300'"
+                @click="activeTab = 'history'"
+              >
+                History
+              </button>
+            </nav>
+          </div>
+
+          <div v-if="loadError" class="mb-6 bg-red-50 border border-red-200 rounded-lg p-4">
+            <p class="text-sm text-red-700">{{ loadError }}</p>
+          </div>
+
+          <div v-show="activeTab === 'issue' && canRecord">
+            <PayTherapistWizard :therapists="therapists" :payment-types="paymentTypes" @created="onCreated" />
+          </div>
+
+          <div v-show="activeTab === 'history'">
+            <ServicePaymentsList :therapists="therapists" />
+          </div>
+        </main>
+        <O2Footer />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref, onMounted } from 'vue';
+import O2MobileNav from '../components/option02/O2MobileNav.vue';
+import O2Sidebar from '../components/option02/O2Sidebar.vue';
+import O2Header from '../components/option02/O2Header.vue';
+import O2Footer from '../components/option02/O2Footer.vue';
+import PayTherapistWizard from '../components/service-payments/PayTherapistWizard.vue';
+import ServicePaymentsList from '../components/service-payments/ServicePaymentsList.vue';
+import { TherapistsHttpClient } from '../services/TherapistsHttpClient';
+import { PaymentsHttpClient } from '../services/PaymentsHttpClient';
+import { useClaims, Permissions } from '../composables/useClaims';
+import type { PaymentTypeInfo } from '../interfaces/Payment';
+
+interface TherapistOption {
+  therapistId: number
+  therapistName: string
+}
+
+export default defineComponent({
+  name: 'ServicePaymentsView',
+  components: { O2MobileNav, O2Sidebar, O2Header, O2Footer, PayTherapistWizard, ServicePaymentsList },
+  setup() {
+    const { hasClaim } = useClaims();
+    const canRecord = hasClaim('Permission', Permissions.ServicePaymentsRecord);
+
+    const therapistsClient = new TherapistsHttpClient();
+    const paymentsClient = new PaymentsHttpClient();
+
+    const therapists = ref<TherapistOption[]>([]);
+    const paymentTypes = ref<PaymentTypeInfo[]>([]);
+    const loadError = ref('');
+    // MGR lands on the Pay Therapist tab; AM (view-only) lands on History.
+    const activeTab = ref<'issue' | 'history'>(canRecord ? 'issue' : 'history');
+
+    const onCreated = () => {
+      activeTab.value = 'history';
+    };
+
+    onMounted(async () => {
+      try {
+        const list = await therapistsClient.getTherapists();
+        therapists.value = list
+          .map((t) => ({ therapistId: t.therapistId, therapistName: t.therapistName }))
+          .sort((a, b) => a.therapistName.localeCompare(b.therapistName));
+      } catch (e: unknown) {
+        loadError.value = e instanceof Error ? e.message : 'Failed to load therapists.';
+      }
+      try {
+        paymentTypes.value = await paymentsClient.getPaymentTypes();
+      } catch {
+        // Non-fatal — the method dropdown will be empty; issuing still validates server-side.
+      }
+    });
+
+    return { therapists, paymentTypes, loadError, activeTab, canRecord, onCreated };
+  },
+});
+</script>

--- a/test-scenarios/wp-14c-service-payments.md
+++ b/test-scenarios/wp-14c-service-payments.md
@@ -1,0 +1,52 @@
+# WP-14C — Service Payments (Therapist Payroll) — User Test Scenarios
+
+These exercise the new **Service Payments** page (`/service-payments`, nav label **Payroll**) and the
+statement integration. Run against a live API + DB with the WP-14A RoleClaim seed applied
+(MGR holds `ServicePayments.View` + `.Record`; AM holds `.View`; FD holds neither).
+
+Sign in as the role noted in each scenario.
+
+---
+
+## 1. Issue a quincena payment (sign in as MGR)
+1. Click **Payroll** in the sidebar → lands on the **Pay Therapist** tab.
+2. Pick a therapist. Note the **From/To** dates default to the current quincena (1st–15th or 16th–EOM).
+3. Click **Find Unpaid Sessions** → completed sessions with a remaining provider amount load, all
+   pre-selected, with a running **total**.
+4. Deselect one session → the total drops by that session's provider amount.
+5. Pick a **Payment Method**, optionally enter a reference and notes, leave **Payment Date** as today.
+6. Click **Issue Payment** → green confirmation appears ("… recorded for <therapist>"), and the page
+   switches to the **History** tab.
+**Expect:** the new payment is recorded; the confirmation offers a **View Statement** link.
+
+## 2. Statement flips to authoritative (sign in as MGR or AM)
+1. After scenario 1, go to **Statements → Therapist**, generate the statement for the same therapist
+   and period.
+**Expect:** the amber **"Estimated — Service Payments not yet tracked"** banner is **gone**; the
+**Service Payments** section lists the payment; **Service Payments** total in the summary is non-zero;
+**Estimated Amount Due** = Provider Amount − Service Payments.
+
+## 3. History view (sign in as MGR or AM)
+1. On **Payroll → History**, pick the therapist + a range covering scenario 1, click **View History**.
+**Expect:** the payment appears with date, amount, method, reference, session count, and notes.
+
+## 4. Empty unpaid list (sign in as MGR)
+1. On **Pay Therapist**, pick a therapist with no completed-unpaid sessions in range (or a future range)
+   and click **Find Unpaid Sessions**.
+**Expect:** "No unpaid completed sessions for this therapist in the selected period."
+
+## 5. Cross-period payment note (sign in as MGR or AM)
+1. Issue a payment whose sessions span two periods (or pay a session, then view a statement whose range
+   only partially overlaps that payment).
+**Expect:** the statement's Service Payments entry still lists the payment; its notes include a clause
+that it "Covers sessions outside this period."
+
+## 6. Permission visibility
+- **AM:** the **Payroll** nav item is visible; opening it shows **only** the **History** tab (no
+  "Pay Therapist" tab — AM cannot issue). Attempting `POST` (not reachable from the UI) would 403.
+- **FD:** the **Payroll** nav item is **absent**; navigating directly to `/service-payments`
+  redirects to the dashboard (no `ServicePayments.View`). FD also never sees provider/payout figures.
+
+## 7. Over-allocation guard (sign in as MGR)
+1. (If exercising the API directly) attempt to apply more than a session's remaining provider amount.
+**Expect:** the API returns `400` and the UI surfaces the error message; no payment is recorded.


### PR DESCRIPTION
New /service-payments page (sidebar "Payroll") gating on the WP-14 claims:
- PayTherapistWizard: pick therapist -> quincena-defaulted date range ->
  Find Unpaid Sessions -> select rows + running total -> payment method /
  reference / notes -> Issue Payment -> confirmation w/ View Statement link.
  Tab gated by ServicePayments.Record (MGR only).
- ServicePaymentsList: payment history per therapist + range.
- Route + sidebar nav item gated by ServicePayments.View (MGR/AM; FD excluded).
- ServicePayment interfaces + ServicePaymentsHttpClient.
- Statement screen auto-hides the pro-forma banner and renders servicePayments[] (already wired in WP-13C — verified, no markup change); refreshed stale TherapistStatement interface comments.
- Re-vendored manifest b10682734edf + regenerated permissions.ts.
- Test scenarios test-scenarios/wp-14c-service-payments.md.

vue-tsc clean, eslint clean, vitest 20/20 green.