### PR TITLE
WP-14.5 (UI): Run Payroll — batch all-therapists tab

### DIFF
--- a/app-ui/src/components/service-payments/RunPayrollWizard.vue
+++ b/app-ui/src/components/service-payments/RunPayrollWizard.vue
@@ -1,0 +1,254 @@
+<template>
+  <div class="space-y-6">
+    <!-- Date range -->
+    <div class="bg-white rounded-xl shadow-sm border border-slate-200 px-6 py-4">
+      <div class="flex flex-col sm:flex-row sm:items-end gap-4">
+        <div>
+          <label class="block text-sm font-medium text-slate-700 mb-1">From</label>
+          <input v-model="fromDate" type="date" class="rounded-lg border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-slate-700 mb-1">To</label>
+          <input v-model="toDate" type="date" class="rounded-lg border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
+        </div>
+        <div>
+          <button
+            :disabled="loading"
+            class="inline-flex items-center px-4 py-2 rounded-lg text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+            @click="loadPreview"
+          >
+            <svg v-if="loading" class="animate-spin -ml-1 mr-2 h-4 w-4 text-white" fill="none" viewBox="0 0 24 24">
+              <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+              <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+            </svg>
+            Preview Payroll
+          </button>
+        </div>
+      </div>
+      <p class="text-xs text-slate-400 mt-2">Pays every therapist owed money in this window at once. Date range defaults to the current quincena. Deselect a therapist to pay them next cycle.</p>
+    </div>
+
+    <div v-if="error" class="bg-red-50 border border-red-200 rounded-lg p-4">
+      <p class="text-sm text-red-700">{{ error }}</p>
+    </div>
+
+    <!-- Success summary -->
+    <div v-if="result" class="bg-green-50 border border-green-200 rounded-lg p-6">
+      <div class="flex items-start gap-3">
+        <svg class="w-6 h-6 text-green-600 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+        </svg>
+        <div class="flex-1">
+          <p class="text-sm font-semibold text-green-900">
+            Payroll run complete — {{ formatCurrency(result.totalPaid) }} across {{ result.therapistCount }} therapist{{ result.therapistCount !== 1 ? 's' : '' }}.
+          </p>
+          <div class="mt-3 flex gap-3">
+            <router-link to="/statements" class="inline-flex items-center px-3 py-1.5 rounded-lg text-sm font-medium text-white bg-green-600 hover:bg-green-700">View Statements</router-link>
+            <button class="inline-flex items-center px-3 py-1.5 rounded-lg text-sm font-medium text-slate-700 bg-white border border-slate-300 hover:bg-slate-50" @click="reset">New Run</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Preview table -->
+    <template v-if="loaded && !result">
+      <div v-if="preview.length === 0" class="bg-white rounded-lg shadow-sm border border-slate-200 p-8 text-center">
+        <p class="text-sm text-slate-500">No therapists are owed for this period.</p>
+      </div>
+
+      <div v-else class="bg-white rounded-lg shadow-sm border border-slate-200">
+        <div class="px-6 py-4 border-b border-slate-200 flex items-center justify-between">
+          <h3 class="text-base font-semibold text-slate-800">Therapists Owed</h3>
+          <div class="flex items-center gap-3 text-sm">
+            <button class="text-blue-600 hover:underline" @click="selectAll(true)">Select all</button>
+            <button class="text-slate-500 hover:underline" @click="selectAll(false)">Clear</button>
+          </div>
+        </div>
+        <div class="overflow-x-auto">
+          <table class="min-w-full divide-y divide-slate-200">
+            <thead class="bg-slate-50">
+              <tr>
+                <th class="px-4 py-3 w-10"></th>
+                <th class="px-4 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Therapist</th>
+                <th class="px-4 py-3 text-right text-xs font-medium text-slate-500 uppercase tracking-wider">Sessions</th>
+                <th class="px-4 py-3 text-right text-xs font-medium text-slate-500 uppercase tracking-wider">Amount Owed</th>
+              </tr>
+            </thead>
+            <tbody class="bg-white divide-y divide-slate-200">
+              <tr v-for="t in preview" :key="t.therapistId" class="hover:bg-slate-50" :class="selected[t.therapistId] ? '' : 'opacity-50'">
+                <td class="px-4 py-3">
+                  <input type="checkbox" v-model="selected[t.therapistId]" class="rounded border-slate-300 text-blue-600 focus:ring-blue-500" />
+                </td>
+                <td class="px-4 py-3 whitespace-nowrap text-sm text-slate-900">{{ t.therapistName }}</td>
+                <td class="px-4 py-3 whitespace-nowrap text-sm text-right text-slate-900">{{ t.sessionCount }}</td>
+                <td class="px-4 py-3 whitespace-nowrap text-sm text-right font-medium text-slate-900">{{ formatCurrency(t.totalRemaining) }}</td>
+              </tr>
+              <tr class="bg-slate-50 font-medium">
+                <td class="px-4 py-3" colspan="3">
+                  <span class="text-sm text-slate-700">{{ selectedCount }} therapist{{ selectedCount !== 1 ? 's' : '' }} selected</span>
+                </td>
+                <td class="px-4 py-3 whitespace-nowrap text-sm text-right text-slate-900">{{ formatCurrency(grandTotal) }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <!-- Shared payment details -->
+      <div v-if="preview.length > 0" class="bg-white rounded-lg shadow-sm border border-slate-200 p-6">
+        <h3 class="text-base font-semibold text-slate-800 mb-1">Payment Details</h3>
+        <p class="text-xs text-slate-400 mb-4">Applied to the whole run. For a one-off exception, use the single-therapist "Pay Therapist" tab instead.</p>
+        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+          <div>
+            <label class="block text-sm font-medium text-slate-700 mb-1">Payment Date</label>
+            <input v-model="paymentDate" type="date" class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-slate-700 mb-1">Payment Method</label>
+            <select v-model="paymentTypeId" class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
+              <option :value="null" disabled>Select...</option>
+              <option v-for="pt in paymentTypes" :key="pt.paymentTypeId" :value="pt.paymentTypeId">{{ pt.name }}</option>
+            </select>
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-slate-700 mb-1">Reference #</label>
+            <input v-model="referenceNumber" type="text" placeholder="Optional" class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-slate-700 mb-1">Notes</label>
+            <input v-model="notes" type="text" placeholder="Optional" class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
+          </div>
+        </div>
+        <div class="mt-6 flex items-center justify-between border-t border-slate-200 pt-4">
+          <div>
+            <span class="text-sm text-slate-600">Total payroll</span>
+            <span class="ml-2 text-2xl font-bold text-blue-700">{{ formatCurrency(grandTotal) }}</span>
+          </div>
+          <button
+            :disabled="!canRun || submitting"
+            class="inline-flex items-center px-5 py-2.5 rounded-lg text-sm font-semibold text-white bg-blue-600 hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+            @click="run"
+          >
+            <svg v-if="submitting" class="animate-spin -ml-1 mr-2 h-4 w-4 text-white" fill="none" viewBox="0 0 24 24">
+              <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+              <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+            </svg>
+            Run Payroll
+          </button>
+        </div>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref, reactive, computed, onMounted, type PropType } from 'vue';
+import { ServicePaymentsHttpClient } from '../../services/ServicePaymentsHttpClient';
+import type { PaymentTypeInfo } from '../../interfaces/Payment';
+import type { PayrollPreviewTherapist, BatchPayrollResult } from '../../interfaces/ServicePayment';
+
+export default defineComponent({
+  name: 'RunPayrollWizard',
+  props: {
+    paymentTypes: { type: Array as PropType<PaymentTypeInfo[]>, required: true },
+  },
+  emits: ['completed'],
+  setup(props, { emit }) {
+    const client = new ServicePaymentsHttpClient();
+
+    const toIso = (d: Date) => d.toISOString().split('T')[0];
+    const fromDate = ref(toIso(new Date()));
+    const toDate = ref(toIso(new Date()));
+    const paymentDate = ref(toIso(new Date()));
+    const paymentTypeId = ref<number | null>(null);
+    const referenceNumber = ref('');
+    const notes = ref('');
+
+    const preview = ref<PayrollPreviewTherapist[]>([]);
+    const selected = reactive<Record<number, boolean>>({});
+    const loaded = ref(false);
+    const loading = ref(false);
+    const submitting = ref(false);
+    const error = ref('');
+    const result = ref<BatchPayrollResult | null>(null);
+
+    const selectedTherapists = computed(() => preview.value.filter((t) => selected[t.therapistId]));
+    const selectedCount = computed(() => selectedTherapists.value.length);
+    const grandTotal = computed(() => selectedTherapists.value.reduce((sum, t) => sum + t.totalRemaining, 0));
+    const canRun = computed(() => selectedCount.value > 0 && !!paymentTypeId.value);
+
+    const formatCurrency = (v: number) => `$${v.toFixed(2)}`;
+
+    const selectAll = (value: boolean) => {
+      preview.value.forEach((t) => { selected[t.therapistId] = value; });
+    };
+
+    const loadPreview = async () => {
+      loading.value = true;
+      error.value = '';
+      result.value = null;
+      try {
+        const list = await client.getPayrollPreview(fromDate.value, toDate.value);
+        preview.value = list;
+        Object.keys(selected).forEach((k) => delete selected[Number(k)]);
+        list.forEach((t) => { selected[t.therapistId] = true; });
+        loaded.value = true;
+      } catch (e: unknown) {
+        error.value = e instanceof Error ? e.message : 'Failed to load payroll preview.';
+      } finally {
+        loading.value = false;
+      }
+    };
+
+    const run = async () => {
+      if (!paymentTypeId.value) return;
+      submitting.value = true;
+      error.value = '';
+      try {
+        result.value = await client.runBatchPayroll({
+          from: fromDate.value,
+          to: toDate.value,
+          paymentDate: paymentDate.value,
+          paymentTypeId: paymentTypeId.value,
+          referenceNumber: referenceNumber.value || null,
+          notes: notes.value || null,
+          therapistIds: selectedTherapists.value.map((t) => t.therapistId),
+        });
+        loaded.value = false;
+        preview.value = [];
+        emit('completed', result.value);
+      } catch (e: unknown) {
+        error.value = e instanceof Error ? e.message : 'Failed to run payroll.';
+      } finally {
+        submitting.value = false;
+      }
+    };
+
+    const reset = () => {
+      result.value = null;
+      referenceNumber.value = '';
+      notes.value = '';
+    };
+
+    onMounted(async () => {
+      try {
+        const window = await client.getQuincena();
+        fromDate.value = window.from;
+        toDate.value = window.to;
+      } catch {
+        // keep today/today if the helper is unreachable
+      }
+      if (props.paymentTypes.length > 0) {
+        paymentTypeId.value = props.paymentTypes[0].paymentTypeId;
+      }
+    });
+
+    return {
+      fromDate, toDate, paymentDate, paymentTypeId, referenceNumber, notes,
+      preview, selected, loaded, loading, submitting, error, result,
+      selectedCount, grandTotal, canRun,
+      formatCurrency, selectAll, loadPreview, run, reset,
+    };
+  },
+});
+</script>

--- a/app-ui/src/interfaces/ServicePayment.ts
+++ b/app-ui/src/interfaces/ServicePayment.ts
@@ -58,3 +58,28 @@ export interface QuincenaWindow {
   from: string
   to: string
 }
+
+// WP-14.5 "Run Payroll" (batch all-therapists).
+export interface PayrollPreviewTherapist {
+  therapistId: number
+  therapistName: string
+  sessionCount: number
+  totalRemaining: number
+  sessions: UnpaidProviderSessionSummary[]
+}
+
+export interface BatchPayrollRequest {
+  from?: string | null
+  to?: string | null
+  paymentDate: string
+  paymentTypeId: number
+  referenceNumber?: string | null
+  notes?: string | null
+  therapistIds: number[]
+}
+
+export interface BatchPayrollResult {
+  payments: ServicePaymentRecord[]
+  therapistCount: number
+  totalPaid: number
+}

--- a/app-ui/src/services/ServicePaymentsHttpClient.ts
+++ b/app-ui/src/services/ServicePaymentsHttpClient.ts
@@ -5,6 +5,9 @@ import type {
   ServicePaymentCreateRequest,
   UnpaidProviderSessionSummary,
   QuincenaWindow,
+  PayrollPreviewTherapist,
+  BatchPayrollRequest,
+  BatchPayrollResult,
 } from '../interfaces/ServicePayment';
 
 export class ServicePaymentsHttpClient extends HttpClientBase {
@@ -35,5 +38,17 @@ export class ServicePaymentsHttpClient extends HttpClientBase {
 
   async createServicePayment(data: ServicePaymentCreateRequest): Promise<ServicePaymentRecord> {
     return this.post<ServicePaymentRecord>('/api/service-payments', data);
+  }
+
+  async getPayrollPreview(from?: string, to?: string): Promise<PayrollPreviewTherapist[]> {
+    const params = new URLSearchParams();
+    if (from) params.append('from', from);
+    if (to) params.append('to', to);
+    const query = params.toString();
+    return this.get<PayrollPreviewTherapist[]>(`/api/service-payments/payroll-preview${query ? `?${query}` : ''}`);
+  }
+
+  async runBatchPayroll(data: BatchPayrollRequest): Promise<BatchPayrollResult> {
+    return this.post<BatchPayrollResult>('/api/service-payments/batch', data);
   }
 }

--- a/app-ui/src/views/ServicePaymentsView.vue
+++ b/app-ui/src/views/ServicePaymentsView.vue
@@ -18,6 +18,15 @@
                 v-if="canRecord"
                 type="button"
                 class="py-3 px-1 border-b-2 text-sm font-medium transition-colors"
+                :class="activeTab === 'run' ? 'border-blue-600 text-blue-600' : 'border-transparent text-slate-500 hover:text-slate-700 hover:border-slate-300'"
+                @click="activeTab = 'run'"
+              >
+                Run Payroll
+              </button>
+              <button
+                v-if="canRecord"
+                type="button"
+                class="py-3 px-1 border-b-2 text-sm font-medium transition-colors"
                 :class="activeTab === 'issue' ? 'border-blue-600 text-blue-600' : 'border-transparent text-slate-500 hover:text-slate-700 hover:border-slate-300'"
                 @click="activeTab = 'issue'"
               >
@@ -36,6 +45,10 @@
 
           <div v-if="loadError" class="mb-6 bg-red-50 border border-red-200 rounded-lg p-4">
             <p class="text-sm text-red-700">{{ loadError }}</p>
+          </div>
+
+          <div v-show="activeTab === 'run' && canRecord">
+            <RunPayrollWizard :payment-types="paymentTypes" @completed="onCreated" />
           </div>
 
           <div v-show="activeTab === 'issue' && canRecord">
@@ -58,6 +71,7 @@ import O2MobileNav from '../components/option02/O2MobileNav.vue';
 import O2Sidebar from '../components/option02/O2Sidebar.vue';
 import O2Header from '../components/option02/O2Header.vue';
 import O2Footer from '../components/option02/O2Footer.vue';
+import RunPayrollWizard from '../components/service-payments/RunPayrollWizard.vue';
 import PayTherapistWizard from '../components/service-payments/PayTherapistWizard.vue';
 import ServicePaymentsList from '../components/service-payments/ServicePaymentsList.vue';
 import { TherapistsHttpClient } from '../services/TherapistsHttpClient';
@@ -72,7 +86,7 @@ interface TherapistOption {
 
 export default defineComponent({
   name: 'ServicePaymentsView',
-  components: { O2MobileNav, O2Sidebar, O2Header, O2Footer, PayTherapistWizard, ServicePaymentsList },
+  components: { O2MobileNav, O2Sidebar, O2Header, O2Footer, RunPayrollWizard, PayTherapistWizard, ServicePaymentsList },
   setup() {
     const { hasClaim } = useClaims();
     const canRecord = hasClaim('Permission', Permissions.ServicePaymentsRecord);
@@ -83,8 +97,8 @@ export default defineComponent({
     const therapists = ref<TherapistOption[]>([]);
     const paymentTypes = ref<PaymentTypeInfo[]>([]);
     const loadError = ref('');
-    // MGR lands on the Pay Therapist tab; AM (view-only) lands on History.
-    const activeTab = ref<'issue' | 'history'>(canRecord ? 'issue' : 'history');
+    // MGR lands on Run Payroll (the headline batch flow); AM (view-only) lands on History.
+    const activeTab = ref<'run' | 'issue' | 'history'>(canRecord ? 'run' : 'history');
 
     const onCreated = () => {
       activeTab.value = 'history';

--- a/test-scenarios/wp-145-run-payroll.md
+++ b/test-scenarios/wp-145-run-payroll.md
@@ -1,0 +1,39 @@
+# WP-14.5 — Run Payroll (batch all-therapists) — User Test Scenarios
+
+Extends WP-14C. New **Run Payroll** tab on `/service-payments` (the "Payroll" nav item). Pays every
+therapist owed money in a window in one pass, with case-by-case opt-out. Single-therapist payments
+remain on the **Pay Therapist** tab.
+
+Prereqs: API + UI on the `feature/wp-145-run-payroll` branches (or merged), RoleClaim seed applied,
+re-login so the JWT carries `ServicePayments.*`.
+
+## 1. Run payroll for everyone (sign in as MGR)
+1. Sidebar → **Payroll** → defaults to the **Run Payroll** tab.
+2. Confirm **From/To** default to the current quincena. Click **Preview Payroll**.
+**Expect:** a table of every therapist owed in the window — name, session count, total owed — all
+pre-checked, with a grand total in the footer.
+3. Pick a **Payment Method** + date, click **Run Payroll**.
+**Expect:** green summary "Payroll run complete — $X across N therapists", page switches to **History**.
+Each therapist now has a ServicePayment; their statements read authoritative for the period.
+
+## 2. Case-by-case opt-out (MGR)
+1. On the preview, untick one therapist → grand total drops by that therapist's owed amount; "N
+   therapists selected" decrements. Use **Select all** / **Clear**.
+2. Run → only the selected therapists are paid; the deselected one still shows as owed on a re-preview.
+
+## 3. Idempotency / no double-pay (MGR)
+1. After a run, click **Preview Payroll** again for the same window.
+**Expect:** therapists paid in step 1 no longer appear (nothing owed); only newly-owed or
+partially-owed therapists remain.
+
+## 4. Empty state (MGR)
+1. Preview a window where nobody is owed (e.g. a future range).
+**Expect:** "No therapists are owed for this period."
+
+## 5. Exception handling guidance (MGR)
+- For a therapist who needs a different method/date than the run, deselect them in Run Payroll and pay
+  them individually on the **Pay Therapist** tab. (Run Payroll uses one shared method + date.)
+
+## 6. Permissions
+- **AM:** no **Run Payroll** (or **Pay Therapist**) tab — only **History**. (Issuing is MGR-only.)
+- **FD:** no **Payroll** nav; `/service-payments` redirects to dashboard.


### PR DESCRIPTION
New "Run Payroll" tab on /service-payments (MGR-only, gated by ServicePayments.Record; MGR now lands here by default):
- RunPayrollWizard: quincena-defaulted range -> Preview Payroll -> table of every therapist owed (session count + total), all pre-checked with case-by-case opt-out -> shared payment method/date -> Run Payroll -> summary + View Statements link.
- ServicePayment interfaces + client: getPayrollPreview, runBatchPayroll.
- Single-therapist "Pay Therapist" wizard unchanged (the exception path).
- Test scenarios test-scenarios/wp-145-run-payroll.md.

vue-tsc clean, eslint clean, vitest 20/20 green.