### PR TITLE
WP-14.5C: Reverse action on Service Payments history (MGR)

### DIFF
--- a/app-ui/src/__tests__/service-payments-reverse.spec.ts
+++ b/app-ui/src/__tests__/service-payments-reverse.spec.ts
@@ -1,0 +1,95 @@
+// WP-14.5 — ServicePaymentsList reverse action gating.
+//
+// The "Reverse" control is gated on ServicePayments.Adjust (MGR-only). It also must not appear on
+// rows that are already reversed or that are themselves reversal entries. Claims are seeded straight
+// from the manifest grants so the gate is tested against the real access-control matrix.
+
+import { describe, it, expect } from 'vitest';
+import { setActivePinia, createPinia, type Pinia } from 'pinia';
+import { mount } from '@vue/test-utils';
+import manifest from '../generated/access-control-matrix.json';
+import { useAuthStore } from '../stores/auth';
+import type { ClaimDto } from '../interfaces/Auth';
+import type { ServicePaymentRecord } from '../interfaces/ServicePayment';
+import ServicePaymentsList from '../components/service-payments/ServicePaymentsList.vue';
+
+type Role = 'MGR' | 'AM' | 'FD';
+
+function claimsForRole(role: Role): ClaimDto[] {
+  return (manifest.claims as Array<{ claim: string; grants: string[] }>)
+    .filter((c) => c.grants.includes(role))
+    .map((c) => ({ type: 'Permission', value: c.claim }));
+}
+
+function authAs(role: Role): Pinia {
+  const pinia = createPinia();
+  setActivePinia(pinia);
+  const store = useAuthStore();
+  store.user = {
+    userId: 1,
+    email: 'test@example.com',
+    fullName: 'Test User',
+    mustChangePassword: false,
+    roles: [role],
+    claims: claimsForRole(role),
+    isSystemAdmin: false,
+  };
+  return pinia;
+}
+
+function payment(overrides: Partial<ServicePaymentRecord> = {}): ServicePaymentRecord {
+  return {
+    servicePaymentId: 500,
+    therapistId: 42,
+    therapistName: 'Smith, Jane',
+    paymentDate: '2026-04-20T00:00:00',
+    amount: 120,
+    paymentType: { paymentTypeId: 1, abbreviation: 'CHK', name: 'Check' },
+    referenceNumber: 'CHK-1',
+    notes: null,
+    allocations: [{ sessionServicePaymentId: 1, sessionId: 1, sessionDate: '2026-04-05', patientName: 'Green, Dan', amountApplied: 120 }],
+    totalApplied: 120,
+    unallocatedAmount: 0,
+    reversesServicePaymentId: null,
+    isReversed: false,
+    ...overrides,
+  };
+}
+
+async function mountWith(role: Role, payments: ServicePaymentRecord[]) {
+  const pinia = authAs(role);
+  const w = mount(ServicePaymentsList, {
+    props: { therapists: [{ therapistId: 42, therapistName: 'Smith, Jane' }] },
+    global: { plugins: [pinia] },
+  });
+  // Drive the component into its loaded state without hitting the network.
+  (w.vm as unknown as { payments: ServicePaymentRecord[] }).payments = payments;
+  (w.vm as unknown as { loaded: boolean }).loaded = true;
+  await w.vm.$nextTick();
+  return w;
+}
+
+describe('ServicePaymentsList — Reverse action gating', () => {
+  it('shows Reverse for MGR on a normal payment', async () => {
+    const w = await mountWith('MGR', [payment()]);
+    expect(w.text()).toContain('Reverse');
+  });
+
+  it('hides Reverse for AM (view-only, lacks ServicePayments.Adjust)', async () => {
+    const w = await mountWith('AM', [payment()]);
+    expect(w.text()).not.toContain('Reverse');
+  });
+
+  it('hides Reverse on an already-reversed original and badges it', async () => {
+    const w = await mountWith('MGR', [payment({ isReversed: true })]);
+    expect(w.text()).toContain('Reversed');
+    expect(w.text()).not.toContain('Reverse payment'); // the action/modal verb
+    expect(w.find('button.text-red-600').exists()).toBe(false);
+  });
+
+  it('hides Reverse on a reversal entry and labels it', async () => {
+    const w = await mountWith('MGR', [payment({ servicePaymentId: 600, amount: -120, reversesServicePaymentId: 500 })]);
+    expect(w.text()).toContain('Reversal of #500');
+    expect(w.find('button.text-red-600').exists()).toBe(false);
+  });
+});

--- a/app-ui/src/components/service-payments/ServicePaymentsList.vue
+++ b/app-ui/src/components/service-payments/ServicePaymentsList.vue
@@ -54,28 +54,93 @@
               <th class="px-4 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Reference</th>
               <th class="px-4 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Sessions</th>
               <th class="px-4 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Notes</th>
+              <th v-if="canAdjust" class="px-4 py-3 text-right text-xs font-medium text-slate-500 uppercase tracking-wider">Actions</th>
             </tr>
           </thead>
           <tbody class="bg-white divide-y divide-slate-200">
             <tr v-for="p in payments" :key="p.servicePaymentId" class="hover:bg-slate-50">
               <td class="px-4 py-3 whitespace-nowrap text-sm text-slate-900">{{ formatDate(p.paymentDate) }}</td>
-              <td class="px-4 py-3 whitespace-nowrap text-sm text-right font-medium text-slate-900">{{ formatCurrency(p.amount) }}</td>
+              <td class="px-4 py-3 whitespace-nowrap text-sm text-right font-medium" :class="p.amount < 0 ? 'text-red-600' : 'text-slate-900'">
+                {{ formatCurrency(p.amount) }}
+              </td>
               <td class="px-4 py-3 whitespace-nowrap text-sm text-slate-900">{{ p.paymentType?.name || '—' }}</td>
               <td class="px-4 py-3 whitespace-nowrap text-sm text-slate-900">{{ p.referenceNumber || '—' }}</td>
               <td class="px-4 py-3 whitespace-nowrap text-sm text-slate-900">{{ p.allocations.length }}</td>
-              <td class="px-4 py-3 text-sm text-slate-600">{{ p.notes || '—' }}</td>
+              <td class="px-4 py-3 text-sm text-slate-600">
+                <span
+                  v-if="p.reversesServicePaymentId"
+                  class="inline-flex items-center px-2 py-0.5 mr-2 rounded text-xs font-medium bg-amber-100 text-amber-800"
+                >Reversal of #{{ p.reversesServicePaymentId }}</span>
+                <span
+                  v-else-if="p.isReversed"
+                  class="inline-flex items-center px-2 py-0.5 mr-2 rounded text-xs font-medium bg-slate-200 text-slate-600"
+                >Reversed</span>
+                {{ p.notes || '—' }}
+              </td>
+              <td v-if="canAdjust" class="px-4 py-3 whitespace-nowrap text-sm text-right">
+                <button
+                  v-if="!p.isReversed && !p.reversesServicePaymentId"
+                  class="text-red-600 hover:text-red-800 text-sm font-medium"
+                  @click="openReverse(p)"
+                >
+                  Reverse
+                </button>
+              </td>
             </tr>
           </tbody>
         </table>
+      </div>
+    </div>
+
+    <!-- Reverse confirmation modal -->
+    <div v-if="reverseTarget" class="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4">
+      <div class="bg-white rounded-xl shadow-xl w-full max-w-md p-6 space-y-4">
+        <h3 class="text-lg font-semibold text-slate-900">Reverse payment #{{ reverseTarget.servicePaymentId }}</h3>
+        <p class="text-sm text-slate-600">
+          This writes an offsetting <span class="font-medium">{{ formatCurrency(-reverseTarget.amount) }}</span>
+          entry; the original is kept for the audit trail and the
+          {{ reverseTarget.allocations.length }} session(s) it covered become unpaid again. This cannot be undone —
+          to re-pay, issue a new payment from the <span class="font-medium">Pay Therapist</span> tab.
+        </p>
+        <div>
+          <label class="block text-sm font-medium text-slate-700 mb-1">Reason <span class="text-red-600">*</span></label>
+          <textarea
+            v-model="reverseReason"
+            rows="3"
+            placeholder="e.g. Issued to the wrong therapist"
+            class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-red-500"
+          ></textarea>
+        </div>
+        <div v-if="reverseError" class="bg-red-50 border border-red-200 rounded-lg p-3">
+          <p class="text-sm text-red-700">{{ reverseError }}</p>
+        </div>
+        <div class="flex justify-end gap-3 pt-2">
+          <button
+            class="px-4 py-2 rounded-lg text-sm font-medium text-slate-700 bg-slate-100 hover:bg-slate-200"
+            :disabled="reverseSubmitting"
+            @click="cancelReverse"
+          >
+            Cancel
+          </button>
+          <button
+            class="px-4 py-2 rounded-lg text-sm font-medium text-white bg-red-600 hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed"
+            :disabled="reverseSubmitting || !reverseReason.trim()"
+            @click="confirmReverse"
+          >
+            {{ reverseSubmitting ? 'Reversing…' : 'Reverse payment' }}
+          </button>
+        </div>
       </div>
     </div>
   </div>
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, type PropType } from 'vue';
+import { defineComponent, ref, computed, type PropType } from 'vue';
 import { ServicePaymentsHttpClient } from '../../services/ServicePaymentsHttpClient';
 import type { ServicePaymentRecord } from '../../interfaces/ServicePayment';
+import { useClaims, Permissions } from '../../composables/useClaims';
+import { formatCurrency } from '../../utils/formatCurrency';
 
 interface TherapistOption {
   therapistId: number
@@ -89,6 +154,8 @@ export default defineComponent({
   },
   setup() {
     const client = new ServicePaymentsHttpClient();
+    const { hasClaim } = useClaims();
+    const canAdjust = computed(() => hasClaim('Permission', Permissions.ServicePaymentsAdjust));
 
     const selectedTherapistId = ref<number | null>(null);
     const toIso = (d: Date) => d.toISOString().split('T')[0];
@@ -103,7 +170,6 @@ export default defineComponent({
     const loading = ref(false);
     const error = ref('');
 
-    const formatCurrency = (v: number) => `$${v.toFixed(2)}`;
     const formatDate = (dateStr: string) => new Date(dateStr).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
 
     const load = async () => {
@@ -120,7 +186,43 @@ export default defineComponent({
       }
     };
 
-    return { selectedTherapistId, fromDate, toDate, payments, loaded, loading, error, formatCurrency, formatDate, load };
+    // ---- Reversal ----
+    const reverseTarget = ref<ServicePaymentRecord | null>(null);
+    const reverseReason = ref('');
+    const reverseError = ref('');
+    const reverseSubmitting = ref(false);
+
+    const openReverse = (p: ServicePaymentRecord) => {
+      reverseTarget.value = p;
+      reverseReason.value = '';
+      reverseError.value = '';
+    };
+
+    const cancelReverse = () => {
+      reverseTarget.value = null;
+    };
+
+    const confirmReverse = async () => {
+      if (!reverseTarget.value || !reverseReason.value.trim()) return;
+      reverseSubmitting.value = true;
+      reverseError.value = '';
+      try {
+        await client.reverseServicePayment(reverseTarget.value.servicePaymentId, { reason: reverseReason.value.trim() });
+        reverseTarget.value = null;
+        await load();
+      } catch (e: unknown) {
+        reverseError.value = e instanceof Error ? e.message : 'Failed to reverse the payment.';
+      } finally {
+        reverseSubmitting.value = false;
+      }
+    };
+
+    return {
+      selectedTherapistId, fromDate, toDate, payments, loaded, loading, error,
+      formatCurrency, formatDate, load, canAdjust,
+      reverseTarget, reverseReason, reverseError, reverseSubmitting,
+      openReverse, cancelReverse, confirmReverse,
+    };
   },
 });
 </script>

--- a/app-ui/src/generated/access-control-matrix.json
+++ b/app-ui/src/generated/access-control-matrix.json
@@ -1,9 +1,9 @@
 {
   "_meta": {
-    "generatedAt": "2026-06-20T14:20:39-05:00",
+    "generatedAt": "2026-06-29T19:18:00-05:00",
     "generator": "tools/generate-access-manifest.sh",
     "hashScope": "sha256 (first 12 hex) of canonical JSON {claims:[{claim,grants}]}, claims+grants sorted; wildcard/restricted cells and all metadata excluded",
-    "semanticHash": "b10682734edf",
+    "semanticHash": "16599d6c39fc",
     "source": "access-control-matrix.md"
   },
   "claims": [
@@ -246,6 +246,12 @@
       "grants": [
         "AM",
         "FD",
+        "MGR"
+      ]
+    },
+    {
+      "claim": "ServicePayments.Adjust",
+      "grants": [
         "MGR"
       ]
     },

--- a/app-ui/src/generated/permissions.ts
+++ b/app-ui/src/generated/permissions.ts
@@ -8,7 +8,7 @@
 //   app-ui/src/generated/access-control-matrix.json, then re-run
 //   tools/generate-ui-permissions.sh.
 //
-//   Access-control manifest semantic hash: b10682734edf
+//   Access-control manifest semantic hash: 16599d6c39fc
 // </auto-generated>
 
 /**
@@ -56,6 +56,7 @@ export const Permissions = {
   ScheduleBook: 'Schedule.Book',
   ScheduleRebook: 'Schedule.Rebook',
   ScheduleView: 'Schedule.View',
+  ServicePaymentsAdjust: 'ServicePayments.Adjust',
   ServicePaymentsRecord: 'ServicePayments.Record',
   ServicePaymentsView: 'ServicePayments.View',
   StatementsCaretakerView: 'Statements.Caretaker.View',
@@ -75,4 +76,4 @@ export const Permissions = {
 export type Permission = (typeof Permissions)[keyof typeof Permissions];
 
 /** Access-control manifest semantic hash this module was generated from (WP-17 anchor). */
-export const ACCESS_CONTROL_MANIFEST_HASH = 'b10682734edf';
+export const ACCESS_CONTROL_MANIFEST_HASH = '16599d6c39fc';

--- a/app-ui/src/interfaces/ServicePayment.ts
+++ b/app-ui/src/interfaces/ServicePayment.ts
@@ -40,6 +40,13 @@ export interface ServicePaymentRecord {
   allocations: ServiceAllocationDetail[]
   totalApplied: number
   unallocatedAmount: number
+  reversesServicePaymentId: number | null   // set when this record is itself a reversal entry (WP-14.5)
+  isReversed: boolean                        // true when a later reversal entry offsets this payment
+}
+
+// WP-14.5 — append-only reversal of an issued payment.
+export interface ReverseServicePaymentRequest {
+  reason: string
 }
 
 export interface UnpaidProviderSessionSummary {

--- a/app-ui/src/services/ServicePaymentsHttpClient.ts
+++ b/app-ui/src/services/ServicePaymentsHttpClient.ts
@@ -3,6 +3,7 @@ import { HttpClientBase } from './HttpClientBase';
 import type {
   ServicePaymentRecord,
   ServicePaymentCreateRequest,
+  ReverseServicePaymentRequest,
   UnpaidProviderSessionSummary,
   QuincenaWindow,
   PayrollPreviewTherapist,
@@ -40,6 +41,11 @@ export class ServicePaymentsHttpClient extends HttpClientBase {
 
   async createServicePayment(data: ServicePaymentCreateRequest): Promise<ServicePaymentRecord> {
     return this.post<ServicePaymentRecord>('/api/service-payments', data);
+  }
+
+  // WP-14.5 — reverse an issued payment via an append-only offsetting entry. Returns the reversal record.
+  async reverseServicePayment(id: number, data: ReverseServicePaymentRequest): Promise<ServicePaymentRecord> {
+    return this.post<ServicePaymentRecord>(`/api/service-payments/${id}/reverse`, data);
   }
 
   async getPayrollPreview(from?: string, to?: string): Promise<PayrollPreviewTherapist[]> {

--- a/test-scenarios/wp-145-reverse-payment.md
+++ b/test-scenarios/wp-145-reverse-payment.md
@@ -1,0 +1,34 @@
+# WP-14.5 — Reverse a Service Payment — User Test Scenarios
+
+Extends WP-14C. Adds a **Reverse** action to the **History** tab on `/service-payments`. Reversal is
+**append-only**: it never edits or deletes the original — it writes one offsetting negative payment and
+re-opens the covered sessions as unpaid. Reversing is **MGR-only** (`ServicePayments.Adjust`).
+
+Prereqs: API + UI on the `feature/wp-14-5*-reverse-*` branches (or merged), the regenerated RoleClaim
+seed applied to the DB, and re-login so the JWT carries the new `ServicePayments.Adjust` claim.
+
+## 1. Reverse a payment (sign in as MGR)
+1. Sidebar → **Payroll** → **History**. Pick a therapist + range, **View History**.
+2. On a normal payment row, click **Reverse** (red link in the Actions column).
+**Expect:** a confirmation modal showing the offsetting amount and how many sessions re-open, with a
+**required Reason** field. The **Reverse payment** button stays disabled until a reason is typed.
+3. Enter a reason (e.g. "Issued to the wrong therapist") → **Reverse payment**.
+**Expect:** the modal closes and the list refreshes. The original row now shows a grey **Reversed**
+badge with no Reverse action; a new row appears with a **Reversal of #N** badge and a red negative
+amount.
+
+## 2. Correct a payment = reverse then re-issue (MGR)
+1. After reversing in scenario 1, go to the **Pay Therapist** tab for that therapist + period.
+**Expect:** the sessions the reversed payment had covered are **owed again** and selectable.
+2. Issue a corrected payment.
+**Expect:** the therapist's statement reads authoritative with the corrected amount due.
+
+## 3. Guard rails (MGR)
+- A **Reversed** original has no Reverse action (can't reverse twice).
+- A **Reversal of #N** entry has no Reverse action (can't reverse a reversal).
+- Submitting with a blank reason is blocked client-side; the API also rejects it (400).
+
+## 4. Permissions
+- **AM:** History is visible (view-only), but there is **no Actions column / Reverse button** — AM lacks
+  `ServicePayments.Adjust`. Direct `POST /api/service-payments/{id}/reverse` returns **403**.
+- **FD:** no **Payroll** nav at all; `/service-payments` redirects to the dashboard.


### PR DESCRIPTION
Add a Reverse action to the History tab on /service-payments, gated on ServicePayments.Adjust (MGR-only). Confirmation modal requires a reason; on success the list refreshes, the original badges "Reversed", and the offsetting entry shows as "Reversal of #N" with a red negative amount. Reverse is hidden on already-reversed originals and on reversal entries themselves.

- reverseServicePayment HTTP client + ReverseServicePaymentRequest type; ServicePaymentRecord gains reversesServicePaymentId + isReversed.
- Re-vendored manifest + regenerated permissions.ts (ServicePaymentsAdjust, hash 16599d6c39fc). ServicePaymentsList now uses the shared formatCurrency (thousands separators) instead of a local toFixed.
- Vitest gating spec (MGR sees Reverse; AM does not; reversed/reversal rows show no action) + test-scenarios doc. vue-tsc / eslint / vitest all green.