### PR TITLE
WP-18C: patient Cedula field + derived Age (UI)

### DIFF
--- a/app-ui/src/__tests__/age.spec.ts
+++ b/app-ui/src/__tests__/age.spec.ts
@@ -1,0 +1,43 @@
+// WP-18C — derived patient age helper.
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import { formatAge } from '../utils/age';
+
+describe('formatAge', () => {
+  beforeAll(() => {
+    // Freeze "now" so age math is deterministic.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-29T12:00:00'));
+  });
+
+  afterAll(() => {
+    vi.useRealTimers();
+  });
+
+  it('computes whole years and months', () => {
+    expect(formatAge('2000-01-15')).toBe('26 yrs 5 mos');
+  });
+
+  it('borrows a month when the birthday day-of-month is later this month', () => {
+    // DoB day (30) is after "today" (29) → June not yet completed.
+    expect(formatAge('2020-05-30')).toBe('6 yrs 0 mos');
+  });
+
+  it('handles an exact birthday (0 months)', () => {
+    expect(formatAge('2010-06-29')).toBe('16 yrs 0 mos');
+  });
+
+  it('accepts full ISO datetime strings (API shape)', () => {
+    expect(formatAge('2000-01-15T00:00:00')).toBe('26 yrs 5 mos');
+  });
+
+  it('returns empty string for blank / null / undefined', () => {
+    expect(formatAge('')).toBe('');
+    expect(formatAge(null)).toBe('');
+    expect(formatAge(undefined)).toBe('');
+  });
+
+  it('returns empty string for invalid or future dates', () => {
+    expect(formatAge('not-a-date')).toBe('');
+    expect(formatAge('2099-01-01')).toBe('');
+  });
+});

--- a/app-ui/src/components/patients/PatientFormModal.vue
+++ b/app-ui/src/components/patients/PatientFormModal.vue
@@ -61,6 +61,17 @@
               required
               class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
             />
+            <p v-if="age" class="mt-1 text-xs text-slate-400">Age: {{ age }}</p>
+          </div>
+
+          <div>
+            <label class="block text-sm font-medium text-slate-700 mb-1">Cedula</label>
+            <input
+              v-model="form.cedula"
+              type="text"
+              class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              placeholder="Government ID (optional)"
+            />
           </div>
 
           <div>
@@ -191,6 +202,7 @@ import { isTemporaryMrn } from '../../interfaces/Patient';
 import { useModalForm } from '../../composables/useModalForm';
 import FormErrorBanner from '../shared/FormErrorBanner.vue';
 import { PatientsHttpClient } from '../../services/PatientsHttpClient';
+import { formatAge } from '../../utils/age';
 
 function parseName(patientName: string) {
   const [last, rest] = patientName.split(', ');
@@ -241,6 +253,7 @@ export default defineComponent({
       phoneNumber: '',
       gender: '',
       medicalRecordNumber: '',
+      cedula: '',
       activeStatus: true,
     });
 
@@ -248,6 +261,7 @@ export default defineComponent({
 
     const hasTemporaryMrn = computed(() => isEdit.value && isTemporaryMrn(form.medicalRecordNumber));
     const cannotActivate = computed(() => hasTemporaryMrn.value && !form.activeStatus);
+    const age = computed(() => formatAge(form.dateOfBirth));
 
     watch(form, () => clearError(), { deep: true });
 
@@ -267,6 +281,7 @@ export default defineComponent({
           form.phoneNumber = props.patient.phoneNumber ?? '';
           form.gender = props.patient.gender ?? '';
           form.medicalRecordNumber = props.patient.medicalRecordNumber ?? '';
+          form.cedula = props.patient.cedula ?? '';
           form.activeStatus = props.patient.isActive;
         } else {
           isEdit.value = false;
@@ -278,6 +293,7 @@ export default defineComponent({
           form.phoneNumber = '';
           form.gender = '';
           form.medicalRecordNumber = '';
+          form.cedula = '';
           form.activeStatus = true;
         }
       }
@@ -306,6 +322,7 @@ export default defineComponent({
             email: form.email,
             phoneNumber: form.phoneNumber,
             gender: form.gender,
+            cedula: form.cedula || undefined,
           };
 
           if (assigningPermanentMrn && form.activeStatus) {
@@ -336,6 +353,7 @@ export default defineComponent({
             phoneNumber: form.phoneNumber,
             gender: form.gender,
             medicalRecordNumber: form.medicalRecordNumber || undefined,
+            cedula: form.cedula || undefined,
           });
           if (isTemporaryMrn(created.medicalRecordNumber ?? '')) {
             emit('created-temp-mrn', created);
@@ -346,7 +364,7 @@ export default defineComponent({
       });
     };
 
-    return { form, isEdit, saving, error, hasError, hasTemporaryMrn, cannotActivate, handleSubmit };
+    return { form, isEdit, saving, error, hasError, hasTemporaryMrn, cannotActivate, age, handleSubmit };
   },
 });
 </script>

--- a/app-ui/src/components/patients/PatientList.vue
+++ b/app-ui/src/components/patients/PatientList.vue
@@ -151,6 +151,7 @@ export default defineComponent({
         list = list.filter((p) =>
           p.patientName.toLowerCase().includes(q) ||
           (p.medicalRecordNumber ?? '').toLowerCase().includes(q) ||
+          (p.cedula ?? '').toLowerCase().includes(q) ||
           (p.email ?? '').toLowerCase().includes(q) ||
           (p.phoneNumber ?? '').includes(q)
         );

--- a/app-ui/src/components/patients/PatientTable.vue
+++ b/app-ui/src/components/patients/PatientTable.vue
@@ -38,7 +38,11 @@
             </span>
             <span v-else class="text-slate-600">{{ patient.medicalRecordNumber }}</span>
           </td>
-          <td class="px-4 py-3 text-sm text-slate-600">{{ formatDate(patient.dateOfBirth) }}</td>
+          <td class="px-4 py-3 text-sm text-slate-600">{{ patient.cedula }}</td>
+          <td class="px-4 py-3 text-sm text-slate-600">
+            {{ formatDate(patient.dateOfBirth) }}
+            <span v-if="formatAge(patient.dateOfBirth)" class="block text-xs text-slate-400">{{ formatAge(patient.dateOfBirth) }}</span>
+          </td>
           <td class="px-4 py-3 text-sm text-slate-600">{{ patient.gender }}</td>
           <td class="px-4 py-3 text-sm text-slate-600">{{ patient.email }}</td>
           <td class="px-4 py-3 text-sm text-slate-600">{{ patient.phoneNumber }}</td>
@@ -115,7 +119,7 @@
           </td>
         </tr>
         <tr v-if="sortedPatients.length === 0">
-          <td colspan="9" class="px-4 py-12 text-center text-sm text-slate-400">
+          <td colspan="10" class="px-4 py-12 text-center text-sm text-slate-400">
             No patients found.
           </td>
         </tr>
@@ -150,8 +154,12 @@
         </span>
       </div>
       <div class="grid grid-cols-2 gap-2 text-xs text-slate-500 mb-3">
-        <div><span class="font-medium">DOB:</span> {{ formatDate(patient.dateOfBirth) }}</div>
+        <div>
+          <span class="font-medium">DOB:</span> {{ formatDate(patient.dateOfBirth) }}
+          <span v-if="formatAge(patient.dateOfBirth)" class="text-slate-400">({{ formatAge(patient.dateOfBirth) }})</span>
+        </div>
         <div><span class="font-medium">Gender:</span> {{ patient.gender }}</div>
+        <div><span class="font-medium">Cedula:</span> {{ patient.cedula || '—' }}</div>
         <div><span class="font-medium">Email:</span> {{ patient.email }}</div>
         <div><span class="font-medium">Phone:</span> {{ patient.phoneNumber }}</div>
         <div class="col-span-2">
@@ -206,6 +214,7 @@
 import { defineComponent, ref, computed, type PropType } from 'vue';
 import type { Patient } from '../../interfaces/Patient';
 import { isTemporaryMrn } from '../../interfaces/Patient';
+import { formatAge } from '../../utils/age';
 import { useClaims, Permissions } from '../../composables/useClaims';
 
 export default defineComponent({
@@ -222,6 +231,7 @@ export default defineComponent({
     const columns = [
       { key: 'patientName', label: 'Name' },
       { key: 'medicalRecordNumber', label: 'MRN' },
+      { key: 'cedula', label: 'Cedula' },
       { key: 'dateOfBirth', label: 'DOB' },
       { key: 'gender', label: 'Gender' },
       { key: 'email', label: 'Email' },
@@ -276,7 +286,7 @@ export default defineComponent({
       return primary ? primary.caretakerName : '';
     };
 
-    return { columns, sortKey, sortAsc, sortedPatients, toggleSort, formatDate, isTemporaryMrn, primaryCaretakerName, hasClaim, Permissions };
+    return { columns, sortKey, sortAsc, sortedPatients, toggleSort, formatDate, formatAge, isTemporaryMrn, primaryCaretakerName, hasClaim, Permissions };
   },
 });
 </script>

--- a/app-ui/src/interfaces/Patient.ts
+++ b/app-ui/src/interfaces/Patient.ts
@@ -6,6 +6,7 @@ export interface Patient {
   userId: number;
   patientName: string;       // "Last, First Middle" from API
   medicalRecordNumber: string | null;
+  cedula: string | null;
   dateOfBirth: string;
   email: string | null;
   phoneNumber: string | null;
@@ -33,6 +34,7 @@ export interface PatientCreateRequest {
   phoneNumber: string;
   gender: string;
   medicalRecordNumber?: string;
+  cedula?: string;
 }
 
 // Maps to API's PatientProfileUpdateRequest (PUT)
@@ -46,6 +48,7 @@ export interface PatientUpdateRequest {
   gender: string;
   activeStatus: boolean;
   medicalRecordNumber?: string;
+  cedula?: string;
 }
 
 // Temporary MRN helper

--- a/app-ui/src/utils/age.ts
+++ b/app-ui/src/utils/age.ts
@@ -1,0 +1,46 @@
+// Derived patient age ("Y yrs M mos") from a date of birth.
+//
+// Display-only — WP-18 keeps Age out of the DB/API entirely; the UI computes it from the patient's
+// `dateOfBirth` at render time. Returns '' for empty/invalid/future DoB so callers can render nothing
+// rather than a nonsensical value.
+//
+// We parse the leading yyyy-MM-dd as plain calendar numbers (covering both 'yyyy-MM-dd' from the form
+// and 'yyyy-MM-ddT00:00:00' from the API) and compare against the local "today". This sidesteps the
+// `new Date('yyyy-MM-dd')`-parses-as-UTC gotcha (the same hazard localDate.ts documents): mixing a
+// UTC-parsed DoB with a local now would shift the age by a day across timezones.
+export function formatAge(dob: string | null | undefined): string {
+  if (!dob) return '';
+
+  let by: number, bm: number, bd: number; // birth year / month(0-based) / day
+  const iso = /^(\d{4})-(\d{2})-(\d{2})/.exec(dob);
+  if (iso) {
+    by = Number(iso[1]);
+    bm = Number(iso[2]) - 1;
+    bd = Number(iso[3]);
+  } else {
+    const d = new Date(dob);
+    if (isNaN(d.getTime())) return '';
+    by = d.getFullYear();
+    bm = d.getMonth();
+    bd = d.getDate();
+  }
+
+  const now = new Date();
+  const ny = now.getFullYear();
+  const nm = now.getMonth();
+  const nd = now.getDate();
+
+  // Future date of birth → no meaningful age.
+  if (by > ny || (by === ny && (bm > nm || (bm === nm && bd > nd)))) return '';
+
+  let years = ny - by;
+  let months = nm - bm;
+  // Borrow a month if the day-of-month hasn't been reached yet this month.
+  if (nd < bd) months -= 1;
+  if (months < 0) {
+    years -= 1;
+    months += 12;
+  }
+
+  return `${years} yrs ${months} mos`;
+}

--- a/app-ui/src/views/PatientsView.vue
+++ b/app-ui/src/views/PatientsView.vue
@@ -166,6 +166,7 @@ export default defineComponent({
           phoneNumber: patient.phoneNumber ?? '',
           gender: patient.gender ?? '',
           activeStatus: !patient.isActive,
+          cedula: patient.cedula ?? undefined,
         });
         await loadPatients();
         pastDueLoaded.value = false;

--- a/app-ui/test-scenarios/wp-18c-patient-cedula-age.md
+++ b/app-ui/test-scenarios/wp-18c-patient-cedula-age.md
@@ -1,0 +1,55 @@
+# WP-18C — Patient Cedula + derived Age (UI test scenarios)
+
+Adds an optional **Cedula** (government ID) field to the patient record and a display-only **Age
+(yy mm)** derived from Date of Birth. Age is never stored or sent to the API — the UI computes it.
+
+## Setup
+- Sign in as a user with `Patients.Edit` (e.g. MGR/AM/FD) so Add/Edit are available.
+- Navigate to **Patients**.
+
+## Scenarios
+
+### 1. Create a patient with a Cedula
+1. Click **Add Patient**.
+2. Fill required fields; in **Cedula**, enter `001-1234567-8`.
+3. Note the **Age** line appears under Date of Birth as you pick a DoB (e.g. "Age: 26 yrs 5 mos").
+4. Save.
+5. **Expect:** patient appears in the table with the Cedula shown in the **Cedula** column; the DOB cell
+   shows the derived age beneath the date.
+
+### 2. Create a patient with no Cedula (optional)
+1. **Add Patient**, leave **Cedula** blank, fill the rest, save.
+2. **Expect:** saves successfully; Cedula column is blank (mobile card shows "—"). No error.
+
+### 3. Duplicate Cedula is rejected
+1. **Add Patient** with a Cedula already used by another patient.
+2. **Expect:** save fails with a friendly error: **"A patient with this Cedula already exists."**
+   (HTTP 409 from the API.) No patient is created.
+
+### 4. Edit an existing patient's Cedula
+1. Edit a patient, change **Cedula** to a new unique value, save.
+2. **Expect:** the new Cedula shows in the table and persists after a refresh.
+
+### 5. Age updates live with Date of Birth
+1. Open Add or Edit; change the **Date of Birth** field.
+2. **Expect:** the **Age** line recomputes immediately ("Y yrs M mos"). Clearing/blank or a future DoB
+   shows no age line.
+
+### 6. Deactivate / reactivate does not drop the Cedula
+1. From the table actions, **Deactivate** then **Activate** a patient that has a Cedula.
+2. **Expect:** the Cedula is unchanged after the toggle (not erased).
+
+### 7. Search by Cedula
+1. In the patient search box, type part of a patient's Cedula.
+2. **Expect:** the list filters to matching patient(s) — Cedula is searchable alongside name/MRN/email/phone.
+
+### 8. Age display in the list
+1. Review the **DOB** column (desktop) and the DOB line (mobile card).
+2. **Expect:** each patient with a valid DoB shows the derived age; a patient with no/blank DoB shows the
+   date only (no age).
+
+## Notes
+- **Age boundaries:** exact birthday → "N yrs 0 mos"; the month borrows correctly when the day-of-month
+  hasn't been reached yet this month. Verified by `src/__tests__/age.spec.ts`.
+- Age is timezone-stable (parses the `yyyy-MM-dd` prefix directly), so it doesn't shift by a day for
+  users west of UTC.


### PR DESCRIPTION
Surface the new optional Cedula attribute and a display-only Age (yy mm) derived from DoB (never stored or sent to the API).

- interfaces/Patient.ts: cedula on Patient + both request types
- utils/age.ts: formatAge() — timezone-stable yyyy-MM-dd parsing; '' for empty/invalid/future; + age.spec.ts
- PatientFormModal: Cedula input, live Age under DoB, cedula in create + both update payloads
- PatientTable: Cedula column + age under DOB (desktop + mobile), colspan 9->10
- PatientList: cedula added to the search filter
- PatientsView.toggleActive: include current cedula in the payload
- test-scenarios/wp-18c-patient-cedula-age.md

vue-tsc clean, eslint clean, vitest 30/30.