### PR TITLE
Delinquent tabs: Oldest/Newest session-date columns (patients + thera…

### DIFF
--- a/app-ui/src/__tests__/delinquency-range.spec.ts
+++ b/app-ui/src/__tests__/delinquency-range.spec.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { pastDueDateRange } from '../utils/delinquencyRange';
+import type { DelinquentSession } from '../interfaces/Delinquency';
+
+function session(overrides: Partial<DelinquentSession>): DelinquentSession {
+  return {
+    sessionId: 1,
+    sessionDate: '2026-01-01',
+    sessionTime: '00:00:00',
+    patient: 'P',
+    therapist: 'T',
+    therapyTypes: 'TC',
+    amount: 50,
+    discount: 0,
+    amountPaid: 0,
+    amountDue: 50,
+    isPastDue: true,
+    isPaidOff: false,
+    notes: '',
+    patientId: 1,
+    therapistId: 1,
+    ...overrides,
+  };
+}
+
+describe('pastDueDateRange', () => {
+  it('returns min and max sessionDate across past-due sessions', () => {
+    const r = pastDueDateRange([
+      session({ sessionId: 1, sessionDate: '2026-03-15' }),
+      session({ sessionId: 2, sessionDate: '2026-01-04' }),
+      session({ sessionId: 3, sessionDate: '2026-05-20' }),
+    ]);
+    expect(r).toEqual({ oldest: '2026-01-04', newest: '2026-05-20' });
+  });
+
+  it('ignores sessions that are not past due (35-day rule not yet crossed)', () => {
+    const r = pastDueDateRange([
+      session({ sessionId: 1, sessionDate: '2026-02-10' }),
+      session({ sessionId: 2, sessionDate: '2025-11-30', isPastDue: false }), // older but not past due
+      session({ sessionId: 3, sessionDate: '2026-06-28', isPastDue: false }), // newer but not past due
+    ]);
+    expect(r).toEqual({ oldest: '2026-02-10', newest: '2026-02-10' });
+  });
+
+  it('collapses to a single date when only one past-due session exists', () => {
+    const r = pastDueDateRange([session({ sessionDate: '2026-04-01' })]);
+    expect(r).toEqual({ oldest: '2026-04-01', newest: '2026-04-01' });
+  });
+
+  it('returns nulls when no session is past due or the list is empty', () => {
+    expect(pastDueDateRange([])).toEqual({ oldest: null, newest: null });
+    expect(pastDueDateRange([session({ isPastDue: false })]))
+      .toEqual({ oldest: null, newest: null });
+  });
+
+  it('skips past-due sessions with a blank date instead of treating them as oldest', () => {
+    const r = pastDueDateRange([
+      session({ sessionId: 1, sessionDate: '' }),
+      session({ sessionId: 2, sessionDate: '2026-02-14' }),
+    ]);
+    expect(r).toEqual({ oldest: '2026-02-14', newest: '2026-02-14' });
+  });
+
+  it('orders correctly across year boundaries (plain string comparison)', () => {
+    const r = pastDueDateRange([
+      session({ sessionId: 1, sessionDate: '2026-01-02' }),
+      session({ sessionId: 2, sessionDate: '2025-12-28' }),
+    ]);
+    expect(r).toEqual({ oldest: '2025-12-28', newest: '2026-01-02' });
+  });
+});

--- a/app-ui/src/components/patients/DelinquentTable.vue
+++ b/app-ui/src/components/patients/DelinquentTable.vue
@@ -7,6 +7,8 @@
           <th class="px-4 py-3 text-left text-xs font-semibold text-amber-700 uppercase tracking-wider w-8"></th>
           <th class="px-4 py-3 text-left text-xs font-semibold text-amber-700 uppercase tracking-wider">Patient</th>
           <th class="px-4 py-3 text-left text-xs font-semibold text-amber-700 uppercase tracking-wider">Past-Due Sessions</th>
+          <th class="px-4 py-3 text-left text-xs font-semibold text-amber-700 uppercase tracking-wider">Oldest</th>
+          <th class="px-4 py-3 text-left text-xs font-semibold text-amber-700 uppercase tracking-wider">Newest</th>
           <th class="px-4 py-3 text-left text-xs font-semibold text-amber-700 uppercase tracking-wider">Total Due</th>
           <th class="px-4 py-3 text-left text-xs font-semibold text-amber-700 uppercase tracking-wider">Paid So Far</th>
           <th class="px-4 py-3 text-left text-xs font-semibold text-amber-700 uppercase tracking-wider">Balance</th>
@@ -33,6 +35,8 @@
                 {{ dp.pastDueSessions }}
               </span>
             </td>
+            <td class="px-4 py-3 text-sm text-slate-600">{{ formatDate(pastDueRange(dp).oldest ?? '') || '—' }}</td>
+            <td class="px-4 py-3 text-sm text-slate-600">{{ formatDate(pastDueRange(dp).newest ?? '') || '—' }}</td>
             <td class="px-4 py-3 text-sm font-medium text-amber-700">${{ dp.pastDueTotalAmount.toFixed(2) }}</td>
             <td class="px-4 py-3 text-sm text-slate-600">${{ dp.amountPaidSoFar.toFixed(2) }}</td>
             <td class="px-4 py-3 text-sm font-semibold text-red-600">
@@ -56,7 +60,7 @@
               class="bg-amber-50/30"
             >
               <td class="px-4 py-2"></td>
-              <td colspan="5" class="px-4 py-2">
+              <td colspan="7" class="px-4 py-2">
                 <router-link
                   :to="{ path: '/', query: { date: session.sessionDate, highlightSession: String(session.sessionId), from: '/patients?tab=delinquent' } }"
                   class="flex items-center justify-between group hover:bg-amber-100/50 rounded-lg px-3 py-2 -mx-3 transition-colors"
@@ -80,7 +84,7 @@
           </template>
         </template>
         <tr v-if="filteredPatients.length === 0">
-          <td colspan="6" class="px-4 py-12 text-center text-sm text-slate-400">
+          <td colspan="8" class="px-4 py-12 text-center text-sm text-slate-400">
             No delinquent patients found.
           </td>
         </tr>
@@ -119,6 +123,11 @@
           <div><span class="font-medium">Paid:</span> ${{ dp.amountPaidSoFar.toFixed(2) }}</div>
           <div><span class="font-medium text-red-600">Balance:</span> <span class="text-red-600">${{ (dp.pastDueTotalAmount - dp.amountPaidSoFar).toFixed(2) }}</span></div>
         </div>
+        <div class="mt-1 text-xs text-slate-500">
+          <span class="font-medium">Oldest:</span> {{ formatDate(pastDueRange(dp).oldest ?? '') || '—' }}
+          <span class="mx-1 text-slate-300">·</span>
+          <span class="font-medium">Newest:</span> {{ formatDate(pastDueRange(dp).newest ?? '') || '—' }}
+        </div>
       </div>
 
       <!-- Expanded sessions -->
@@ -149,6 +158,7 @@
 <script lang="ts">
 import { defineComponent, ref, computed, type PropType } from 'vue';
 import type { DelinquentPatient } from '../../interfaces/Delinquency';
+import { pastDueDateRange, type SessionDateRange } from '../../utils/delinquencyRange';
 
 export default defineComponent({
   name: 'DelinquentTable',
@@ -185,7 +195,18 @@ export default defineComponent({
       return d.toLocaleDateString('en-US', { month: '2-digit', day: '2-digit', year: 'numeric' });
     };
 
-    return { expanded, toggleExpand, filteredPatients, formatDate };
+    // cached per row object — template reads it twice per row (Oldest + Newest)
+    const rangeCache = new WeakMap<DelinquentPatient, SessionDateRange>();
+    const pastDueRange = (dp: DelinquentPatient): SessionDateRange => {
+      let r = rangeCache.get(dp);
+      if (!r) {
+        r = pastDueDateRange(dp.delinquency);
+        rangeCache.set(dp, r);
+      }
+      return r;
+    };
+
+    return { expanded, toggleExpand, filteredPatients, formatDate, pastDueRange };
   },
 });
 </script>

--- a/app-ui/src/components/therapists/TherapistDelinquentTable.vue
+++ b/app-ui/src/components/therapists/TherapistDelinquentTable.vue
@@ -7,6 +7,8 @@
           <th class="px-4 py-3 text-left text-xs font-semibold text-amber-700 uppercase tracking-wider w-8"></th>
           <th class="px-4 py-3 text-left text-xs font-semibold text-amber-700 uppercase tracking-wider">Therapist</th>
           <th class="px-4 py-3 text-left text-xs font-semibold text-amber-700 uppercase tracking-wider">Past-Due Sessions</th>
+          <th class="px-4 py-3 text-left text-xs font-semibold text-amber-700 uppercase tracking-wider">Oldest</th>
+          <th class="px-4 py-3 text-left text-xs font-semibold text-amber-700 uppercase tracking-wider">Newest</th>
           <th class="px-4 py-3 text-left text-xs font-semibold text-amber-700 uppercase tracking-wider">Total Due</th>
           <th class="px-4 py-3 text-left text-xs font-semibold text-amber-700 uppercase tracking-wider">Paid So Far</th>
           <th class="px-4 py-3 text-left text-xs font-semibold text-amber-700 uppercase tracking-wider">Balance</th>
@@ -33,6 +35,8 @@
                 {{ dt.pastDueSessions }}
               </span>
             </td>
+            <td class="px-4 py-3 text-sm text-slate-600">{{ formatDate(pastDueRange(dt).oldest ?? '') || '—' }}</td>
+            <td class="px-4 py-3 text-sm text-slate-600">{{ formatDate(pastDueRange(dt).newest ?? '') || '—' }}</td>
             <td class="px-4 py-3 text-sm font-medium text-amber-700">${{ dt.pastDueTotalAmount.toFixed(2) }}</td>
             <td class="px-4 py-3 text-sm text-slate-600">${{ dt.amountPaidSoFar.toFixed(2) }}</td>
             <td class="px-4 py-3 text-sm font-semibold text-red-600">${{ (dt.pastDueTotalAmount - dt.amountPaidSoFar).toFixed(2) }}</td>
@@ -45,7 +49,7 @@
               class="bg-amber-50/30"
             >
               <td class="px-4 py-2"></td>
-              <td colspan="5" class="px-4 py-2">
+              <td colspan="7" class="px-4 py-2">
                 <router-link
                   :to="{ path: '/', query: { date: session.sessionDate, highlightSession: String(session.sessionId), from: '/therapists?tab=delinquent' } }"
                   class="flex items-center justify-between group hover:bg-amber-100/50 rounded-lg px-3 py-2 -mx-3 transition-colors"
@@ -69,7 +73,7 @@
           </template>
         </template>
         <tr v-if="filteredTherapists.length === 0">
-          <td colspan="6" class="px-4 py-12 text-center text-sm text-slate-400">
+          <td colspan="8" class="px-4 py-12 text-center text-sm text-slate-400">
             No delinquent therapists found.
           </td>
         </tr>
@@ -108,6 +112,11 @@
           <div><span class="font-medium">Paid:</span> ${{ dt.amountPaidSoFar.toFixed(2) }}</div>
           <div><span class="font-medium text-red-600">Balance:</span> <span class="text-red-600">${{ (dt.pastDueTotalAmount - dt.amountPaidSoFar).toFixed(2) }}</span></div>
         </div>
+        <div class="mt-1 text-xs text-slate-500">
+          <span class="font-medium">Oldest:</span> {{ formatDate(pastDueRange(dt).oldest ?? '') || '—' }}
+          <span class="mx-1 text-slate-300">·</span>
+          <span class="font-medium">Newest:</span> {{ formatDate(pastDueRange(dt).newest ?? '') || '—' }}
+        </div>
       </div>
 
       <!-- Expanded sessions -->
@@ -138,6 +147,7 @@
 <script lang="ts">
 import { defineComponent, ref, computed, type PropType } from 'vue';
 import type { DelinquentTherapist } from '../../interfaces/Delinquency';
+import { pastDueDateRange, type SessionDateRange } from '../../utils/delinquencyRange';
 
 export default defineComponent({
   name: 'TherapistDelinquentTable',
@@ -173,7 +183,18 @@ export default defineComponent({
       return d.toLocaleDateString('en-US', { month: '2-digit', day: '2-digit', year: 'numeric' });
     };
 
-    return { expanded, toggleExpand, filteredTherapists, formatDate };
+    // cached per row object — template reads it twice per row (Oldest + Newest)
+    const rangeCache = new WeakMap<DelinquentTherapist, SessionDateRange>();
+    const pastDueRange = (dt: DelinquentTherapist): SessionDateRange => {
+      let r = rangeCache.get(dt);
+      if (!r) {
+        r = pastDueDateRange(dt.delinquency);
+        rangeCache.set(dt, r);
+      }
+      return r;
+    };
+
+    return { expanded, toggleExpand, filteredTherapists, formatDate, pastDueRange };
   },
 });
 </script>

--- a/app-ui/src/utils/delinquencyRange.ts
+++ b/app-ui/src/utils/delinquencyRange.ts
@@ -1,0 +1,27 @@
+// Oldest/newest session dates for a delinquency row.
+//
+// Scope decision (owner, 2026-07-05): the range covers PAST-DUE sessions only,
+// matching the "Past-Due Sessions" count column — a row's drill-down may also
+// list newer unpaid sessions that haven't crossed the 35-day rule yet, and
+// those must not stretch the range.
+//
+// sessionDate is the API's date-only string (yyyy-MM-dd), so lexicographic
+// comparison IS chronological comparison — no Date parsing (and no timezone
+// pitfalls) needed here.
+import type { DelinquentSession } from '../interfaces/Delinquency';
+
+export interface SessionDateRange {
+  oldest: string | null;
+  newest: string | null;
+}
+
+export function pastDueDateRange(sessions: DelinquentSession[]): SessionDateRange {
+  let oldest: string | null = null;
+  let newest: string | null = null;
+  for (const s of sessions) {
+    if (!s.isPastDue || !s.sessionDate) continue;
+    if (oldest === null || s.sessionDate < oldest) oldest = s.sessionDate;
+    if (newest === null || s.sessionDate > newest) newest = s.sessionDate;
+  }
+  return { oldest, newest };
+}

--- a/test-scenarios/delinquency-oldest-newest-columns.md
+++ b/test-scenarios/delinquency-oldest-newest-columns.md
@@ -1,0 +1,38 @@
+# Test Scenarios — Oldest/Newest columns on the Delinquent tabs
+
+Feature: both delinquency tables (Patients → Delinquent, Therapists → Delinquent)
+show two new columns, **Oldest** and **Newest** — the earliest and latest session
+dates among that row's **past-due** sessions (matches the "Past-Due Sessions"
+count; unpaid-but-not-yet-past-due sessions do not stretch the range).
+
+## Scenario 1 — Multi-session range (desktop)
+1. Log in as MGR/AM/FD; go to **Patients → Delinquent** tab.
+2. Pick a row whose Past-Due Sessions count is ≥ 2 and expand it.
+3. VERIFY: the **Oldest** cell equals the earliest date in the expanded list's
+   past-due rows, **Newest** the latest, both formatted MM/DD/YYYY.
+
+## Scenario 2 — Single-session row
+1. Find a row with Past-Due Sessions = 1.
+2. VERIFY: Oldest and Newest show the same date.
+
+## Scenario 3 — Range excludes not-yet-past-due sessions
+1. Find (or create) a patient with an old unpaid session AND a session from the
+   last few days (inside the 35-day grace window). The recent one appears in the
+   expanded list but is not counted in the Past-Due badge.
+2. VERIFY: **Newest** shows the newest *past-due* date, not the recent session's.
+
+## Scenario 4 — Therapists tab parity
+1. Go to **Therapists → Delinquent**.
+2. Repeat Scenarios 1–2. VERIFY identical behavior and formatting.
+
+## Scenario 5 — Mobile cards
+1. Narrow the window below the md breakpoint (or use a phone).
+2. VERIFY each delinquency card shows an "Oldest: … · Newest: …" line under the
+   Total Due / Paid / Balance row, on both tabs.
+
+## Scenario 6 — Layout regression
+1. On both tabs (desktop): expand a row and click a session line.
+2. VERIFY the session link still opens the dashboard at that date with the
+   session highlighted, detail lines span the full table width (no orphan
+   columns), and the "No delinquent … found." empty state (search for gibberish)
+   still spans the whole table.


### PR DESCRIPTION
…pists)

Two new columns on both delinquency tables showing the earliest and latest session dates among the row's PAST-DUE sessions (owner decision: range matches the Past-Due count — unpaid sessions still inside the 35-day grace window do not stretch it). Mobile cards get an "Oldest: ... - Newest: ..." line.

Pure UI change — the row DTO already ships the session list; min/max is a lexicographic pass over the yyyy-MM-dd strings (utils/delinquencyRange.ts, WeakMap-cached per row). Colspans widened 6->8 / 5->7.

vue-tsc + eslint clean; vitest 40 green (6 new in delinquency-range.spec.ts). Test scenarios: test-scenarios/delinquency-oldest-newest-columns.md