### PR TITLE
Dashboard: "Pending Caretaker Pay" tile — clinic-wide past-due receiv…

### DIFF
--- a/app-ui/src/__tests__/delinquency-range.spec.ts
+++ b/app-ui/src/__tests__/delinquency-range.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { pastDueDateRange } from '../utils/delinquencyRange';
-import type { DelinquentSession } from '../interfaces/Delinquency';
+import { pastDueDateRange, pastDueReceivable } from '../utils/delinquencyRange';
+import type { DelinquentPatient, DelinquentSession } from '../interfaces/Delinquency';
 
 function session(overrides: Partial<DelinquentSession>): DelinquentSession {
   return {
@@ -67,5 +67,31 @@ describe('pastDueDateRange', () => {
       session({ sessionId: 2, sessionDate: '2025-12-28' }),
     ]);
     expect(r).toEqual({ oldest: '2025-12-28', newest: '2026-01-02' });
+  });
+});
+
+function patient(pastDueTotalAmount: number, amountPaidSoFar: number): DelinquentPatient {
+  return {
+    partyType: 'Patient',
+    party: { id: 1, name: 'P', isValid: true },
+    pastDueSessions: 1,
+    pastDueTotalAmount,
+    amountPaidSoFar,
+    delinquency: [],
+  };
+}
+
+describe('pastDueReceivable', () => {
+  it('sums Balance (past-due total minus paid-so-far) across all patients', () => {
+    // mirrors the Delinquent tab's Balance column so the dashboard tile matches the tab
+    expect(pastDueReceivable([patient(300, 60), patient(75, 0)])).toBe(315);
+  });
+
+  it('returns 0 for an empty list', () => {
+    expect(pastDueReceivable([])).toBe(0);
+  });
+
+  it('keeps partial payments and cent amounts exact per row', () => {
+    expect(pastDueReceivable([patient(100.5, 25.25), patient(50, 50)])).toBeCloseTo(75.25, 2);
   });
 });

--- a/app-ui/src/components/option02/O2StatsBar.vue
+++ b/app-ui/src/components/option02/O2StatsBar.vue
@@ -1,7 +1,8 @@
 <template>
   <div>
     <!-- Stat Tiles -->
-    <div :class="['grid grid-cols-2 gap-4', stats.length >= 5 ? 'lg:grid-cols-5' : 'lg:grid-cols-4']">
+    <div :class="['grid grid-cols-2 gap-4',
+                  stats.length >= 6 ? 'lg:grid-cols-6' : stats.length >= 5 ? 'lg:grid-cols-5' : 'lg:grid-cols-4']">
       <component
         :is="stat.to ? 'router-link' : 'div'"
         v-for="stat in stats"
@@ -138,7 +139,10 @@ import { defineComponent, computed, ref, onMounted, PropType } from 'vue';
 import type { RouteLocationRaw } from 'vue-router';
 import { Appointment } from '../../interfaces/Appointment';
 import { PendingPayrollSummary } from '../../interfaces/ServicePayment';
+import type { DelinquentPatient } from '../../interfaces/Delinquency';
 import { ServicePaymentsHttpClient } from '../../services/ServicePaymentsHttpClient';
+import { PatientsHttpClient } from '../../services/PatientsHttpClient';
+import { pastDueReceivable } from '../../utils/delinquencyRange';
 import { formatCurrency } from '../../utils/formatCurrency';
 import { useClaims, Permissions } from '../../composables/useClaims';
 import { library } from '@fortawesome/fontawesome-svg-core';
@@ -150,9 +154,11 @@ import {
   faCheckCircle,
   faDollarSign,
   faMoneyBillWave,
+  faHandHoldingDollar,
 } from '@fortawesome/free-solid-svg-icons';
 
-library.add(faCalendarDay, faHourglassHalf, faExclamationTriangle, faCheckCircle, faDollarSign, faMoneyBillWave);
+library.add(faCalendarDay, faHourglassHalf, faExclamationTriangle, faCheckCircle, faDollarSign,
+  faMoneyBillWave, faHandHoldingDollar);
 
 interface StatTile {
   label: string;
@@ -181,12 +187,22 @@ export default defineComponent({
     // lacks ServicePayments.View and the API would 403, so we don't even fetch for them.
     const canViewPayroll = hasClaim('Permission', Permissions.ServicePaymentsView);
     const pendingPayroll = ref<PendingPayrollSummary | null>(null);
+    // Clinic-wide past-due receivable (caretaker side). Same endpoint the Patients →
+    // Delinquent tab renders from, so the tile always equals the tab it links to.
+    // Patients.Delinquent.View is MGR/AM only — FD would 403, so no fetch for them.
+    const canViewDelinquency = hasClaim('Permission', Permissions.PatientsDelinquentView);
+    const delinquentPatients = ref<DelinquentPatient[] | null>(null);
     onMounted(async () => {
-      if (!canViewPayroll) return;
-      try {
-        pendingPayroll.value = await new ServicePaymentsHttpClient().getPendingSummary();
-      } catch {
-        pendingPayroll.value = null; // tile is simply omitted if the summary can't be loaded
+      // independent fetches: either tile is simply omitted if its summary can't load
+      if (canViewPayroll) {
+        new ServicePaymentsHttpClient().getPendingSummary()
+          .then((s) => { pendingPayroll.value = s; })
+          .catch(() => { pendingPayroll.value = null; });
+      }
+      if (canViewDelinquency) {
+        new PatientsHttpClient().getPastDuePatients()
+          .then((list) => { delinquentPatients.value = list; })
+          .catch(() => { delinquentPatients.value = null; });
       }
     });
 
@@ -242,6 +258,21 @@ export default defineComponent({
           iconColor: 'text-sky-600',
           borderClass: summary.totalPending > 0 ? 'border-sky-200' : 'border-gray-200',
           to: { path: '/therapists', query: { tab: 'pending-pay' } },
+        });
+      }
+
+      const delinquent = delinquentPatients.value;
+      if (canViewDelinquency && delinquent) {
+        const receivable = pastDueReceivable(delinquent);
+        tiles.push({
+          label: 'Pending Caretaker Pay',
+          value: formatCurrency(receivable),
+          subtitle: `${delinquent.length} patient${delinquent.length === 1 ? '' : 's'} past due`,
+          icon: 'hand-holding-dollar',
+          iconBg: 'bg-rose-100',
+          iconColor: 'text-rose-600',
+          borderClass: receivable > 0 ? 'border-rose-200' : 'border-gray-200',
+          to: { path: '/patients', query: { tab: 'delinquent' } },
         });
       }
 

--- a/app-ui/src/utils/delinquencyRange.ts
+++ b/app-ui/src/utils/delinquencyRange.ts
@@ -8,11 +8,20 @@
 // sessionDate is the API's date-only string (yyyy-MM-dd), so lexicographic
 // comparison IS chronological comparison — no Date parsing (and no timezone
 // pitfalls) needed here.
-import type { DelinquentSession } from '../interfaces/Delinquency';
+import type { DelinquentPatient, DelinquentSession } from '../interfaces/Delinquency';
 
 export interface SessionDateRange {
   oldest: string | null;
   newest: string | null;
+}
+
+// Clinic-wide past-due receivable: what caretakers/patients still owe, summed as
+// the Delinquent tab's Balance column (past-due total minus paid-so-far) so the
+// dashboard tile always equals the tab it links to. Negative row balances
+// (overpayments) are kept as-is — same arithmetic as the tab.
+export function pastDueReceivable(patients: DelinquentPatient[]): number {
+  return patients.reduce(
+    (sum, dp) => sum + (dp.pastDueTotalAmount - dp.amountPaidSoFar), 0);
 }
 
 export function pastDueDateRange(sessions: DelinquentSession[]): SessionDateRange {

--- a/test-scenarios/dashboard-caretaker-receivables-tile.md
+++ b/test-scenarios/dashboard-caretaker-receivables-tile.md
@@ -1,0 +1,43 @@
+# Test Scenarios — "Pending Caretaker Pay" dashboard tile
+
+Feature: a sixth dashboard tile showing the clinic-wide **past-due** amount that
+caretakers/patients still owe (sum of the Delinquent tab's Balance column),
+hyperlinked to Patients → Delinquent. Rose accent, `hand-holding-dollar` icon,
+subtitle "N patients past due". Visible to MGR/AM only (rides
+`Patients.Delinquent.View`, same pattern as Pending Therapist Pay).
+
+## Scenario 1 — Tile value matches the tab (MGR or AM)
+1. Log in as MGR; open the dashboard (`/`).
+2. Note the "Pending Caretaker Pay" amount and its "N patients past due" subtitle.
+3. Click the tile → VERIFY it lands on **Patients → Delinquent**.
+4. Sum the **Balance** column (or spot-check totals) and count the rows.
+5. VERIFY: tile amount = sum of Balance; N = number of delinquent rows.
+
+## Scenario 2 — Row layout (desktop, MGR/AM)
+1. On a large screen, VERIFY the tile row shows **6 evenly-sized tiles** in one
+   line: Today's Appointments, Paid Off, Pending Payment, Past Due, Pending
+   Therapist Pay (sky), Pending Caretaker Pay (rose, last).
+2. VERIFY no tile text is clipped; long amounts truncate gracefully.
+
+## Scenario 3 — FD sees no money tiles
+1. Log in as FD (front desk); open the dashboard.
+2. VERIFY: only the 4 count tiles appear (no Pending Therapist Pay, no Pending
+   Caretaker Pay), spread across the full row width as before.
+
+## Scenario 4 — Mobile layout
+1. As MGR on a phone-width viewport: VERIFY the 6 tiles stack 2 per row
+   (3 rows), all readable, the rose tile tappable and navigating to the
+   Delinquent tab.
+2. As FD on mobile: VERIFY 4 tiles in 2 rows, unchanged from before.
+
+## Scenario 5 — Payment recorded updates the tile
+1. As MGR, record a payment fully covering one delinquent patient's balance
+   (Delinquent tab → Record Payment).
+2. Return to the dashboard (reload).
+3. VERIFY the tile amount dropped by that balance and the patient count fell
+   by one; if no delinquents remain, the tile shows $0.00 with a neutral border.
+
+## Scenario 6 — API failure degrades silently
+1. With the API's `/api/patients/pastdue` unreachable (or a token lacking the
+   claim), VERIFY the dashboard renders without the rose tile and without
+   console-visible layout breakage (5 or 4 tiles, row still balanced).


### PR DESCRIPTION
…able

Sixth stat tile (MGR/AM only, rides Patients.Delinquent.View like the payroll tile rides ServicePayments.View — FD keeps the 4-tile row): total past-due balance caretakers/patients still owe, subtitle "N patients past due", rose accent, hand-holding-dollar icon, hyperlinked to Patients -> Delinquent.

Amount = sum of the Delinquent tab's Balance column, computed from the SAME endpoint the tab renders from (/api/patients/pastdue), so tile and tab always agree (owner decision: past-due only, global). Grid gains a lg:grid-cols-6 case for even distribution; mobile keeps 2-per-row stacking (3 rows MGR/AM, 2 rows FD). Fetches are independent — either money tile is omitted if its call fails.

vue-tsc + eslint clean; vitest 43 green (3 new pastDueReceivable tests). Scenarios: test-scenarios/dashboard-caretaker-receivables-tile.md No API/DB/contract/matrix change.