### PR TITLE
WP-20C: paid-in-range disclosure on Pay Therapist + Run Payroll

### DIFF
--- a/app-ui/src/__tests__/payroll-paid-in-range.spec.ts
+++ b/app-ui/src/__tests__/payroll-paid-in-range.spec.ts
@@ -176,6 +176,24 @@ describe('PayTherapistWizard — paid-in-range disclosure', () => {
     expect(w.findAll('input[type="checkbox"]').length).toBe(1);
   });
 
+  it('renders the all-paid disclosure when the payable list is empty', async () => {
+    const w = await mountPayWizard(paidInRange(), []);
+    expect(w.text()).toContain('No unpaid sessions in this range — 4 sessions ($85.00) were already paid');
+    // The generic empty-state copy is replaced in this case.
+    expect(w.text()).not.toContain('No unpaid completed sessions');
+    // Expand still works from the empty state.
+    const btn = disclosureButton(w);
+    await btn!.trigger('click');
+    expect(w.text()).toContain('Rivera, Ana');
+    expect(w.text()).toContain('PAYROLL-2026-05 ($21.25)');
+  });
+
+  it('keeps the plain empty state when nothing was paid in range', async () => {
+    const w = await mountPayWizard(null, []);
+    expect(w.text()).toContain('No unpaid completed sessions for this therapist in the selected period.');
+    expect(w.text()).not.toContain('already paid');
+  });
+
   it('collapses again on a second click', async () => {
     const w = await mountPayWizard(paidInRange());
     const btn = disclosureButton(w);

--- a/app-ui/src/__tests__/payroll-paid-in-range.spec.ts
+++ b/app-ui/src/__tests__/payroll-paid-in-range.spec.ts
@@ -1,0 +1,226 @@
+// WP-20 — payroll "paid in range" visibility.
+//
+// PayTherapistWizard shows a muted disclosure line under the Unpaid Sessions header when the
+// unpaid-sessions envelope reports prior payments in the range, expandable (chevron) into a
+// read-only paid-sessions table. RunPayrollWizard shows a "N paid · $X" sub-line under each
+// therapist name when paidSessionCount > 0. Components are driven via internal refs (no HTTP).
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { setActivePinia, createPinia, type Pinia } from 'pinia';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import manifest from '../generated/access-control-matrix.json';
+import { useAuthStore } from '../stores/auth';
+import type { ClaimDto } from '../interfaces/Auth';
+import type {
+  PaidInRangeSummary,
+  PaidProviderSessionDetail,
+  PayrollPreviewTherapist,
+  UnpaidProviderSessionSummary,
+} from '../interfaces/ServicePayment';
+import { ServicePaymentsHttpClient } from '../services/ServicePaymentsHttpClient';
+import PayTherapistWizard from '../components/service-payments/PayTherapistWizard.vue';
+import RunPayrollWizard from '../components/service-payments/RunPayrollWizard.vue';
+
+function claimsForRole(role: string): ClaimDto[] {
+  return (manifest.claims as Array<{ claim: string; grants: string[] }>)
+    .filter((c) => c.grants.includes(role))
+    .map((c) => ({ type: 'Permission', value: c.claim }));
+}
+
+function authAsMgr(): Pinia {
+  const pinia = createPinia();
+  setActivePinia(pinia);
+  const store = useAuthStore();
+  store.user = {
+    userId: 1,
+    email: 'test@example.com',
+    fullName: 'Test User',
+    mustChangePassword: false,
+    roles: ['MGR'],
+    claims: claimsForRole('MGR'),
+    isSystemAdmin: false,
+  };
+  return pinia;
+}
+
+function unpaidSession(overrides: Partial<UnpaidProviderSessionSummary> = {}): UnpaidProviderSessionSummary {
+  return {
+    sessionId: 10,
+    sessionDate: '2026-06-02',
+    sessionTime: '09:00',
+    patientId: 5,
+    patientName: 'Green, Dan',
+    therapyType: 'TO/IS',
+    providerAmount: 20,
+    alreadyApplied: 0,
+    remainingProviderAmount: 20,
+    ...overrides,
+  };
+}
+
+function paidDetail(overrides: Partial<PaidProviderSessionDetail> = {}): PaidProviderSessionDetail {
+  return {
+    sessionId: 90,
+    sessionDate: '2026-05-30',
+    sessionTime: '10:00',
+    patientName: 'Rivera, Ana',
+    therapyType: 'TO/IS',
+    providerAmount: 21.25,
+    amountApplied: 21.25,
+    remainingProviderAmount: 0,
+    paymentReferences: [
+      { servicePaymentId: 88, referenceNumber: 'PAYROLL-2026-05', paymentDate: '2026-05-31', amountApplied: 21.25 },
+    ],
+    ...overrides,
+  };
+}
+
+function paidInRange(overrides: Partial<PaidInRangeSummary> = {}): PaidInRangeSummary {
+  return {
+    fullyPaidSessionCount: 4,
+    fullyPaidTotal: 85,
+    totalApplied: 85,
+    sessions: [paidDetail()],
+    ...overrides,
+  };
+}
+
+const PAY_WIZARD_PROPS = {
+  therapists: [{ therapistId: 23, therapistName: 'ANNELYS' }],
+  paymentTypes: [{ paymentTypeId: 1, abbreviation: 'ACH', name: 'Bank Transfer' }],
+};
+
+async function mountPayWizard(paid: PaidInRangeSummary | null, sessions: UnpaidProviderSessionSummary[] = [unpaidSession()]) {
+  const pinia = authAsMgr();
+  const w = mount(PayTherapistWizard, {
+    props: PAY_WIZARD_PROPS,
+    global: { plugins: [pinia] },
+  });
+  // Drive the component into its loaded state without hitting the network.
+  const vm = w.vm as unknown as {
+    sessions: UnpaidProviderSessionSummary[]
+    paidInRange: PaidInRangeSummary | null
+    loaded: boolean
+  };
+  vm.sessions = sessions;
+  vm.paidInRange = paid;
+  vm.loaded = true;
+  await w.vm.$nextTick();
+  return w;
+}
+
+function disclosureButton(w: VueWrapper) {
+  return w.findAll('button').find((b) => b.text().includes('already paid'));
+}
+
+beforeEach(() => {
+  // Neutralize the onMounted quincena-default helper so no real network call is attempted.
+  vi.spyOn(ServicePaymentsHttpClient.prototype, 'getQuincena')
+    .mockResolvedValue({ from: '2026-05-30', to: '2026-06-12' });
+});
+
+describe('PayTherapistWizard — paid-in-range disclosure', () => {
+  it('is hidden when paidInRange is null', async () => {
+    const w = await mountPayWizard(null);
+    expect(w.text()).not.toContain('already paid');
+  });
+
+  it('is hidden when totalApplied is 0', async () => {
+    const w = await mountPayWizard(paidInRange({ fullyPaidSessionCount: 0, fullyPaidTotal: 0, totalApplied: 0, sessions: [] }));
+    expect(w.text()).not.toContain('already paid');
+  });
+
+  it('renders count and formatted total (plural)', async () => {
+    const w = await mountPayWizard(paidInRange());
+    expect(w.text()).toContain('4 sessions ($85.00) in this range were already paid');
+    expect(w.text()).not.toContain('incl.');
+  });
+
+  it('uses singular phrasing for one session', async () => {
+    const w = await mountPayWizard(paidInRange({ fullyPaidSessionCount: 1, fullyPaidTotal: 21.25, totalApplied: 21.25 }));
+    expect(w.text()).toContain('1 session ($21.25) in this range was already paid');
+  });
+
+  it('appends the partial-applied suffix when fullyPaidTotal !== totalApplied', async () => {
+    const w = await mountPayWizard(paidInRange({ fullyPaidTotal: 85, totalApplied: 97.5 }));
+    expect(w.text()).toContain(
+      '4 sessions ($85.00) in this range were already paid (incl. $12.50 applied on partially-paid sessions shown above)',
+    );
+  });
+
+  it('chevron expand reveals the paid table with reference and Partial badge', async () => {
+    const partial = paidDetail({
+      sessionId: 91,
+      patientName: 'Solis, Mia',
+      amountApplied: 10,
+      remainingProviderAmount: 11.25,
+      paymentReferences: [{ servicePaymentId: 88, referenceNumber: '', paymentDate: '2026-05-31', amountApplied: 10 }],
+    });
+    const w = await mountPayWizard(paidInRange({ totalApplied: 95, sessions: [paidDetail(), partial] }));
+
+    // Collapsed by default — no detail rows yet.
+    expect(w.text()).not.toContain('Rivera, Ana');
+
+    const btn = disclosureButton(w);
+    expect(btn).toBeTruthy();
+    expect(btn!.find('svg').classes()).not.toContain('rotate-90');
+    await btn!.trigger('click');
+
+    expect(btn!.find('svg').classes()).toContain('rotate-90');
+    expect(w.text()).toContain('Rivera, Ana');
+    expect(w.text()).toContain('PAYROLL-2026-05 ($21.25)');  // named reference
+    expect(w.text()).toContain('#88 ($10.00)');              // blank reference falls back to payment id
+    expect(w.text()).toContain('Full');
+    expect(w.text()).toContain('Partial');
+    // Read-only: the paid table adds no checkboxes beyond the payable rows' own.
+    expect(w.findAll('input[type="checkbox"]').length).toBe(1);
+  });
+
+  it('collapses again on a second click', async () => {
+    const w = await mountPayWizard(paidInRange());
+    const btn = disclosureButton(w);
+    await btn!.trigger('click');
+    expect(w.text()).toContain('Rivera, Ana');
+    await btn!.trigger('click');
+    expect(w.text()).not.toContain('Rivera, Ana');
+  });
+});
+
+describe('RunPayrollWizard — paid-in-range sub-line', () => {
+  function therapistRow(overrides: Partial<PayrollPreviewTherapist> = {}): PayrollPreviewTherapist {
+    return {
+      therapistId: 23,
+      therapistName: 'ANNELYS',
+      sessionCount: 16,
+      totalRemaining: 363.4,
+      paidSessionCount: 0,
+      paidTotal: 0,
+      sessions: [],
+      ...overrides,
+    };
+  }
+
+  async function mountRunWizard(preview: PayrollPreviewTherapist[]) {
+    const pinia = authAsMgr();
+    const w = mount(RunPayrollWizard, {
+      props: { paymentTypes: PAY_WIZARD_PROPS.paymentTypes },
+      global: { plugins: [pinia] },
+    });
+    const vm = w.vm as unknown as { preview: PayrollPreviewTherapist[]; loaded: boolean };
+    vm.preview = preview;
+    vm.loaded = true;
+    await w.vm.$nextTick();
+    return w;
+  }
+
+  it('renders the sub-line when paidSessionCount > 0', async () => {
+    const w = await mountRunWizard([therapistRow({ paidSessionCount: 4, paidTotal: 85 })]);
+    expect(w.text()).toMatch(/4 paid\s*·\s*\$85\.00/);
+  });
+
+  it('renders no sub-line when paidSessionCount is 0', async () => {
+    const w = await mountRunWizard([therapistRow()]);
+    expect(w.text()).not.toContain('paid ·');
+    expect(w.text()).toContain('ANNELYS');
+  });
+});

--- a/app-ui/src/components/service-payments/PaidInRangeDisclosure.vue
+++ b/app-ui/src/components/service-payments/PaidInRangeDisclosure.vue
@@ -1,0 +1,89 @@
+<template>
+  <!-- WP-20 — muted paid-in-range disclosure: chevron-toggle line + read-only paid table. -->
+  <div>
+    <button type="button" class="inline-flex items-center gap-1.5 text-xs text-slate-400 hover:text-slate-600" @click="expanded = !expanded">
+      <svg :class="['w-3.5 h-3.5 flex-shrink-0 transition-transform', expanded ? 'rotate-90' : '']" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+      </svg>
+      <span>{{ lineText }}</span>
+    </button>
+    <div v-if="expanded" class="mt-2 mb-1 overflow-x-auto rounded-lg border border-slate-200 bg-slate-50 text-left">
+      <table class="min-w-full divide-y divide-slate-200">
+        <thead>
+          <tr>
+            <th class="px-4 py-2 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Date</th>
+            <th class="px-4 py-2 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Patient</th>
+            <th class="px-4 py-2 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Therapy Type</th>
+            <th class="px-4 py-2 text-right text-xs font-medium text-slate-500 uppercase tracking-wider">Provider Amount</th>
+            <th class="px-4 py-2 text-right text-xs font-medium text-slate-500 uppercase tracking-wider">Applied</th>
+            <th class="px-4 py-2 text-left text-xs font-medium text-slate-500 uppercase tracking-wider"></th>
+            <th class="px-4 py-2 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Payment Ref</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-slate-200">
+          <tr v-for="p in paid.sessions" :key="p.sessionId">
+            <td class="px-4 py-2 whitespace-nowrap text-xs text-slate-600">{{ formatDate(p.sessionDate) }}</td>
+            <td class="px-4 py-2 whitespace-nowrap text-xs text-slate-600">{{ p.patientName }}</td>
+            <td class="px-4 py-2 whitespace-nowrap text-xs text-slate-600">{{ p.therapyType }}</td>
+            <td class="px-4 py-2 whitespace-nowrap text-xs text-right text-slate-600">{{ formatCurrency(p.providerAmount) }}</td>
+            <td class="px-4 py-2 whitespace-nowrap text-xs text-right text-slate-600">{{ formatCurrency(p.amountApplied) }}</td>
+            <td class="px-4 py-2 whitespace-nowrap text-xs">
+              <span
+                v-if="p.remainingProviderAmount > 0"
+                class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-700"
+              >Partial</span>
+              <span
+                v-else
+                class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-700"
+              >Full</span>
+            </td>
+            <td class="px-4 py-2 whitespace-nowrap text-xs text-slate-500">{{ formatPaymentRefs(p.paymentReferences) }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref, computed, watch, type PropType } from 'vue';
+import type { PaidByPaymentRef, PaidInRangeSummary } from '../../interfaces/ServicePayment';
+import { formatCurrency } from '../../utils/formatCurrency';
+
+export default defineComponent({
+  name: 'PaidInRangeDisclosure',
+  props: {
+    paid: { type: Object as PropType<PaidInRangeSummary>, required: true },
+    /** The payable list is empty — lead with the empty-state copy ("No unpaid sessions in this range — …"). */
+    allPaid: { type: Boolean, default: false },
+  },
+  setup(props) {
+    const expanded = ref(false);
+    // A fresh lookup (new envelope) collapses the detail again.
+    watch(() => props.paid, () => { expanded.value = false; });
+
+    // "N session(s) ($X) in this range were already paid", with a partial-applied suffix.
+    const lineText = computed(() => {
+      const p = props.paid;
+      const n = p.fullyPaidSessionCount;
+      const counted = `${n} session${n === 1 ? '' : 's'} (${formatCurrency(p.fullyPaidTotal)})`;
+      const verb = n === 1 ? 'was' : 'were';
+      let text = props.allPaid
+        ? `No unpaid sessions in this range — ${counted} ${verb} already paid`
+        : `${counted} in this range ${verb} already paid`;
+      if (p.fullyPaidTotal !== p.totalApplied) {
+        text += ` (incl. ${formatCurrency(p.totalApplied - p.fullyPaidTotal)} applied on partially-paid sessions shown above)`;
+      }
+      return text;
+    });
+
+    const formatDate = (dateStr: string) => new Date(dateStr).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+
+    // Compact "REF ($amt)" list; a blank reference falls back to the payment id as "#88".
+    const formatPaymentRefs = (refs: PaidByPaymentRef[]) =>
+      refs.map((r) => `${r.referenceNumber || `#${r.servicePaymentId}`} (${formatCurrency(r.amountApplied)})`).join(', ');
+
+    return { expanded, lineText, formatCurrency, formatDate, formatPaymentRefs };
+  },
+});
+</script>

--- a/app-ui/src/components/service-payments/PayTherapistWizard.vue
+++ b/app-ui/src/components/service-payments/PayTherapistWizard.vue
@@ -82,6 +82,50 @@
             <button class="text-slate-500 hover:underline" @click="selectAll(false)">Clear</button>
           </div>
         </div>
+        <!-- WP-20 — paid-in-range disclosure -->
+        <div v-if="paidInRange && paidInRange.totalApplied > 0" class="px-6 py-2 border-b border-slate-200">
+          <button type="button" class="flex items-center gap-1.5 text-xs text-slate-400 hover:text-slate-600" @click="paidExpanded = !paidExpanded">
+            <svg :class="['w-3.5 h-3.5 flex-shrink-0 transition-transform', paidExpanded ? 'rotate-90' : '']" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+            </svg>
+            <span>{{ paidDisclosureText }}</span>
+          </button>
+          <div v-if="paidExpanded" class="mt-2 mb-1 overflow-x-auto rounded-lg border border-slate-200 bg-slate-50">
+            <table class="min-w-full divide-y divide-slate-200">
+              <thead>
+                <tr>
+                  <th class="px-4 py-2 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Date</th>
+                  <th class="px-4 py-2 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Patient</th>
+                  <th class="px-4 py-2 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Therapy Type</th>
+                  <th class="px-4 py-2 text-right text-xs font-medium text-slate-500 uppercase tracking-wider">Provider Amount</th>
+                  <th class="px-4 py-2 text-right text-xs font-medium text-slate-500 uppercase tracking-wider">Applied</th>
+                  <th class="px-4 py-2 text-left text-xs font-medium text-slate-500 uppercase tracking-wider"></th>
+                  <th class="px-4 py-2 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Payment Ref</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-slate-200">
+                <tr v-for="p in paidInRange.sessions" :key="p.sessionId">
+                  <td class="px-4 py-2 whitespace-nowrap text-xs text-slate-600">{{ formatDate(p.sessionDate) }}</td>
+                  <td class="px-4 py-2 whitespace-nowrap text-xs text-slate-600">{{ p.patientName }}</td>
+                  <td class="px-4 py-2 whitespace-nowrap text-xs text-slate-600">{{ p.therapyType }}</td>
+                  <td class="px-4 py-2 whitespace-nowrap text-xs text-right text-slate-600">{{ formatCurrency(p.providerAmount) }}</td>
+                  <td class="px-4 py-2 whitespace-nowrap text-xs text-right text-slate-600">{{ formatCurrency(p.amountApplied) }}</td>
+                  <td class="px-4 py-2 whitespace-nowrap text-xs">
+                    <span
+                      v-if="p.remainingProviderAmount > 0"
+                      class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-700"
+                    >Partial</span>
+                    <span
+                      v-else
+                      class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-700"
+                    >Full</span>
+                  </td>
+                  <td class="px-4 py-2 whitespace-nowrap text-xs text-slate-500">{{ formatPaymentRefs(p.paymentReferences) }}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
         <div class="overflow-x-auto">
           <table class="min-w-full divide-y divide-slate-200">
             <thead class="bg-slate-50">
@@ -166,8 +210,9 @@
 import { defineComponent, ref, reactive, computed, onMounted, type PropType } from 'vue';
 import { ServicePaymentsHttpClient } from '../../services/ServicePaymentsHttpClient';
 import type { PaymentTypeInfo } from '../../interfaces/Payment';
-import type { ServicePaymentRecord, UnpaidProviderSessionSummary } from '../../interfaces/ServicePayment';
+import type { PaidByPaymentRef, PaidInRangeSummary, ServicePaymentRecord, UnpaidProviderSessionSummary } from '../../interfaces/ServicePayment';
 import { toLocalYmd } from '../../utils/localDate';
+import { formatCurrency } from '../../utils/formatCurrency';
 
 interface TherapistOption {
   therapistId: number
@@ -193,6 +238,8 @@ export default defineComponent({
     const notes = ref('');
 
     const sessions = ref<UnpaidProviderSessionSummary[]>([]);
+    const paidInRange = ref<PaidInRangeSummary | null>(null);  // WP-20
+    const paidExpanded = ref(false);
     const selected = reactive<Record<number, boolean>>({});
     const loaded = ref(false);
     const loading = ref(false);
@@ -205,8 +252,23 @@ export default defineComponent({
     const selectedTotal = computed(() => selectedSessions.value.reduce((sum, s) => sum + s.remainingProviderAmount, 0));
     const canSubmit = computed(() => !!selectedTherapistId.value && !!paymentTypeId.value && selectedTotal.value > 0);
 
-    const formatCurrency = (v: number) => `$${v.toFixed(2)}`;
     const formatDate = (dateStr: string) => new Date(dateStr).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+
+    // WP-20 — "N session(s) ($X) in this range were already paid", with a partial-applied suffix.
+    const paidDisclosureText = computed(() => {
+      const p = paidInRange.value;
+      if (!p) return '';
+      const n = p.fullyPaidSessionCount;
+      let text = `${n} session${n === 1 ? '' : 's'} (${formatCurrency(p.fullyPaidTotal)}) in this range ${n === 1 ? 'was' : 'were'} already paid`;
+      if (p.fullyPaidTotal !== p.totalApplied) {
+        text += ` (incl. ${formatCurrency(p.totalApplied - p.fullyPaidTotal)} applied on partially-paid sessions shown above)`;
+      }
+      return text;
+    });
+
+    // Compact "REF ($amt)" list; a blank reference falls back to the payment id as "#88".
+    const formatPaymentRefs = (refs: PaidByPaymentRef[]) =>
+      refs.map((r) => `${r.referenceNumber || `#${r.servicePaymentId}`} (${formatCurrency(r.amountApplied)})`).join(', ');
 
     const selectAll = (value: boolean) => {
       sessions.value.forEach((s) => { selected[s.sessionId] = value; });
@@ -218,10 +280,12 @@ export default defineComponent({
       error.value = '';
       successRecord.value = null;
       try {
-        const list = await client.getUnpaidSessions(selectedTherapistId.value, fromDate.value, toDate.value);
-        sessions.value = list;
+        const result = await client.getUnpaidSessions(selectedTherapistId.value, fromDate.value, toDate.value);
+        sessions.value = result.sessions;
+        paidInRange.value = result.paidInRange;
+        paidExpanded.value = false;
         Object.keys(selected).forEach((k) => delete selected[Number(k)]);
-        list.forEach((s) => { selected[s.sessionId] = true; });
+        result.sessions.forEach((s) => { selected[s.sessionId] = true; });
         loaded.value = true;
       } catch (e: unknown) {
         error.value = e instanceof Error ? e.message : 'Failed to load unpaid sessions.';
@@ -250,6 +314,8 @@ export default defineComponent({
         successRecord.value = record;
         loaded.value = false;
         sessions.value = [];
+        paidInRange.value = null;
+        paidExpanded.value = false;
         emit('created', record);
       } catch (e: unknown) {
         error.value = e instanceof Error ? e.message : 'Failed to issue payment.';
@@ -280,9 +346,9 @@ export default defineComponent({
 
     return {
       selectedTherapistId, fromDate, toDate, paymentDate, paymentTypeId, referenceNumber, notes,
-      sessions, selected, loaded, loading, submitting, error, successRecord,
-      selectedCount, selectedTotal, canSubmit,
-      formatCurrency, formatDate, selectAll, loadSessions, submit, resetForNext,
+      sessions, paidInRange, paidExpanded, selected, loaded, loading, submitting, error, successRecord,
+      selectedCount, selectedTotal, canSubmit, paidDisclosureText,
+      formatCurrency, formatDate, formatPaymentRefs, selectAll, loadSessions, submit, resetForNext,
     };
   },
 });

--- a/app-ui/src/components/service-payments/PayTherapistWizard.vue
+++ b/app-ui/src/components/service-payments/PayTherapistWizard.vue
@@ -71,7 +71,9 @@
     <!-- Unpaid sessions + payment form -->
     <template v-if="loaded && !successRecord">
       <div v-if="sessions.length === 0" class="bg-white rounded-lg shadow-sm border border-slate-200 p-8 text-center">
-        <p class="text-sm text-slate-500">No unpaid completed sessions for this therapist in the selected period.</p>
+        <!-- WP-20 — the all-paid range is the most confusing case: say WHY nothing is payable. -->
+        <PaidInRangeDisclosure v-if="paidInRange && paidInRange.totalApplied > 0" :paid="paidInRange" all-paid />
+        <p v-else class="text-sm text-slate-500">No unpaid completed sessions for this therapist in the selected period.</p>
       </div>
 
       <div v-else class="bg-white rounded-lg shadow-sm border border-slate-200">
@@ -83,49 +85,11 @@
           </div>
         </div>
         <!-- WP-20 — paid-in-range disclosure -->
-        <div v-if="paidInRange && paidInRange.totalApplied > 0" class="px-6 py-2 border-b border-slate-200">
-          <button type="button" class="flex items-center gap-1.5 text-xs text-slate-400 hover:text-slate-600" @click="paidExpanded = !paidExpanded">
-            <svg :class="['w-3.5 h-3.5 flex-shrink-0 transition-transform', paidExpanded ? 'rotate-90' : '']" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-            </svg>
-            <span>{{ paidDisclosureText }}</span>
-          </button>
-          <div v-if="paidExpanded" class="mt-2 mb-1 overflow-x-auto rounded-lg border border-slate-200 bg-slate-50">
-            <table class="min-w-full divide-y divide-slate-200">
-              <thead>
-                <tr>
-                  <th class="px-4 py-2 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Date</th>
-                  <th class="px-4 py-2 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Patient</th>
-                  <th class="px-4 py-2 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Therapy Type</th>
-                  <th class="px-4 py-2 text-right text-xs font-medium text-slate-500 uppercase tracking-wider">Provider Amount</th>
-                  <th class="px-4 py-2 text-right text-xs font-medium text-slate-500 uppercase tracking-wider">Applied</th>
-                  <th class="px-4 py-2 text-left text-xs font-medium text-slate-500 uppercase tracking-wider"></th>
-                  <th class="px-4 py-2 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Payment Ref</th>
-                </tr>
-              </thead>
-              <tbody class="divide-y divide-slate-200">
-                <tr v-for="p in paidInRange.sessions" :key="p.sessionId">
-                  <td class="px-4 py-2 whitespace-nowrap text-xs text-slate-600">{{ formatDate(p.sessionDate) }}</td>
-                  <td class="px-4 py-2 whitespace-nowrap text-xs text-slate-600">{{ p.patientName }}</td>
-                  <td class="px-4 py-2 whitespace-nowrap text-xs text-slate-600">{{ p.therapyType }}</td>
-                  <td class="px-4 py-2 whitespace-nowrap text-xs text-right text-slate-600">{{ formatCurrency(p.providerAmount) }}</td>
-                  <td class="px-4 py-2 whitespace-nowrap text-xs text-right text-slate-600">{{ formatCurrency(p.amountApplied) }}</td>
-                  <td class="px-4 py-2 whitespace-nowrap text-xs">
-                    <span
-                      v-if="p.remainingProviderAmount > 0"
-                      class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-700"
-                    >Partial</span>
-                    <span
-                      v-else
-                      class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-700"
-                    >Full</span>
-                  </td>
-                  <td class="px-4 py-2 whitespace-nowrap text-xs text-slate-500">{{ formatPaymentRefs(p.paymentReferences) }}</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-        </div>
+        <PaidInRangeDisclosure
+          v-if="paidInRange && paidInRange.totalApplied > 0"
+          :paid="paidInRange"
+          class="px-6 py-2 border-b border-slate-200"
+        />
         <div class="overflow-x-auto">
           <table class="min-w-full divide-y divide-slate-200">
             <thead class="bg-slate-50">
@@ -210,9 +174,10 @@
 import { defineComponent, ref, reactive, computed, onMounted, type PropType } from 'vue';
 import { ServicePaymentsHttpClient } from '../../services/ServicePaymentsHttpClient';
 import type { PaymentTypeInfo } from '../../interfaces/Payment';
-import type { PaidByPaymentRef, PaidInRangeSummary, ServicePaymentRecord, UnpaidProviderSessionSummary } from '../../interfaces/ServicePayment';
+import type { PaidInRangeSummary, ServicePaymentRecord, UnpaidProviderSessionSummary } from '../../interfaces/ServicePayment';
 import { toLocalYmd } from '../../utils/localDate';
 import { formatCurrency } from '../../utils/formatCurrency';
+import PaidInRangeDisclosure from './PaidInRangeDisclosure.vue';
 
 interface TherapistOption {
   therapistId: number
@@ -221,6 +186,7 @@ interface TherapistOption {
 
 export default defineComponent({
   name: 'PayTherapistWizard',
+  components: { PaidInRangeDisclosure },
   props: {
     therapists: { type: Array as PropType<TherapistOption[]>, required: true },
     paymentTypes: { type: Array as PropType<PaymentTypeInfo[]>, required: true },
@@ -239,7 +205,6 @@ export default defineComponent({
 
     const sessions = ref<UnpaidProviderSessionSummary[]>([]);
     const paidInRange = ref<PaidInRangeSummary | null>(null);  // WP-20
-    const paidExpanded = ref(false);
     const selected = reactive<Record<number, boolean>>({});
     const loaded = ref(false);
     const loading = ref(false);
@@ -254,22 +219,6 @@ export default defineComponent({
 
     const formatDate = (dateStr: string) => new Date(dateStr).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
 
-    // WP-20 — "N session(s) ($X) in this range were already paid", with a partial-applied suffix.
-    const paidDisclosureText = computed(() => {
-      const p = paidInRange.value;
-      if (!p) return '';
-      const n = p.fullyPaidSessionCount;
-      let text = `${n} session${n === 1 ? '' : 's'} (${formatCurrency(p.fullyPaidTotal)}) in this range ${n === 1 ? 'was' : 'were'} already paid`;
-      if (p.fullyPaidTotal !== p.totalApplied) {
-        text += ` (incl. ${formatCurrency(p.totalApplied - p.fullyPaidTotal)} applied on partially-paid sessions shown above)`;
-      }
-      return text;
-    });
-
-    // Compact "REF ($amt)" list; a blank reference falls back to the payment id as "#88".
-    const formatPaymentRefs = (refs: PaidByPaymentRef[]) =>
-      refs.map((r) => `${r.referenceNumber || `#${r.servicePaymentId}`} (${formatCurrency(r.amountApplied)})`).join(', ');
-
     const selectAll = (value: boolean) => {
       sessions.value.forEach((s) => { selected[s.sessionId] = value; });
     };
@@ -283,7 +232,6 @@ export default defineComponent({
         const result = await client.getUnpaidSessions(selectedTherapistId.value, fromDate.value, toDate.value);
         sessions.value = result.sessions;
         paidInRange.value = result.paidInRange;
-        paidExpanded.value = false;
         Object.keys(selected).forEach((k) => delete selected[Number(k)]);
         result.sessions.forEach((s) => { selected[s.sessionId] = true; });
         loaded.value = true;
@@ -315,7 +263,6 @@ export default defineComponent({
         loaded.value = false;
         sessions.value = [];
         paidInRange.value = null;
-        paidExpanded.value = false;
         emit('created', record);
       } catch (e: unknown) {
         error.value = e instanceof Error ? e.message : 'Failed to issue payment.';
@@ -346,9 +293,9 @@ export default defineComponent({
 
     return {
       selectedTherapistId, fromDate, toDate, paymentDate, paymentTypeId, referenceNumber, notes,
-      sessions, paidInRange, paidExpanded, selected, loaded, loading, submitting, error, successRecord,
-      selectedCount, selectedTotal, canSubmit, paidDisclosureText,
-      formatCurrency, formatDate, formatPaymentRefs, selectAll, loadSessions, submit, resetForNext,
+      sessions, paidInRange, selected, loaded, loading, submitting, error, successRecord,
+      selectedCount, selectedTotal, canSubmit,
+      formatCurrency, formatDate, selectAll, loadSessions, submit, resetForNext,
     };
   },
 });

--- a/app-ui/src/components/service-payments/RunPayrollWizard.vue
+++ b/app-ui/src/components/service-payments/RunPayrollWizard.vue
@@ -79,7 +79,13 @@
                 <td class="px-4 py-3">
                   <input type="checkbox" v-model="selected[t.therapistId]" class="rounded border-slate-300 text-blue-600 focus:ring-blue-500" />
                 </td>
-                <td class="px-4 py-3 whitespace-nowrap text-sm text-slate-900">{{ t.therapistName }}</td>
+                <td class="px-4 py-3 whitespace-nowrap text-sm text-slate-900">
+                  {{ t.therapistName }}
+                  <!-- WP-20 — paid-in-range context sub-line -->
+                  <div v-if="t.paidSessionCount > 0" class="text-xs text-slate-400">
+                    {{ t.paidSessionCount }} paid &middot; {{ formatCurrency(t.paidTotal) }}
+                  </div>
+                </td>
                 <td class="px-4 py-3 whitespace-nowrap text-sm text-right text-slate-900">{{ t.sessionCount }}</td>
                 <td class="px-4 py-3 whitespace-nowrap text-sm text-right font-medium text-slate-900">{{ formatCurrency(t.totalRemaining) }}</td>
               </tr>
@@ -147,6 +153,7 @@ import { ServicePaymentsHttpClient } from '../../services/ServicePaymentsHttpCli
 import type { PaymentTypeInfo } from '../../interfaces/Payment';
 import type { PayrollPreviewTherapist, BatchPayrollResult } from '../../interfaces/ServicePayment';
 import { toLocalYmd } from '../../utils/localDate';
+import { formatCurrency } from '../../utils/formatCurrency';
 
 export default defineComponent({
   name: 'RunPayrollWizard',
@@ -176,8 +183,6 @@ export default defineComponent({
     const selectedCount = computed(() => selectedTherapists.value.length);
     const grandTotal = computed(() => selectedTherapists.value.reduce((sum, t) => sum + t.totalRemaining, 0));
     const canRun = computed(() => selectedCount.value > 0 && !!paymentTypeId.value);
-
-    const formatCurrency = (v: number) => `$${v.toFixed(2)}`;
 
     const selectAll = (value: boolean) => {
       preview.value.forEach((t) => { selected[t.therapistId] = value; });

--- a/app-ui/src/interfaces/ServicePayment.ts
+++ b/app-ui/src/interfaces/ServicePayment.ts
@@ -62,6 +62,39 @@ export interface UnpaidProviderSessionSummary {
   remainingProviderAmount: number
 }
 
+// WP-20 — "paid in range" visibility on the unpaid-sessions envelope.
+export interface PaidByPaymentRef {
+  servicePaymentId: number
+  referenceNumber: string | null
+  paymentDate: string
+  amountApplied: number
+}
+
+export interface PaidProviderSessionDetail {
+  sessionId: number
+  sessionDate: string
+  sessionTime: string
+  patientName: string
+  therapyType: string
+  providerAmount: number
+  amountApplied: number
+  remainingProviderAmount: number   // > 0 marks a partially-paid session (also listed as payable)
+  paymentReferences: PaidByPaymentRef[]
+}
+
+export interface PaidInRangeSummary {
+  fullyPaidSessionCount: number
+  fullyPaidTotal: number            // Σ providerAmount of fully-paid sessions
+  totalApplied: number              // Σ amountApplied across ALL sessions in range (incl. partials)
+  sessions: PaidProviderSessionDetail[]
+}
+
+// WP-20 envelope for GET /api/service-payments/unpaid-sessions.
+export interface UnpaidProviderSessionsResult {
+  sessions: UnpaidProviderSessionSummary[]
+  paidInRange: PaidInRangeSummary
+}
+
 export interface QuincenaWindow {
   from: string
   to: string
@@ -73,6 +106,8 @@ export interface PayrollPreviewTherapist {
   therapistName: string
   sessionCount: number
   totalRemaining: number
+  paidSessionCount: number          // WP-20 — fully-paid session count in range (context only)
+  paidTotal: number                 // WP-20 — Σ amountApplied across the therapist's in-range sessions
   sessions: UnpaidProviderSessionSummary[]
 }
 

--- a/app-ui/src/services/ServicePaymentsHttpClient.ts
+++ b/app-ui/src/services/ServicePaymentsHttpClient.ts
@@ -4,7 +4,7 @@ import type {
   ServicePaymentRecord,
   ServicePaymentCreateRequest,
   ReverseServicePaymentRequest,
-  UnpaidProviderSessionSummary,
+  UnpaidProviderSessionsResult,
   QuincenaWindow,
   PayrollPreviewTherapist,
   BatchPayrollRequest,
@@ -26,12 +26,13 @@ export class ServicePaymentsHttpClient extends HttpClientBase {
     return this.get<ServicePaymentRecord>(`/api/service-payments/${id}`);
   }
 
-  async getUnpaidSessions(therapistId: number, from?: string, to?: string): Promise<UnpaidProviderSessionSummary[]> {
+  // WP-20 — returns the envelope: payable sessions + a "paid in range" summary.
+  async getUnpaidSessions(therapistId: number, from?: string, to?: string): Promise<UnpaidProviderSessionsResult> {
     const params = new URLSearchParams();
     params.append('therapistId', String(therapistId));
     if (from) params.append('from', from);
     if (to) params.append('to', to);
-    return this.get<UnpaidProviderSessionSummary[]>(`/api/service-payments/unpaid-sessions?${params.toString()}`);
+    return this.get<UnpaidProviderSessionsResult>(`/api/service-payments/unpaid-sessions?${params.toString()}`);
   }
 
   async getQuincena(date?: string): Promise<QuincenaWindow> {

--- a/test-scenarios/payroll-paid-in-range.md
+++ b/test-scenarios/payroll-paid-in-range.md
@@ -1,0 +1,61 @@
+# Test Scenarios — Payroll "paid in range" visibility (WP-20C)
+
+Feature: the Pay Therapist wizard now discloses sessions in the selected range that
+were **already paid** by prior service payments — a muted line under the Unpaid
+Sessions header ("N sessions ($X) in this range were already paid") with a chevron
+that expands into a read-only table (date, patient, therapy type, provider amount,
+applied, Full/Partial badge, payment reference). The Run Payroll preview shows a
+muted "N paid · $X" sub-line under each therapist name. Context only — nothing new
+is selectable or payable. Visible wherever the wizards are (MGR/AM; issuing MGR).
+
+## Scenario 1 — Disclosure line and expanded detail (origin case)
+1. Log in as MGR; open Payments → Pay Therapist.
+2. Select therapist **ANNELYS** (id 23), range **2026-05-30 → 2026-06-12**, click
+   Find Unpaid Sessions.
+3. VERIFY the payable table shows **16 sessions**, all pre-selected, with a
+   selected-total of **$363.40**.
+4. VERIFY a muted line directly under the "Unpaid Sessions" header reads
+   **"4 sessions ($85.00) in this range were already paid"** with a chevron.
+5. Click the chevron → VERIFY it rotates and a subdued read-only table appears with
+   **4 rows dated 2026-05-30**, each showing a **Full** badge and referencing
+   **PAYROLL-2026-05** with its applied amount.
+6. VERIFY the paid rows have no checkboxes and no links, and the selected-total
+   above stays $363.40 (paid rows never enter the payable math).
+7. Click the chevron again → VERIFY the table collapses.
+
+## Scenario 2 — Zero case (no paid sessions in range)
+1. Same wizard; pick a therapist/range with unpaid sessions but no prior service
+   payments in the range (e.g. a fresh JULIO 2026 window).
+2. VERIFY no "already paid" line renders at all — the card looks exactly as before
+   WP-20 (header bar, then the payable table).
+
+## Scenario 3 — Partially-paid suffix
+1. Pick a range containing a session with a partial allocation (some `amountApplied`
+   but `remainingProviderAmount > 0`) — e.g. after reversing/re-issuing a smaller
+   payment on one session.
+2. VERIFY the session still appears in the **payable** list (for its remainder) AND
+   in the expanded paid table with a **Partial** badge.
+3. VERIFY the disclosure line ends with
+   **"(incl. $Y applied on partially-paid sessions shown above)"** where $Y is the
+   partial amount, and the singular form reads "1 session … was already paid".
+
+## Scenario 4 — Run Payroll sub-line
+1. Open Payments → Run Payroll; preview the range **2026-05-30 → 2026-06-12**.
+2. VERIFY the ANNELYS row shows a muted **"4 paid · $85.00"** sub-line under the
+   name; her Sessions / Amount Owed figures are unchanged by WP-20.
+3. VERIFY therapists with nothing previously paid in range show **no** sub-line,
+   and therapists with only paid (nothing owed) sessions still do not appear.
+
+## Scenario 5 — Totals reconcile
+1. For the Scenario 1 range, sum: selected-total ($363.40) + paid line total
+   ($85.00, plus any partial suffix amount).
+2. VERIFY it equals the therapist's total provider amount for all completed
+   sessions in the range (invariant: Σ providerAmount = Σ remaining + Σ applied).
+
+## Scenario 6 — Issue payment clears the disclosure
+1. From Scenario 1, issue the payment for the 16 sessions.
+2. VERIFY the success panel replaces the tables (no stale paid line lingering).
+3. Re-run Find Unpaid Sessions for the same range → VERIFY the empty state
+   ("No unpaid completed sessions…") renders. The disclosure line lives under the
+   Unpaid Sessions header, so it does not appear when nothing is payable (by
+   design — see the WP-20 plan).

--- a/test-scenarios/payroll-paid-in-range.md
+++ b/test-scenarios/payroll-paid-in-range.md
@@ -52,10 +52,15 @@ is selectable or payable. Visible wherever the wizards are (MGR/AM; issuing MGR)
 2. VERIFY it equals the therapist's total provider amount for all completed
    sessions in the range (invariant: Σ providerAmount = Σ remaining + Σ applied).
 
-## Scenario 6 — Issue payment clears the disclosure
+## Scenario 6 — All-paid range (issue payment, then re-query)
 1. From Scenario 1, issue the payment for the 16 sessions.
 2. VERIFY the success panel replaces the tables (no stale paid line lingering).
-3. Re-run Find Unpaid Sessions for the same range → VERIFY the empty state
-   ("No unpaid completed sessions…") renders. The disclosure line lives under the
-   Unpaid Sessions header, so it does not appear when nothing is payable (by
-   design — see the WP-20 plan).
+3. Re-run Find Unpaid Sessions for the same range → VERIFY the empty-state card
+   now explains itself: **"No unpaid sessions in this range — 20 sessions
+   ($448.40) were already paid"** with the chevron.
+4. Expand → VERIFY all 20 paid rows appear (the original 4 referencing
+   PAYROLL-2026-05 plus the 16 just issued with the new payment's reference),
+   every row badged **Full**.
+5. VERIFY the plain copy ("No unpaid completed sessions for this therapist in
+   the selected period.") appears **only** when the range truly has no prior
+   payments (Scenario 2), never in the all-paid case.


### PR DESCRIPTION
## Summary
- Pay Therapist wizard: new muted disclosure line under the Unpaid Sessions header — *"N sessions ($X.XX) in this range were already paid"* — with a chevron expand revealing a read-only table of the paid sessions (date, patient, therapy type, amounts, Full/Partial badge, payment reference(s)). Partial-applied suffix when applicable.
- **All-paid empty state**: when every session in range is already paid, the empty state now explains it (*"No unpaid sessions in this range — N sessions ($X.XX) were already paid"*) with the same expand, instead of a bare "no sessions" message.
- Run Payroll tab: per-therapist muted sub-line *"N paid · $X.XX"* when the range contains paid sessions.
- New reusable `PaidInRangeDisclosure.vue` component; new TS interfaces mirroring the contract envelope; `getUnpaidSessions` returns `UnpaidProviderSessionsResult`.
- Drive-by: both wizards switched from an inline `$X.XX` formatter to the shared thousands-grouping `utils/formatCurrency.ts`.

## ⚠️ Lockstep deploy
Consumes the **breaking** `unpaid-sessions` envelope. Merge and deploy together with `patient-care-api` PR `feature/wp-20b-paid-in-range` in the same window.

## Origin
Therapist-23 reconciliation question (2026-07-07): UI showed 16 sessions/$363.40 vs raw SQL 20/$448.40 — the 4/$85.00 delta was sessions already settled via `PAYROLL-2026-05`. The report now discloses that instead of hiding it.

## Verification
- `npx vue-tsc --noEmit` clean · `npm run lint` clean · `npx vitest run` **54/54 green** (11 new in `payroll-paid-in-range.spec.ts`, incl. all-paid empty state, partial suffix, expand contents, Run Payroll sub-line zero/positive).
- Test scenarios: `test-scenarios/payroll-paid-in-range.md` (6 scenarios; walkthrough = the therapist-23 origin case).
- Owner tested locally against the WP-20B API — confirmed working.

Plan: `patient-care-super/planning/active/wp-20-paid-in-range-visibility.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
