### PR TITLE
B2: make patient MRN generally editable in the edit modal

### DIFF
--- a/app-ui/src/__tests__/patient-mrn-edit.spec.ts
+++ b/app-ui/src/__tests__/patient-mrn-edit.spec.ts
@@ -1,0 +1,154 @@
+// B2 (meeting punch list 2026-07-07): correcting a patient's MRN from the edit modal.
+//   The modal used to render the MRN read-only unless it was TEMP-prefixed, so imported
+//   L24-/L25-/L26-#### MRNs could never be corrected — and even an editable value was
+//   dropped from the PUT payload unless the "assign permanent MRN" path was taken.
+//   Fix: MRN is generally editable on edit; a changed, non-blank value is always sent
+//   (the API enforces uniqueness → 409). TEMP- activation semantics are unchanged.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { setActivePinia, createPinia, type Pinia } from 'pinia';
+import { mount } from '@vue/test-utils';
+import manifest from '../generated/access-control-matrix.json';
+import { useAuthStore } from '../stores/auth';
+import type { ClaimDto } from '../interfaces/Auth';
+import type { Patient } from '../interfaces/Patient';
+import PatientFormModal from '../components/patients/PatientFormModal.vue';
+
+const { updatePatientMock, createPatientMock } = vi.hoisted(() => ({
+  updatePatientMock: vi.fn().mockResolvedValue(undefined),
+  createPatientMock: vi.fn().mockResolvedValue({ patientId: 99, medicalRecordNumber: 'MRN-099' }),
+}));
+
+vi.mock('../services/PatientsHttpClient', () => ({
+  PatientsHttpClient: vi.fn().mockImplementation(() => ({
+    updatePatient: updatePatientMock,
+    createPatient: createPatientMock,
+  })),
+}));
+
+function claimsForRole(role: string): ClaimDto[] {
+  return (manifest.claims as Array<{ claim: string; grants: string[] }>)
+    .filter((c) => c.grants.includes(role))
+    .map((c) => ({ type: 'Permission', value: c.claim }));
+}
+
+function authAs(role: string): Pinia {
+  const pinia = createPinia();
+  setActivePinia(pinia);
+  const store = useAuthStore();
+  store.user = {
+    userId: 1,
+    email: 'test@example.com',
+    fullName: 'Test User',
+    mustChangePassword: false,
+    roles: [role],
+    claims: claimsForRole(role),
+    isSystemAdmin: false,
+  };
+  return pinia;
+}
+
+function patient(overrides: Partial<Patient> = {}): Patient {
+  return {
+    patientId: 1,
+    userId: 10,
+    patientName: 'Doe, John',
+    medicalRecordNumber: 'MRN-001',
+    cedula: null,
+    dateOfBirth: '2000-01-15T00:00:00',
+    email: 'john@example.com',
+    phoneNumber: '555-0100',
+    gender: 'Male',
+    isActive: true,
+    hasCompletedDiscovery: true,
+    createdTimestamp: '2025-01-01T00:00:00',
+    caretakers: [],
+    ...overrides,
+  };
+}
+
+async function openEditModal(p: Patient) {
+  const pinia = authAs('MGR');
+  const wrapper = mount(PatientFormModal, {
+    props: { visible: false, patient: p },
+    // Render the <teleport to="body"> content in place so find() can reach the form.
+    global: { plugins: [pinia], stubs: { teleport: true } },
+  });
+  // The form hydrates on the visible=false→true transition.
+  await wrapper.setProps({ visible: true });
+  return wrapper;
+}
+
+const mrnInput = 'input[placeholder="Enter MRN"]';
+
+beforeEach(() => {
+  updatePatientMock.mockClear();
+  createPatientMock.mockClear();
+});
+
+describe('PatientFormModal — MRN is editable on edit (B2)', () => {
+  it('renders an editable MRN input for an imported L24-#### MRN (was read-only)', async () => {
+    const wrapper = await openEditModal(patient({ medicalRecordNumber: 'L24-0123', isActive: false }));
+    const input = wrapper.find(mrnInput);
+    expect(input.exists()).toBe(true);
+    expect((input.element as HTMLInputElement).value).toBe('L24-0123');
+  });
+
+  it('sends the corrected MRN on PUT when changed', async () => {
+    const wrapper = await openEditModal(patient({ medicalRecordNumber: 'L24-0123', isActive: false }));
+    await wrapper.find(mrnInput).setValue('  NC-2024-0123  ');
+
+    await wrapper.find('form').trigger('submit');
+    await vi.waitFor(() => expect(updatePatientMock).toHaveBeenCalled());
+
+    expect(updatePatientMock).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ medicalRecordNumber: 'NC-2024-0123' })
+    );
+  });
+
+  it('omits medicalRecordNumber from the payload when unchanged', async () => {
+    const wrapper = await openEditModal(patient({ medicalRecordNumber: 'L24-0123', isActive: false }));
+
+    await wrapper.find('form').trigger('submit');
+    await vi.waitFor(() => expect(updatePatientMock).toHaveBeenCalled());
+
+    expect(updatePatientMock).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ medicalRecordNumber: undefined })
+    );
+  });
+
+  it('omits medicalRecordNumber when the field is blanked (blank never clears an MRN)', async () => {
+    const wrapper = await openEditModal(patient({ medicalRecordNumber: 'L24-0123', isActive: false }));
+    await wrapper.find(mrnInput).setValue('');
+
+    await wrapper.find('form').trigger('submit');
+    await vi.waitFor(() => expect(updatePatientMock).toHaveBeenCalled());
+
+    expect(updatePatientMock).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ medicalRecordNumber: undefined })
+    );
+  });
+
+  it('still shows the temporary-MRN hint and two-step activate flow for TEMP- patients', async () => {
+    const wrapper = await openEditModal(patient({ medicalRecordNumber: 'TEMP-5', isActive: false }));
+    expect(wrapper.text()).toContain('temporary MRN');
+
+    await wrapper.find(mrnInput).setValue('NC-2026-0005');
+    // Toggle Active Status on (enabled once the pending MRN is permanent).
+    await wrapper.find('button.w-11').trigger('click');
+
+    await wrapper.find('form').trigger('submit');
+    await vi.waitFor(() => expect(updatePatientMock).toHaveBeenCalledTimes(2));
+
+    // Step 1: assign the permanent MRN while still inactive; step 2: activate.
+    expect(updatePatientMock.mock.calls[0][1]).toEqual(
+      expect.objectContaining({ medicalRecordNumber: 'NC-2026-0005', activeStatus: false })
+    );
+    expect(updatePatientMock.mock.calls[1][1]).toEqual(
+      expect.objectContaining({ activeStatus: true })
+    );
+  });
+});

--- a/app-ui/src/components/patients/PatientFormModal.vue
+++ b/app-ui/src/components/patients/PatientFormModal.vue
@@ -123,22 +123,23 @@
 
           <div v-if="isEdit">
             <label class="block text-sm font-medium text-slate-700 mb-1">MRN</label>
-            <div v-if="hasTemporaryMrn">
-              <input
-                v-model="form.medicalRecordNumber"
-                type="text"
-                class="w-full rounded-lg border border-amber-300 bg-amber-50 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-amber-500 focus:border-transparent"
-                placeholder="Enter permanent MRN"
-              />
-              <p class="mt-1 text-xs text-amber-600">
-                This patient has a temporary MRN. Assign a permanent MRN to enable activation.
-              </p>
-            </div>
-            <div v-else>
-              <p class="px-3 py-2 text-sm text-slate-600 bg-slate-50 rounded-lg border border-slate-200">
-                {{ form.medicalRecordNumber }}
-              </p>
-            </div>
+            <input
+              v-model="form.medicalRecordNumber"
+              type="text"
+              :class="[
+                'w-full rounded-lg border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:border-transparent',
+                hasTemporaryMrn
+                  ? 'border-amber-300 bg-amber-50 focus:ring-amber-500'
+                  : 'border-slate-300 focus:ring-blue-500',
+              ]"
+              placeholder="Enter MRN"
+            />
+            <p v-if="hasTemporaryMrn" class="mt-1 text-xs text-amber-600">
+              This patient has a temporary MRN. Assign a permanent MRN to enable activation.
+            </p>
+            <p v-else class="mt-1 text-xs text-slate-400">
+              Changing the MRN must keep it unique; leave blank to keep the current one.
+            </p>
           </div>
 
           <div v-if="isEdit" class="space-y-1">
@@ -259,7 +260,11 @@ export default defineComponent({
 
     const isEdit = ref(false);
 
-    const hasTemporaryMrn = computed(() => isEdit.value && isTemporaryMrn(form.medicalRecordNumber));
+    // Blank on edit means "keep the current MRN", so temp-ness is judged on the effective value.
+    const effectiveMrn = computed(
+      () => form.medicalRecordNumber.trim() || props.patient?.medicalRecordNumber || ''
+    );
+    const hasTemporaryMrn = computed(() => isEdit.value && isTemporaryMrn(effectiveMrn.value));
     const cannotActivate = computed(() => hasTemporaryMrn.value && !form.activeStatus);
     const age = computed(() => formatAge(form.dateOfBirth));
 
@@ -305,7 +310,7 @@ export default defineComponent({
         return;
       }
       // Cannot activate a patient while a temporary MRN is still in place.
-      if (isEdit.value && props.patient && form.activeStatus && isTemporaryMrn(form.medicalRecordNumber)) {
+      if (isEdit.value && props.patient && form.activeStatus && isTemporaryMrn(effectiveMrn.value)) {
         setError('Cannot activate a patient with a temporary MRN. Assign a permanent MRN first.');
         return;
       }
@@ -313,7 +318,11 @@ export default defineComponent({
         const client = new PatientsHttpClient();
         if (isEdit.value && props.patient) {
           const originalMrn = props.patient.medicalRecordNumber || '';
-          const assigningPermanentMrn = isTemporaryMrn(originalMrn) && form.medicalRecordNumber && !isTemporaryMrn(form.medicalRecordNumber);
+          // MRN is generally editable (B2): send a changed, non-blank value; blank keeps the
+          // current MRN (the API treats an omitted/empty MRN as "leave as-is"; uniqueness → 409).
+          const newMrn = form.medicalRecordNumber.trim();
+          const mrnChanged = newMrn !== '' && newMrn !== originalMrn;
+          const assigningPermanentMrn = isTemporaryMrn(originalMrn) && mrnChanged && !isTemporaryMrn(newMrn);
           const baseFields = {
             firstName: form.firstName,
             middleName: form.middleName || undefined,
@@ -332,7 +341,7 @@ export default defineComponent({
             await client.updatePatient(props.patient.patientId, {
               ...baseFields,
               activeStatus: false,
-              medicalRecordNumber: form.medicalRecordNumber,
+              medicalRecordNumber: newMrn,
             });
             await client.updatePatient(props.patient.patientId, {
               ...baseFields,
@@ -342,7 +351,7 @@ export default defineComponent({
             await client.updatePatient(props.patient.patientId, {
               ...baseFields,
               activeStatus: form.activeStatus,
-              medicalRecordNumber: assigningPermanentMrn ? form.medicalRecordNumber : undefined,
+              medicalRecordNumber: mrnChanged ? newMrn : undefined,
             });
           }
         } else {

--- a/test-scenarios/patient-mrn-edit-b2.md
+++ b/test-scenarios/patient-mrn-edit-b2.md
@@ -1,0 +1,36 @@
+# Test Scenarios — B2: MRN editable in the patient edit modal
+
+**Origin:** 2026-07-07 meeting punch list, bug B2 ("Inactive patient with a temp MRN: the UI
+won't allow correcting the MRN"). Root cause: the edit modal rendered the MRN read-only unless
+it was `TEMP-`-prefixed, so imported `L24-/L25-/L26-####` MRNs could never be corrected — and
+the PUT payload dropped the MRN except on the assign-permanent path.
+
+**Fix:** the MRN field is now always editable in the edit modal. A changed, non-blank value is
+sent to the API (uniqueness enforced server-side → 409 with a specific message). Blank means
+"keep the current MRN". `TEMP-` semantics (activation block, two-step assign+activate) are
+unchanged.
+
+## Scenario 1 — Correct an imported legacy MRN
+1. Patients → find any legacy patient (MRN like `L24-0123`) → Edit.
+2. **Expect:** the MRN shows in an editable input (was a grey read-only box), with the hint
+   "Changing the MRN must keep it unique; leave blank to keep the current one."
+3. Change the MRN to a new unique value → Save Patient.
+4. **Expect:** save succeeds; the table shows the corrected MRN.
+
+## Scenario 2 — Duplicate MRN is rejected cleanly
+1. Edit a patient and set their MRN to another patient's existing MRN → Save.
+2. **Expect:** error banner "A patient with this Medical Record Number already exists."
+   (409 from the API); no data changes.
+
+## Scenario 3 — Blank keeps the current MRN
+1. Edit a patient, clear the MRN field entirely, change something else (e.g. phone) → Save.
+2. **Expect:** save succeeds; the MRN is unchanged (blank does not erase an MRN).
+3. On an **active** patient this must not trigger the "Cannot activate with a temporary MRN"
+   error.
+
+## Scenario 4 — Temp-MRN flow unchanged (regression)
+1. Create a patient with a blank MRN (gets `TEMP-{id}`, inactive).
+2. Edit them: **expect** the amber input + "temporary MRN" hint; the Active toggle is disabled
+   until a permanent MRN is typed.
+3. Type a permanent MRN, toggle Active on, Save.
+4. **Expect:** patient is active with the new MRN (two-step update under the hood).


### PR DESCRIPTION
The modal rendered the MRN read-only unless TEMP--prefixed, so imported L24-/L25-/L26-#### MRNs could never be corrected; the PUT payload also dropped the MRN outside the assign-permanent path. MRN is now always editable on edit: a changed, non-blank value is sent (API uniqueness 409 handled by the existing error banner), blank keeps the current MRN, and temp-ness/activation gating key on the effective (typed-or-current) value so TEMP- semantics are unchanged. Red-to-green regression spec patient-mrn-edit.spec.ts (5 tests); suite 59 green.