### PR TITLE
B3+B4: caretaker contact in Session Details; specialty name on dashbo…

### DIFF
--- a/app-ui/src/__tests__/appointment-display.spec.ts
+++ b/app-ui/src/__tests__/appointment-display.spec.ts
@@ -1,0 +1,139 @@
+// B3 + B4 (meeting punch list 2026-07-07):
+//   B3 — the Proposed › Session Details panel (ActionsPanel) must show the patient's
+//        primary caretaker name/phone/email (new SessionEvent fields, contract-first).
+//   B4 — the Dashboard Appointments panel rows must show the resolved Specialty Type
+//        name (specialtyName was already in the DTO but never rendered).
+
+import { describe, it, expect, vi } from 'vitest';
+import { setActivePinia, createPinia, type Pinia } from 'pinia';
+import { mount, flushPromises } from '@vue/test-utils';
+import manifest from '../generated/access-control-matrix.json';
+import { useAuthStore } from '../stores/auth';
+import type { ClaimDto } from '../interfaces/Auth';
+import type { Appointment } from '../interfaces/Appointment';
+import ActionsPanel from '../components/appointments/ActionsPanel.vue';
+import O2Appointments from '../components/option02/O2Appointments.vue';
+
+const { getSessionsMock } = vi.hoisted(() => ({
+  getSessionsMock: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('../services/SessionsHttpClient', () => ({
+  SessionsHttpClient: vi.fn().mockImplementation(() => ({
+    getSessions: getSessionsMock,
+  })),
+}));
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+function claimsForRole(role: string): ClaimDto[] {
+  return (manifest.claims as Array<{ claim: string; grants: string[] }>)
+    .filter((c) => c.grants.includes(role))
+    .map((c) => ({ type: 'Permission', value: c.claim }));
+}
+
+function authAs(role: string): Pinia {
+  const pinia = createPinia();
+  setActivePinia(pinia);
+  const store = useAuthStore();
+  store.user = {
+    userId: 1,
+    email: 'test@example.com',
+    fullName: 'Test User',
+    mustChangePassword: false,
+    roles: [role],
+    claims: claimsForRole(role),
+    isSystemAdmin: false,
+  };
+  return pinia;
+}
+
+function appointment(overrides: Partial<Appointment> = {}): Appointment {
+  return {
+    sessionId: 1,
+    sessionDate: '2026-07-11',
+    sessionTime: '09:00:00',
+    patient: 'Doe, John',
+    therapist: 'Smith, Jane',
+    therapyTypes: 'NM',
+    amount: 100,
+    discount: 0,
+    amountPaid: 0,
+    amountDue: 100,
+    isPastDue: false,
+    isPaidOff: false,
+    notes: '',
+    patientId: 1,
+    therapistId: 1,
+    time: '09:00',
+    appointmentStatusId: 1,
+    statusName: 'Proposed',
+    isConfirmed: false,
+    siteId: 1,
+    siteName: 'Main',
+    specialtyTypeId: 14,
+    specialtyAbbreviation: 'NM',
+    specialtyName: 'Neuro Motor',
+    isDiscovery: false,
+    caretakerName: 'Doe, Mary',
+    caretakerPhone: '555-0001',
+    caretakerEmail: 'mary@example.com',
+    ...overrides,
+  };
+}
+
+describe('ActionsPanel — caretaker contact info (B3)', () => {
+  function mountPanel(appt: Appointment) {
+    const pinia = authAs('MGR');
+    return mount(ActionsPanel, {
+      props: { visible: true, appointment: appt },
+      global: { plugins: [pinia], stubs: { teleport: true } },
+    });
+  }
+
+  it('shows the caretaker name, phone, and email in Appointment Info', () => {
+    const wrapper = mountPanel(appointment());
+    expect(wrapper.text()).toContain('Caretaker');
+    expect(wrapper.text()).toContain('Doe, Mary');
+    expect(wrapper.text()).toContain('555-0001');
+    expect(wrapper.text()).toContain('mary@example.com');
+  });
+
+  it('shows a dash when the patient has no caretaker', () => {
+    const wrapper = mountPanel(
+      appointment({ caretakerName: null, caretakerPhone: null, caretakerEmail: null })
+    );
+    expect(wrapper.text()).toContain('Caretaker');
+    expect(wrapper.text()).not.toContain('mary@example.com');
+  });
+});
+
+describe('O2Appointments — specialty type on rows (B4)', () => {
+  it('renders the resolved specialty name on the appointment row', async () => {
+    getSessionsMock.mockResolvedValueOnce([appointment()]);
+    const pinia = authAs('MGR');
+    const wrapper = mount(O2Appointments, {
+      props: { selectedDate: '2026-07-11' },
+      global: { plugins: [pinia] },
+    });
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('Neuro Motor');
+  });
+
+  it('falls back to the raw therapy-type code when no specialty is resolved', async () => {
+    getSessionsMock.mockResolvedValueOnce([
+      appointment({ specialtyName: null, specialtyAbbreviation: null, specialtyTypeId: null, therapyTypes: 'XY' }),
+    ]);
+    const pinia = authAs('MGR');
+    const wrapper = mount(O2Appointments, {
+      props: { selectedDate: '2026-07-11' },
+      global: { plugins: [pinia] },
+    });
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('XY');
+  });
+});

--- a/app-ui/src/components/appointments/ActionsPanel.vue
+++ b/app-ui/src/components/appointments/ActionsPanel.vue
@@ -34,6 +34,20 @@
                 <span class="font-medium text-slate-800">{{ appointment.therapist }}</span>
               </div>
               <div class="flex justify-between">
+                <span class="text-slate-500">Caretaker</span>
+                <span class="font-medium text-slate-800">{{ appointment.caretakerName || '—' }}</span>
+              </div>
+              <div v-if="appointment.caretakerName" class="flex justify-between">
+                <span class="text-slate-500">Caretaker Phone</span>
+                <span class="text-slate-700">{{ appointment.caretakerPhone || '—' }}</span>
+              </div>
+              <div v-if="appointment.caretakerName" class="flex justify-between gap-2">
+                <span class="text-slate-500 flex-shrink-0">Caretaker Email</span>
+                <span class="text-slate-700 truncate" :title="appointment.caretakerEmail || undefined">
+                  {{ appointment.caretakerEmail || '—' }}
+                </span>
+              </div>
+              <div class="flex justify-between">
                 <span class="text-slate-500">Date</span>
                 <span class="text-slate-700">{{ appointment.sessionDate }}</span>
               </div>

--- a/app-ui/src/components/option02/O2Appointments.vue
+++ b/app-ui/src/components/option02/O2Appointments.vue
@@ -55,7 +55,8 @@
           <div class="flex-1 min-w-0">
             <p class="text-sm font-medium text-gray-800 truncate">{{ appt.patient }}</p>
             <p class="text-xs text-gray-400 truncate">
-              {{ appt.therapyTypes }} &middot; {{ appt.therapist }}
+              <!-- B4: prefer the resolved Specialty Type name over the raw therapy-type code -->
+              {{ appt.specialtyName || appt.therapyTypes || 'N/A' }} &middot; {{ appt.therapist }}
             </p>
             <!-- Mobile financial summary -->
             <p class="md:hidden text-[10px] mt-0.5 truncate">

--- a/app-ui/src/interfaces/Appointment.ts
+++ b/app-ui/src/interfaces/Appointment.ts
@@ -25,6 +25,11 @@ export interface Appointment {
     specialtyAbbreviation: string | null;
     specialtyName: string | null;
     isDiscovery: boolean | null;
+    // B3: primary caretaker contact info (first link as fallback; null when the patient
+    // has no caretaker) — see _contracts/sessions-api.md.
+    caretakerName: string | null;
+    caretakerPhone: string | null;
+    caretakerEmail: string | null;
     // WP-17: confidential (matrix grants Appointments.ProviderAmount to MGR/AM only). The API omits
     // this field from the response for callers lacking the claim (e.g. FrontDesk), so it is optional.
     providerAmount?: number;

--- a/test-scenarios/appointment-display-b3-b4.md
+++ b/test-scenarios/appointment-display-b3-b4.md
@@ -1,0 +1,36 @@
+# Test Scenarios — B3 caretaker in Session Details + B4 specialty on dashboard rows
+
+**Origin:** 2026-07-07 meeting punch list, bugs B3 and B4.
+**Depends on:** API branch `fix/b3-session-caretaker-fields` (new `caretakerName`/`caretakerPhone`/
+`caretakerEmail` on every SessionEvent — deploy API before or with this UI change; without it the
+Caretaker row just shows "—").
+
+## B3 — Caretaker contact info in Session Details
+
+### Scenario 1 — Patient with a primary caretaker
+1. Appointments → Proposed tab → open "More actions" (Session Details) on any session whose
+   patient has a caretaker.
+2. **Expect:** Appointment Info now shows **Caretaker** (Last, First), **Caretaker Phone**, and
+   **Caretaker Email** rows between Therapist and Date.
+3. Cross-check the values against Patients → that patient's caretaker links (primary wins).
+
+### Scenario 2 — Legacy synthetic placeholder caretaker
+1. Open Session Details for a legacy-imported patient (most have a synthetic
+   `<Name>-SH (LEGACY)` placeholder caretaker).
+2. **Expect:** the placeholder name shows; phone/email show "—" (they are genuinely blank).
+
+### Scenario 3 — Patient with no caretaker
+1. Open Session Details for a session whose patient has no caretaker link (rare — backfill
+   gave everyone a primary).
+2. **Expect:** Caretaker row shows "—"; no phone/email rows; no errors.
+
+## B4 — Specialty Type on dashboard appointment rows
+
+### Scenario 4 — Resolved specialty name
+1. Dashboard → Appointments panel (any date with sessions).
+2. **Expect:** each row's second line reads "<Specialty Name> · <Therapist>"
+   (e.g. "Neuro Motor · Smith, Jane") instead of the raw code ("NM · Smith, Jane").
+
+### Scenario 5 — Session without a resolved specialty
+1. Find a session with no SpecialtyType link (if any).
+2. **Expect:** the row falls back to the raw therapy-type code; "N/A" only when both are absent.


### PR DESCRIPTION
…ard rows

B3: the Proposed > Session Details panel (ActionsPanel) now shows the patient's primary caretaker name/phone/email from the new SessionEvent fields (API branch fix/b3-session-caretaker-fields; contract updated). Dash when the patient has no caretaker. B4: dashboard Appointments rows render the resolved specialtyName (already in the DTO, never displayed), falling back to the raw therapy-type code. Red-to-green spec appointment-display.spec.ts (4 tests); vitest 58 green, vue-tsc/eslint clean.