### PR TITLE
CI: fix stale-CloudFront dead menu items (cache-control split + inval…

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -99,5 +99,24 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
 
+      # Cache strategy: hashed assets are immutable (cache forever); the entry documents
+      # (index.html, config.js) are what NAME the hashed chunks, so they must never be
+      # cached — a stale index.html referencing chunks that `--delete` already removed is
+      # exactly the "Failed to fetch dynamically imported module" dead-menu bug (2026-07-11).
       - name: Sync files to S3
-        run: aws s3 sync app-ui/dist/ s3://neurocorp --delete
+        run: |
+          aws s3 sync app-ui/dist/ s3://neurocorp --delete \
+            --exclude index.html --exclude config.js \
+            --cache-control "public,max-age=31536000,immutable"
+          aws s3 cp app-ui/dist/index.html s3://neurocorp/index.html \
+            --cache-control "no-cache, no-store, must-revalidate"
+          aws s3 cp app-ui/dist/config.js s3://neurocorp/config.js \
+            --cache-control "no-cache, no-store, must-revalidate"
+
+      # Belt-and-suspenders: even with no-cache going forward, drop any already-cached
+      # copies at the edges so the new build is live immediately after deploy.
+      - name: Invalidate CloudFront
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id "${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}" \
+            --paths "/index.html" "/config.js" "/"


### PR DESCRIPTION
…idation)

Every route view is a lazy-loaded hashed chunk, and the S3 deploy used sync --delete with no cache headers and no invalidation: each deploy deleted the previous chunks while CloudFront kept serving the stale index.html/shell (default 24h TTL) that referenced them, so clicking a nav item whose chunk was gone failed with 'Failed to fetch dynamically imported module' (repro: AppointmentsView-qUOW1GBQ.js via index-DaG9VFdB.js). Hashed assets now upload as immutable/1y; index.html + config.js upload as no-cache; a CloudFront invalidation runs after each sync. Requires new repo secret
CLOUDFRONT_DISTRIBUTION_ID.