### PR TITLE
CI: pin CloudFront invalidation to us-east-1 + guard empty distributi…

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -117,6 +117,14 @@ jobs:
       # copies at the edges so the new build is live immediately after deploy.
       - name: Invalidate CloudFront
         run: |
+          # Guard: an unset secret expands to "" and the AWS CLI error is cryptic.
+          if [ -z "${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}" ]; then
+            echo "::error::CLOUDFRONT_DISTRIBUTION_ID repo secret is not set"
+            exit 1
+          fi
+          # CloudFront's control-plane API is global and served from us-east-1; resolving it
+          # through the job's AWS_REGION can hit an endpoint that answers "InvalidAction".
           aws cloudfront create-invalidation \
+            --region us-east-1 \
             --distribution-id "${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}" \
             --paths "/index.html" "/config.js" "/"


### PR DESCRIPTION
…on-id secret

CreateInvalidation failed with InvalidAction: CloudFront's control plane is global (us-east-1) and resolving it via the job's AWS_REGION can hit an endpoint that doesn't speak the CloudFront API. Also fail fast with a clear message when CLOUDFRONT_DISTRIBUTION_ID is unset (an empty secret previously produced --distribution-id "").