### PR TITLE
H2: Admin > About shows the API build date (buildTimeUtc from /api/he…

### DIFF
--- a/app-ui/src/__tests__/about-panel.spec.ts
+++ b/app-ui/src/__tests__/about-panel.spec.ts
@@ -1,0 +1,88 @@
+// H2 (meeting punch list 2026-07-07): Admin › About › Build Info must show the REST API
+// build date. The API's GET /api/health/checks now returns `buildTimeUtc` (contract
+// health-api.md); the panel renders it as an "API built" row and must tolerate older
+// deployed APIs that omit the field.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import AboutPanel from '../components/admin/AboutPanel.vue';
+import type { HealthCheckResponse } from '../interfaces/HealthCheck';
+
+const { getHealthChecksMock } = vi.hoisted(() => ({
+  getHealthChecksMock: vi.fn(),
+}));
+
+vi.mock('../services/HealthHttpClient', () => ({
+  HealthHttpClient: vi.fn().mockImplementation(() => ({
+    getHealthChecks: getHealthChecksMock,
+  })),
+}));
+
+function healthResponse(overrides: Partial<HealthCheckResponse> = {}): HealthCheckResponse {
+  return {
+    version: '121.0.0.0',
+    buildTimeUtc: '2026-07-11T18:24:03.1234567Z',
+    statuses: [],
+    ...overrides,
+  };
+}
+
+function rowValue(wrapper: ReturnType<typeof mount>, label: string): string {
+  const row = wrapper
+    .findAll('dl > div')
+    .find((r) => r.find('dt').text() === label);
+  expect(row, `row "${label}" should exist`).toBeTruthy();
+  return row!.find('dd').text();
+}
+
+describe('AboutPanel — API build date (H2)', () => {
+  beforeEach(() => {
+    getHealthChecksMock.mockReset();
+  });
+
+  it('renders the API version and formatted API build date', async () => {
+    getHealthChecksMock.mockResolvedValue(healthResponse());
+    const wrapper = mount(AboutPanel);
+    await flushPromises();
+
+    expect(rowValue(wrapper, 'API')).toBe('121.0.0.0');
+    // Locale-formatted from the ISO stamp; assert on the stable date portion
+    // (the hour depends on the test runner's timezone).
+    expect(rowValue(wrapper, 'API built')).toMatch(/^7\/11\/2026, \d{1,2}:\d{2} (AM|PM)$/);
+  });
+
+  it('shows an em-dash when the API omits buildTimeUtc (builds ≤ v120)', async () => {
+    getHealthChecksMock.mockResolvedValue(healthResponse({ buildTimeUtc: undefined }));
+    const wrapper = mount(AboutPanel);
+    await flushPromises();
+
+    expect(rowValue(wrapper, 'API')).toBe('121.0.0.0');
+    expect(rowValue(wrapper, 'API built')).toBe('—');
+  });
+
+  it('shows an em-dash for the "unknown" sentinel (unstamped assembly)', async () => {
+    getHealthChecksMock.mockResolvedValue(healthResponse({ buildTimeUtc: 'unknown' }));
+    const wrapper = mount(AboutPanel);
+    await flushPromises();
+
+    expect(rowValue(wrapper, 'API built')).toBe('—');
+  });
+
+  it('degrades both API rows when the health call fails', async () => {
+    getHealthChecksMock.mockRejectedValue(new Error('network down'));
+    const wrapper = mount(AboutPanel);
+    await flushPromises();
+
+    expect(rowValue(wrapper, 'API')).toBe('unavailable');
+    expect(rowValue(wrapper, 'API built')).toBe('—');
+  });
+
+  it('still shows the UI version and UI build time rows', async () => {
+    getHealthChecksMock.mockResolvedValue(healthResponse());
+    const wrapper = mount(AboutPanel);
+    await flushPromises();
+
+    expect(rowValue(wrapper, 'UI')).not.toBe('');
+    expect(rowValue(wrapper, 'UI built')).not.toBe('');
+  });
+});

--- a/app-ui/src/components/admin/AboutPanel.vue
+++ b/app-ui/src/components/admin/AboutPanel.vue
@@ -14,6 +14,11 @@
       </div>
 
       <div class="py-3 flex items-baseline justify-between gap-4">
+        <dt class="text-sm font-medium text-slate-600">UI built</dt>
+        <dd class="font-mono text-sm text-slate-800">{{ formattedUiBuildTime }}</dd>
+      </div>
+
+      <div class="py-3 flex items-baseline justify-between gap-4">
         <dt class="text-sm font-medium text-slate-600">API</dt>
         <dd class="font-mono text-sm text-slate-800">
           <span v-if="apiLoading">…</span>
@@ -23,8 +28,12 @@
       </div>
 
       <div class="py-3 flex items-baseline justify-between gap-4">
-        <dt class="text-sm font-medium text-slate-600">Built</dt>
-        <dd class="font-mono text-sm text-slate-800">{{ formattedBuildTime }}</dd>
+        <dt class="text-sm font-medium text-slate-600">API built</dt>
+        <dd class="font-mono text-sm text-slate-800">
+          <span v-if="apiLoading">…</span>
+          <span v-else-if="apiError || !apiBuildTime" class="text-slate-400">—</span>
+          <span v-else>{{ formattedApiBuildTime }}</span>
+        </dd>
       </div>
     </dl>
   </div>
@@ -34,6 +43,19 @@
 import { defineComponent, ref, computed, onMounted } from 'vue'
 import { HealthHttpClient } from '../../services/HealthHttpClient'
 
+function formatTimestamp(value: string): string {
+  const d = new Date(value)
+  if (Number.isNaN(d.getTime())) return value
+  return d.toLocaleString('en-US', {
+    month: 'numeric',
+    day: 'numeric',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+  })
+}
+
 export default defineComponent({
   name: 'AboutPanel',
   setup() {
@@ -42,6 +64,7 @@ export default defineComponent({
     const buildTime = __APP_BUILD_TIME__
 
     const apiVersion = ref('')
+    const apiBuildTime = ref('')
     const apiLoading = ref(true)
     const apiError = ref(false)
 
@@ -50,23 +73,16 @@ export default defineComponent({
       return `${versionPart} (${uiCommit})`
     })
 
-    const formattedBuildTime = computed(() => {
-      const d = new Date(buildTime)
-      if (Number.isNaN(d.getTime())) return buildTime
-      return d.toLocaleString('en-US', {
-        month: 'numeric',
-        day: 'numeric',
-        year: 'numeric',
-        hour: 'numeric',
-        minute: '2-digit',
-        hour12: true,
-      })
-    })
+    const formattedUiBuildTime = computed(() => formatTimestamp(buildTime))
+    const formattedApiBuildTime = computed(() => formatTimestamp(apiBuildTime.value))
 
     onMounted(async () => {
       try {
         const data = await new HealthHttpClient().getHealthChecks()
         apiVersion.value = data.version
+        // Absent on API builds ≤ v120; "unknown" if the assembly missed the stamp.
+        apiBuildTime.value =
+          data.buildTimeUtc && data.buildTimeUtc !== 'unknown' ? data.buildTimeUtc : ''
       } catch {
         apiError.value = true
       } finally {
@@ -74,7 +90,15 @@ export default defineComponent({
       }
     })
 
-    return { uiDisplay, apiVersion, apiLoading, apiError, formattedBuildTime }
+    return {
+      uiDisplay,
+      apiVersion,
+      apiBuildTime,
+      apiLoading,
+      apiError,
+      formattedUiBuildTime,
+      formattedApiBuildTime,
+    }
   },
 })
 </script>

--- a/app-ui/src/interfaces/HealthCheck.ts
+++ b/app-ui/src/interfaces/HealthCheck.ts
@@ -10,5 +10,7 @@ export interface HealthCheckStatus {
 
 export interface HealthCheckResponse {
   version: string;
+  /** ISO-8601 UTC compile-time stamp; absent on API builds ≤ v120 (H2). */
+  buildTimeUtc?: string;
   statuses: HealthCheckStatus[];
 }

--- a/test-scenarios/about-api-build-date.md
+++ b/test-scenarios/about-api-build-date.md
@@ -1,0 +1,41 @@
+# Test Scenarios — Admin › About: API build date (H2)
+
+Punch-list H2 (2026-07-07 meeting): the Build Info panel showed UI version/SHA/build time but
+no REST API build date. The panel now has four rows — **UI**, **UI built**, **API**,
+**API built** — the last one read from the new `buildTimeUtc` field on
+`GET /api/health/checks`.
+
+> Pre-req: an API build that includes the H2 change (first build after PR merge, > v120).
+> Against an older API the "API built" row legitimately shows "—" (scenario 3).
+
+## 1. Happy path — all four rows populated
+
+1. Log in and open **Admin → About** (Build Info panel).
+2. Verify rows, in order:
+   - **UI** — `v{n} ({sha})` (or `dev (…)` on a local dev build).
+   - **UI built** — locale-formatted date/time (e.g. `7/11/2026, 1:24 PM`).
+   - **API** — assembly version (e.g. `121.0.0.0`).
+   - **API built** — locale-formatted date/time, plausibly matching the deploy day of the
+     running API build.
+3. Cross-check: `curl -s $API/api/health/checks | jq -r '.buildTimeUtc'` — the row should be
+   that instant rendered in your local timezone.
+
+## 2. API unreachable
+
+1. Stop the API (or block the network) and reload Admin → About.
+2. **API** shows *unavailable* (italic); **API built** shows **—**. UI rows unaffected.
+
+## 3. Older API without the field (rollout window)
+
+1. Point the UI at a deployed API build ≤ v120 (field absent from the JSON).
+2. **API** shows its version normally; **API built** shows **—** (no error, no blank).
+
+## 4. Loading state
+
+1. On a slow connection (devtools throttling), while the health call is in flight both
+   **API** and **API built** show `…`, then resolve together.
+
+## Automated coverage
+
+`app-ui/src/__tests__/about-panel.spec.ts` (5 specs): happy path, absent field, `"unknown"`
+sentinel, fetch failure, UI rows intact. Suite 69 green; vue-tsc + eslint clean.


### PR DESCRIPTION
…alth/checks)

Build Info panel regrouped to UI / UI built / API / API built; the new row reads buildTimeUtc (contract health-api.md), rendering em-dash for older APIs that omit the field, the 'unknown' sentinel, or a failed health call. Shared timestamp formatter for both built rows.

vue-tsc + eslint clean; vitest 69 green (5 new in about-panel.spec.ts). Scenarios: test-scenarios/about-api-build-date.md