### PR TITLE
Questionnaire A: vendor manifest 776a7665d67b (OWN/ACCT) + landing-ro…

### DIFF
--- a/app-ui/src/__tests__/router-guard.spec.ts
+++ b/app-ui/src/__tests__/router-guard.spec.ts
@@ -13,7 +13,7 @@ import manifest from '../generated/access-control-matrix.json';
 import { Permissions } from '../generated/permissions';
 import type { ClaimDto } from '../interfaces/Auth';
 
-type Role = 'MGR' | 'AM' | 'FD';
+type Role = 'MGR' | 'AM' | 'FD' | 'OWN' | 'ACCT';
 
 function claimsForRole(role: Role): ClaimDto[] {
   return (manifest.claims as Array<{ claim: string; grants: string[] }>)
@@ -89,6 +89,47 @@ describe('accessGuard', () => {
     authAs({ isSystemAdmin: true });
     const result = await accessGuard(
       to({ name: 'admin', fullPath: '/admin', meta: { requiresSystemAdmin: true } }),
+    );
+    expect(result).toBe(true);
+  });
+
+  // Questionnaire A (2026-07-11): ACCT is the first operator role WITHOUT Dashboard.View.
+  // The old guard hard-coded dashboard as both the app-access test and every redirect target,
+  // which would sign ACCT out at login ("no-access") and loop any denied navigation.
+
+  it('does NOT sign out an Accountant (no Dashboard.View but real claims)', async () => {
+    const store = authAs({ role: 'ACCT' });
+    const result = await accessGuard(
+      to({ name: 'patients', fullPath: '/patients', meta: { permission: Permissions.PatientsView } }),
+    );
+    expect(result).toBe(true);
+    expect(store.isAuthenticated).toBe(true);
+  });
+
+  it('redirects an Accountant hitting the dashboard to their first allowed page, not a loop', async () => {
+    authAs({ role: 'ACCT' });
+    const result = await accessGuard(
+      to({ name: 'dashboard', fullPath: '/', meta: { permission: Permissions.DashboardView } }),
+    );
+    expect(result).toMatchObject({ name: 'patients' });
+  });
+
+  it('redirects an Accountant away from a denied page (Appointments) to their landing page', async () => {
+    authAs({ role: 'ACCT' });
+    const result = await accessGuard(
+      to({
+        name: 'appointments',
+        fullPath: '/appointments',
+        meta: { permission: Permissions.AppointmentsView },
+      }),
+    );
+    expect(result).toMatchObject({ name: 'patients' });
+  });
+
+  it('lets an Owner reach the dashboard (has Dashboard.View)', async () => {
+    authAs({ role: 'OWN' });
+    const result = await accessGuard(
+      to({ name: 'dashboard', fullPath: '/', meta: { permission: Permissions.DashboardView } }),
     );
     expect(result).toBe(true);
   });

--- a/app-ui/src/generated/access-control-matrix.json
+++ b/app-ui/src/generated/access-control-matrix.json
@@ -1,9 +1,9 @@
 {
   "_meta": {
-    "generatedAt": "2026-06-29T19:18:00-05:00",
+    "generatedAt": "2026-07-11T15:16:15-05:00",
     "generator": "tools/generate-access-manifest.sh",
     "hashScope": "sha256 (first 12 hex) of canonical JSON {claims:[{claim,grants}]}, claims+grants sorted; wildcard/restricted cells and all metadata excluded",
-    "semanticHash": "16599d6c39fc",
+    "semanticHash": "776a7665d67b",
     "source": "access-control-matrix.md"
   },
   "claims": [
@@ -14,7 +14,8 @@
     {
       "claim": "Admin.Lookups.AppointmentStatus.View",
       "grants": [
-        "MGR"
+        "MGR",
+        "OWN"
       ]
     },
     {
@@ -24,7 +25,8 @@
     {
       "claim": "Admin.Lookups.PaymentType.View",
       "grants": [
-        "MGR"
+        "MGR",
+        "OWN"
       ]
     },
     {
@@ -34,7 +36,8 @@
     {
       "claim": "Admin.Lookups.RoleType.View",
       "grants": [
-        "MGR"
+        "MGR",
+        "OWN"
       ]
     },
     {
@@ -44,7 +47,8 @@
     {
       "claim": "Admin.Lookups.SpecialtyType.View",
       "grants": [
-        "MGR"
+        "MGR",
+        "OWN"
       ]
     },
     {
@@ -54,7 +58,8 @@
     {
       "claim": "Admin.Sites.View",
       "grants": [
-        "MGR"
+        "MGR",
+        "OWN"
       ]
     },
     {
@@ -64,13 +69,15 @@
     {
       "claim": "Admin.Users.View",
       "grants": [
-        "MGR"
+        "MGR",
+        "OWN"
       ]
     },
     {
       "claim": "Admin.View",
       "grants": [
-        "MGR"
+        "MGR",
+        "OWN"
       ]
     },
     {
@@ -85,7 +92,8 @@
       "claim": "Appointments.ProviderAmount",
       "grants": [
         "AM",
-        "MGR"
+        "MGR",
+        "OWN"
       ]
     },
     {
@@ -100,12 +108,14 @@
       "grants": [
         "AM",
         "FD",
-        "MGR"
+        "MGR",
+        "OWN"
       ]
     },
     {
       "claim": "Caretakers.Edit",
       "grants": [
+        "ACCT",
         "AM",
         "FD",
         "MGR"
@@ -122,9 +132,11 @@
     {
       "claim": "Caretakers.View",
       "grants": [
+        "ACCT",
         "AM",
         "FD",
-        "MGR"
+        "MGR",
+        "OWN"
       ]
     },
     {
@@ -132,14 +144,16 @@
       "grants": [
         "AM",
         "FD",
-        "MGR"
+        "MGR",
+        "OWN"
       ]
     },
     {
       "claim": "Dashboard.ProviderAmount",
       "grants": [
         "AM",
-        "MGR"
+        "MGR",
+        "OWN"
       ]
     },
     {
@@ -147,14 +161,16 @@
       "grants": [
         "AM",
         "FD",
-        "MGR"
+        "MGR",
+        "OWN"
       ]
     },
     {
       "claim": "Patients.Delinquent.View",
       "grants": [
         "AM",
-        "MGR"
+        "MGR",
+        "OWN"
       ]
     },
     {
@@ -183,14 +199,17 @@
     {
       "claim": "Patients.View",
       "grants": [
+        "ACCT",
         "AM",
         "FD",
-        "MGR"
+        "MGR",
+        "OWN"
       ]
     },
     {
       "claim": "Payments.Adjust",
       "grants": [
+        "ACCT",
         "AM",
         "MGR"
       ]
@@ -206,6 +225,7 @@
     {
       "claim": "Payments.Refund",
       "grants": [
+        "ACCT",
         "MGR"
       ]
     },
@@ -220,9 +240,11 @@
     {
       "claim": "Payments.View",
       "grants": [
+        "ACCT",
         "AM",
         "FD",
-        "MGR"
+        "MGR",
+        "OWN"
       ]
     },
     {
@@ -246,47 +268,58 @@
       "grants": [
         "AM",
         "FD",
-        "MGR"
+        "MGR",
+        "OWN"
       ]
     },
     {
       "claim": "ServicePayments.Adjust",
       "grants": [
+        "ACCT",
         "MGR"
       ]
     },
     {
       "claim": "ServicePayments.Record",
       "grants": [
+        "ACCT",
         "MGR"
       ]
     },
     {
       "claim": "ServicePayments.View",
       "grants": [
+        "ACCT",
         "AM",
-        "MGR"
+        "MGR",
+        "OWN"
       ]
     },
     {
       "claim": "Statements.Caretaker.View",
       "grants": [
+        "ACCT",
         "AM",
-        "MGR"
+        "MGR",
+        "OWN"
       ]
     },
     {
       "claim": "Statements.Therapist.View",
       "grants": [
+        "ACCT",
         "AM",
-        "MGR"
+        "MGR",
+        "OWN"
       ]
     },
     {
       "claim": "Statements.View",
       "grants": [
+        "ACCT",
         "AM",
-        "MGR"
+        "MGR",
+        "OWN"
       ]
     },
     {
@@ -296,8 +329,10 @@
     {
       "claim": "Therapists.Delinquent.View",
       "grants": [
+        "ACCT",
         "AM",
-        "MGR"
+        "MGR",
+        "OWN"
       ]
     },
     {
@@ -316,9 +351,11 @@
     {
       "claim": "Therapists.View",
       "grants": [
+        "ACCT",
         "AM",
         "FD",
-        "MGR"
+        "MGR",
+        "OWN"
       ]
     },
     {
@@ -341,7 +378,8 @@
       "grants": [
         "AM",
         "FD",
-        "MGR"
+        "MGR",
+        "OWN"
       ]
     }
   ],
@@ -349,7 +387,9 @@
     "granular": [
       "MGR",
       "AM",
-      "FD"
+      "FD",
+      "OWN",
+      "ACCT"
     ],
     "restricted": [
       "THERAPIST",

--- a/app-ui/src/generated/permissions.ts
+++ b/app-ui/src/generated/permissions.ts
@@ -8,7 +8,7 @@
 //   app-ui/src/generated/access-control-matrix.json, then re-run
 //   tools/generate-ui-permissions.sh.
 //
-//   Access-control manifest semantic hash: 16599d6c39fc
+//   Access-control manifest semantic hash: 776a7665d67b
 // </auto-generated>
 
 /**
@@ -76,4 +76,4 @@ export const Permissions = {
 export type Permission = (typeof Permissions)[keyof typeof Permissions];
 
 /** Access-control manifest semantic hash this module was generated from (WP-17 anchor). */
-export const ACCESS_CONTROL_MANIFEST_HASH = '16599d6c39fc';
+export const ACCESS_CONTROL_MANIFEST_HASH = '776a7665d67b';

--- a/app-ui/src/router/index.ts
+++ b/app-ui/src/router/index.ts
@@ -14,7 +14,8 @@ declare module 'vue-router' {
 }
 
 // `meta.permission` (a generated coarse `*.View` claim) gates page access: the global guard below
-// redirects to the dashboard when the signed-in user lacks it (WP-17C). SYSADMIN passes everything
+// redirects to the user's landing route (first allowed page) when they lack it (WP-17C; landing
+// order added for Questionnaire A roles — ACCT has no Dashboard.View). SYSADMIN passes everything
 // via the wildcard. `/admin` stays SYSADMIN-only this WP — honoring the matrix's MGR `Admin.View`
 // (read-only) is a tracked 17C follow-up (needs AdminView's Manage controls split first).
 const router = createRouter({
@@ -100,11 +101,34 @@ const router = createRouter({
   ],
 });
 
+// Landing candidates in preference order. Not every operator role holds Dashboard.View
+// (Questionnaire A: ACCT doesn't), so redirects resolve to the user's FIRST allowed page
+// instead of a hard-coded dashboard — which would sign such users out / loop them.
+// `/admin` is excluded: it's SA-only in the UI for now (17C follow-up).
+const LANDING_ORDER: ReadonlyArray<readonly [Permission, string]> = [
+  [Permissions.DashboardView, 'dashboard'],
+  [Permissions.PatientsView, 'patients'],
+  [Permissions.TherapistsView, 'therapists'],
+  [Permissions.CaretakersView, 'caretakers'],
+  [Permissions.PaymentsView, 'payments'],
+  [Permissions.StatementsView, 'statements'],
+  [Permissions.ServicePaymentsView, 'service-payments'],
+  [Permissions.AppointmentsView, 'appointments'],
+  [Permissions.TreatmentPlansView, 'treatment-plans'],
+  [Permissions.ScheduleView, 'schedule'],
+];
+
+/** The signed-in user's landing route: first page they may open, or null if none. */
+function landingRoute(auth: ReturnType<typeof useAuthStore>): string | null {
+  if (auth.isSystemAdmin) return 'dashboard';
+  const hit = LANDING_ORDER.find(([claim]) => auth.hasClaim('Permission', claim));
+  return hit ? hit[1] : null;
+}
+
 /** Does the signed-in user have a usable entry into the operator app? */
 function hasAppAccess(auth: ReturnType<typeof useAuthStore>): boolean {
-  // Dashboard is every operator role's landing page (granted to MGR/AM/FD and the SA wildcard).
-  // A principal without it — e.g. a Caretaker-only / claimless user — has no usable page at all.
-  return auth.isSystemAdmin || auth.hasClaim('Permission', Permissions.DashboardView);
+  // A principal with no reachable page at all — e.g. a Caretaker-only / claimless user.
+  return landingRoute(auth) !== null;
 }
 
 /**
@@ -141,19 +165,20 @@ export async function accessGuard(to: RouteLocationNormalized) {
 
   // Don't show the login page to an already-authenticated user.
   if (auth.isAuthenticated && to.name === 'login') {
-    return { name: 'dashboard' };
+    return { name: landingRoute(auth)! };
   }
 
   if (to.meta.requiresSystemAdmin && !auth.isSystemAdmin) {
-    return { name: 'dashboard' };
+    return { name: landingRoute(auth)! };
   }
 
   // Coarse page-access gate: a route with a `meta.permission` requires that claim (WP-17C).
-  // SYSADMIN passes via the wildcard inside hasClaim. Unauthorized users land on the dashboard
-  // (which itself requires Dashboard.View — granted to every operator role).
+  // SYSADMIN passes via the wildcard inside hasClaim. Unauthorized users land on their landing
+  // route — their first allowed page, which passes this gate by construction (no redirect loop).
+  // landingRoute() is non-null here: hasAppAccess() above already signed out users without one.
   const permission = to.meta.permission;
   if (typeof permission === 'string' && !auth.hasClaim('Permission', permission)) {
-    return { name: 'dashboard' };
+    return { name: landingRoute(auth)! };
   }
 
   return true;

--- a/test-scenarios/questionnaire-a-own-acct-routing.md
+++ b/test-scenarios/questionnaire-a-own-acct-routing.md
@@ -1,0 +1,53 @@
+# Test Scenarios — Questionnaire A: OWN / ACCT roles (manifest 776a7665d67b)
+
+The UI vendors the new manifest (OWN=24 / ACCT=14 grants) and the router guard now resolves
+a per-user **landing route** (first allowed page, in sidebar order) instead of hard-coding the
+dashboard — ACCT is the first operator role without `Dashboard.View`, which previously would
+have been **signed out at login** as "no-access", or redirect-looped.
+
+> Pre-req: a SystemUser holding the OWN or ACCT role (RoleType rows exist since 2026-07-11;
+> user assignment is still SQL-only until the Admin user-mgmt WP).
+
+## 1. ACCT login lands on Patients
+
+1. Log in as an ACCT-role user.
+2. You are **not** rejected; you land on **/patients** (ACCT's first allowed page).
+3. Sidebar shows only: Patients, Therapists, Caretakers, Payments, Statements, Service
+   Payments. No Dashboard, Appointments, Treatment Plans, Schedule, or Admin.
+
+## 2. ACCT deep-links to a denied page
+
+1. As ACCT, navigate directly to `/` or `/appointments`.
+2. You are redirected to `/patients` — no blank screen, no logout, no redirect loop.
+
+## 3. ACCT capabilities inside pages
+
+1. Payments: sees list; can **Adjust**; cannot Record or Split (buttons hidden).
+2. Service Payments: sees all tabs; can **issue** (Pay Therapist / Run Payroll) and
+   **reverse** payments.
+3. Statements: both tabs (Caretaker + Therapist) visible.
+4. Caretakers: can create/edit caretakers; cannot link/unlink patients.
+
+## 4. OWN login is read-only oversight
+
+1. Log in as an OWN-role user → lands on **/** (dashboard, incl. the ProviderAmount column
+   and both money tiles).
+2. Every page opens: Patients (incl. Delinquent tab), Therapists (incl. Delinquent),
+   Caretakers, Payments, Statements (both tabs), Service Payments, Appointments, Treatment
+   Plans, Schedule.
+3. **No write controls anywhere**: no create/edit buttons, no payment recording, no booking,
+   no payroll issue/reverse.
+4. `/admin` — still SysAdmin-only in the UI (17C follow-up); OWN's `Admin.View` claim is
+   seeded but the route stays gated for now.
+
+## 5. Existing roles unaffected
+
+1. MGR / AM / FD logins behave exactly as before (landing = dashboard; same pages/buttons).
+2. A claimless user (e.g. caretaker-only) is still signed out at login with the
+   "no-access" message.
+
+## Automated coverage
+
+`src/__tests__/router-guard.spec.ts` (4 new, red→green): ACCT not signed out, ACCT
+dashboard→patients redirect, ACCT denied-page→landing redirect, OWN reaches dashboard.
+Suite 73 green; vue-tsc + eslint clean.


### PR DESCRIPTION
…ute guard fix

Re-vendored generated manifest + permissions.ts (hash bump only - no new claims). Router guard fix (red->green): ACCT is the first operator role WITHOUT Dashboard.View - the old guard used Dashboard.View as the app-access test and hard-coded 'dashboard' as every redirect target, so an ACCT login was signed out as 'no-access' and any denied navigation looped. Guard now resolves a landing route (first allowed page in sidebar order); redirect targets pass their own gate by construction.

vue-tsc + eslint clean; vitest 73 green (4 new router-guard specs). Scenarios: test-scenarios/questionnaire-a-own-acct-routing.md