### PR TITLE
WP-22C: Admin > Merge Patients panel (SYSADMIN-only, F2)

### DIFF
--- a/app-ui/src/__tests__/patient-merge.spec.ts
+++ b/app-ui/src/__tests__/patient-merge.spec.ts
@@ -1,0 +1,238 @@
+// WP-22C (F2) — Admin › Merge Patients (SYSADMIN-only).
+//
+// Three layers:
+//  1. Store matrix — Patients.Merge has an EMPTY grants row: hasClaim must be false for every
+//     granular operator role and true only via the SYSADMIN wildcard.
+//  2. Nav gating — the Data Maintenance group renders only when the principal holds
+//     Patients.Merge (i.e. SYSADMIN).
+//  3. Panel behavior — preview gates execute, blockers disable it, type-to-confirm must match
+//     the duplicate's MRN, and a successful merge shows the result card.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { setActivePinia, createPinia, type Pinia } from 'pinia';
+import manifest from '../generated/access-control-matrix.json';
+import { Permissions } from '../generated/permissions';
+import { useAuthStore } from '../stores/auth';
+import type { ClaimDto } from '../interfaces/Auth';
+import AdminAccordionNav from '../components/admin/AdminAccordionNav.vue';
+import PatientMergePanel from '../components/admin/PatientMergePanel.vue';
+import type { Patient } from '../interfaces/Patient';
+import type { PatientMergePreview, PatientMergeResult } from '../interfaces/PatientMerge';
+
+const { getPatientsMock, previewMergeMock, executeMergeMock } = vi.hoisted(() => ({
+  getPatientsMock: vi.fn(),
+  previewMergeMock: vi.fn(),
+  executeMergeMock: vi.fn(),
+}));
+
+vi.mock('../services/PatientsHttpClient', () => ({
+  PatientsHttpClient: vi.fn().mockImplementation(() => ({
+    getPatients: getPatientsMock,
+    previewMerge: previewMergeMock,
+    executeMerge: executeMergeMock,
+  })),
+}));
+
+type Role = 'MGR' | 'AM' | 'FD' | 'ACCT' | 'OWN';
+
+function claimsForRole(role: Role): ClaimDto[] {
+  return (manifest.claims as Array<{ claim: string; grants: string[] }>)
+    .filter((c) => c.grants.includes(role))
+    .map((c) => ({ type: 'Permission', value: c.claim }));
+}
+
+function authAs(opts: { role?: Role; isSystemAdmin?: boolean }): Pinia {
+  const pinia = createPinia();
+  setActivePinia(pinia);
+  const store = useAuthStore();
+  store.user = {
+    userId: 1,
+    email: 'test@example.com',
+    fullName: 'Test User',
+    mustChangePassword: false,
+    roles: opts.role ? [opts.role] : [],
+    claims: opts.role ? claimsForRole(opts.role) : [],
+    isSystemAdmin: opts.isSystemAdmin ?? false,
+  };
+  return pinia;
+}
+
+function makePatient(overrides: Partial<Patient> = {}): Patient {
+  return {
+    patientId: 1, userId: 10, patientName: 'Perez, Juan', medicalRecordNumber: 'L24-0312',
+    cedula: null, dateOfBirth: '2018-05-04T00:00:00', email: null, phoneNumber: null,
+    gender: 'Male', isActive: true, hasCompletedDiscovery: null, createdTimestamp: '',
+    ...overrides,
+  };
+}
+
+const survivor = makePatient();
+const duplicate = makePatient({ patientId: 2, userId: 20, patientName: 'Perez, Jaun', medicalRecordNumber: 'L24-0313' });
+
+function makePreview(overrides: Partial<PatientMergePreview> = {}): PatientMergePreview {
+  return {
+    survivor: {
+      patientId: 1, userId: 10, patientName: 'Perez, Juan', medicalRecordNumber: 'L24-0312',
+      cedula: null, dateOfBirth: '2018-05-04T00:00:00', gender: 'Male', isActive: true,
+      sessionCount: 12, planCount: 1, caretakerCount: 1,
+    },
+    eliminated: {
+      patientId: 2, userId: 20, patientName: 'Perez, Jaun', medicalRecordNumber: 'L24-0313',
+      cedula: null, dateOfBirth: null, gender: null, isActive: true,
+      sessionCount: 2, planCount: 0, caretakerCount: 1,
+    },
+    counts: {
+      sessionsToRemap: 2, plansToRemap: 0, caretakerLinksToRemap: 0,
+      caretakerLinksToDedupe: 0, syntheticCaretakersToDelete: 1,
+    },
+    caretakers: [
+      { caretakerId: 55, caretakerName: 'Perez-SH (LEGACY), Jaun', isSynthetic: true, disposition: 'retire-synthetic', primaryFlagDropped: false },
+    ],
+    fieldFills: [],
+    warnings: [],
+    blockers: [],
+    ...overrides,
+  };
+}
+
+function makeResult(): PatientMergeResult {
+  return {
+    survivorPatientId: 1, eliminatedPatientId: 2, mergeLogId: 42,
+    counts: { sessionsRemapped: 2, plansRemapped: 0, caretakerLinksRemapped: 0, caretakerLinksDeduped: 0, syntheticCaretakersDeleted: 1 },
+    fieldsFilled: ['DateOfBirth'], mergedAtUtc: '2026-07-15T14:30:00Z',
+  };
+}
+
+async function mountPanel(): Promise<ReturnType<typeof mount>> {
+  const pinia = authAs({ isSystemAdmin: true });
+  const wrapper = mount(PatientMergePanel, { global: { plugins: [pinia] } });
+  await flushPromises();
+  return wrapper;
+}
+
+/** Drive the panel to the previewed state with both patients selected. */
+async function mountPreviewedPanel(preview = makePreview()) {
+  previewMergeMock.mockResolvedValue(preview);
+  const wrapper = await mountPanel();
+  const vm = wrapper.vm as unknown as { survivor: Patient | null; eliminated: Patient | null };
+  vm.survivor = survivor;
+  vm.eliminated = duplicate;
+  await wrapper.vm.$nextTick();
+  await wrapper.find('button.bg-violet-600').trigger('click');
+  await flushPromises();
+  return wrapper;
+}
+
+beforeEach(() => {
+  getPatientsMock.mockReset().mockResolvedValue([survivor, duplicate]);
+  previewMergeMock.mockReset();
+  executeMergeMock.mockReset();
+});
+
+describe('store hasClaim matrix — Patients.Merge is wildcard-only', () => {
+  it.each(['MGR', 'AM', 'FD', 'OWN', 'ACCT'] as Role[])('%s does NOT hold Patients.Merge', (role) => {
+    authAs({ role });
+    expect(useAuthStore().hasClaim('Permission', Permissions.PatientsMerge)).toBe(false);
+  });
+
+  it('SYSADMIN satisfies Patients.Merge via the wildcard', () => {
+    authAs({ isSystemAdmin: true });
+    expect(useAuthStore().hasClaim('Permission', Permissions.PatientsMerge)).toBe(true);
+  });
+
+  it('the manifest itself carries an empty grants row for Patients.Merge', () => {
+    const row = (manifest.claims as Array<{ claim: string; grants: string[] }>)
+      .find((c) => c.claim === 'Patients.Merge');
+    expect(row).toBeDefined();
+    expect(row!.grants).toEqual([]);
+  });
+});
+
+describe('AdminAccordionNav — Data Maintenance gating', () => {
+  function mountNav(opts: { role?: Role; isSystemAdmin?: boolean }) {
+    const pinia = authAs(opts);
+    return mount(AdminAccordionNav, {
+      props: { activeSection: 'sites' },
+      global: { plugins: [pinia] },
+    });
+  }
+
+  it('hides the group for MGR (holds Admin.View but not Patients.Merge)', () => {
+    const w = mountNav({ role: 'MGR' });
+    expect(w.find('[data-testid="nav-group-data-maintenance"]').exists()).toBe(false);
+    expect(w.find('[data-testid="nav-merge-patients"]').exists()).toBe(false);
+  });
+
+  it('shows the group for SYSADMIN and emits select on click', async () => {
+    const w = mountNav({ isSystemAdmin: true });
+    expect(w.find('[data-testid="nav-group-data-maintenance"]').exists()).toBe(true);
+    await w.find('[data-testid="nav-merge-patients"]').trigger('click');
+    expect(w.emitted('select')).toEqual([['merge-patients']]);
+  });
+});
+
+describe('PatientMergePanel — stepper behavior', () => {
+  it('loads the patient census on mount', async () => {
+    await mountPanel();
+    expect(getPatientsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('preview button disabled until both sides are picked', async () => {
+    const wrapper = await mountPanel();
+    const previewBtn = wrapper.find('button.bg-violet-600');
+    expect(previewBtn.attributes('disabled')).toBeDefined();
+  });
+
+  it('preview renders counts and dispositions; execute requires the matching MRN', async () => {
+    const wrapper = await mountPreviewedPanel();
+
+    expect(previewMergeMock).toHaveBeenCalledWith({ survivorPatientId: 1, eliminatedPatientId: 2 });
+    expect(wrapper.find('[data-testid="merge-preview"]').exists()).toBe(true);
+    expect(wrapper.text()).toContain('placeholder retired');
+
+    const execBtn = wrapper.find('[data-testid="merge-execute-button"]');
+    expect(execBtn.attributes('disabled')).toBeDefined();
+
+    // Wrong text keeps it disabled; the duplicate's MRN enables it.
+    await wrapper.find('[data-testid="merge-confirm-input"]').setValue('nope');
+    expect(wrapper.find('[data-testid="merge-execute-button"]').attributes('disabled')).toBeDefined();
+    await wrapper.find('[data-testid="merge-confirm-input"]').setValue('L24-0313');
+    expect(wrapper.find('[data-testid="merge-execute-button"]').attributes('disabled')).toBeUndefined();
+  });
+
+  it('blockers hide the confirm step entirely', async () => {
+    const wrapper = await mountPreviewedPanel(makePreview({
+      blockers: ['Eliminated patient\'s user 20 holds non-Patient roles; resolve manually before merging.'],
+    }));
+
+    expect(wrapper.find('[data-testid="merge-blockers"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="merge-execute-button"]').exists()).toBe(false);
+  });
+
+  it('successful merge shows the result card and reloads the census', async () => {
+    executeMergeMock.mockResolvedValue(makeResult());
+    const wrapper = await mountPreviewedPanel();
+
+    await wrapper.find('[data-testid="merge-confirm-input"]').setValue('L24-0313');
+    await wrapper.find('[data-testid="merge-execute-button"]').trigger('click');
+    await flushPromises();
+
+    expect(executeMergeMock).toHaveBeenCalledWith({ survivorPatientId: 1, eliminatedPatientId: 2 });
+    expect(wrapper.text()).toContain('Merge completed — log #42');
+    expect(wrapper.text()).toContain('2 session(s) moved');
+    expect(getPatientsMock).toHaveBeenCalledTimes(2); // mount + post-merge reload
+  });
+
+  it('a failed merge surfaces the error and stays on the preview', async () => {
+    executeMergeMock.mockRejectedValue(new Error('Conflict: resolve manually'));
+    const wrapper = await mountPreviewedPanel();
+
+    await wrapper.find('[data-testid="merge-confirm-input"]').setValue('L24-0313');
+    await wrapper.find('[data-testid="merge-execute-button"]').trigger('click');
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('Conflict: resolve manually');
+    expect(wrapper.find('[data-testid="merge-preview"]').exists()).toBe(true);
+  });
+});

--- a/app-ui/src/components/admin/AdminAccordionNav.vue
+++ b/app-ui/src/components/admin/AdminAccordionNav.vue
@@ -70,6 +70,42 @@
       </div>
     </div>
 
+    <!-- Data Maintenance group (WP-22) -->
+    <div v-if="hasClaim('Permission', Permissions.PatientsMerge)">
+      <button
+        class="w-full px-4 py-3 bg-slate-50 border-b border-slate-200 flex items-center justify-between hover:bg-slate-100 transition-colors"
+        data-testid="nav-group-data-maintenance"
+        @click="dataMaintOpen = !dataMaintOpen"
+      >
+        <span class="text-xs font-semibold text-slate-500 uppercase tracking-wider">Data Maintenance</span>
+        <svg
+          class="w-4 h-4 text-slate-400 transition-transform duration-200"
+          :class="{ 'rotate-180': dataMaintOpen }"
+          fill="none" stroke="currentColor" viewBox="0 0 24 24"
+        >
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+      <div
+        class="overflow-hidden transition-all duration-200"
+        :class="dataMaintOpen ? 'max-h-20' : 'max-h-0'"
+      >
+        <button
+          class="w-full px-4 py-2.5 text-left text-sm flex items-center gap-3 transition-colors border-b border-slate-50"
+          :class="activeSection === 'merge-patients'
+            ? 'bg-violet-50 text-violet-700 font-medium border-l-2 border-l-violet-600'
+            : 'text-slate-600 hover:bg-slate-50'"
+          data-testid="nav-merge-patients"
+          @click="$emit('select', 'merge-patients')"
+        >
+          <svg class="w-4 h-4" :class="activeSection === 'merge-patients' ? 'text-violet-500' : 'text-slate-400'" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197m13.5-9a2.5 2.5 0 11-5 0 2.5 2.5 0 015 0z" />
+          </svg>
+          Merge Patients
+        </button>
+      </div>
+    </div>
+
     <!-- Security group (placeholder) -->
     <div>
       <button
@@ -136,6 +172,7 @@
 
 <script lang="ts">
 import { defineComponent, ref } from 'vue';
+import { useClaims, Permissions } from '../../composables/useClaims';
 
 export default defineComponent({
   name: 'AdminAccordionNav',
@@ -144,8 +181,13 @@ export default defineComponent({
   },
   emits: ['select'],
   setup() {
+    // /admin is already SYSADMIN-only at the route; gating the Data Maintenance group on
+    // Patients.Merge (wildcard-only claim) is belt-and-suspenders and keeps the nav honest
+    // if the route gate ever loosens (the tracked "MGR read-only Admin" follow-up).
+    const { hasClaim } = useClaims();
     const configOpen = ref(true);
     const refdataOpen = ref(true);
+    const dataMaintOpen = ref(true);
     const securityOpen = ref(false);
     const aboutOpen = ref(false);
 
@@ -172,7 +214,7 @@ export default defineComponent({
       },
     ];
 
-    return { configOpen, refdataOpen, securityOpen, aboutOpen, refDataItems };
+    return { configOpen, refdataOpen, dataMaintOpen, securityOpen, aboutOpen, refDataItems, hasClaim, Permissions };
   },
 });
 </script>

--- a/app-ui/src/components/admin/PatientMergePanel.vue
+++ b/app-ui/src/components/admin/PatientMergePanel.vue
@@ -1,0 +1,319 @@
+<template>
+  <div class="bg-white rounded-xl shadow-sm border border-slate-200">
+    <div class="px-6 py-4 border-b border-slate-200">
+      <h2 class="text-lg font-semibold text-slate-800">Merge Duplicate Patients</h2>
+      <p class="text-sm text-slate-500 mt-0.5">
+        Move everything from a duplicate record onto the record you keep, then permanently
+        delete the duplicate. SYSADMIN only — this cannot be undone from the app.
+      </p>
+    </div>
+
+    <div class="p-6 space-y-6">
+      <!-- Error banner -->
+      <div v-if="error" class="rounded-lg border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
+        {{ error }}
+      </div>
+
+      <!-- Result card (terminal step) -->
+      <div v-if="result" class="rounded-lg border border-emerald-200 bg-emerald-50 p-4">
+        <p class="text-sm font-semibold text-emerald-800">
+          ✓ Merge completed — log #{{ result.mergeLogId }}
+        </p>
+        <ul class="mt-2 text-sm text-emerald-900 space-y-0.5">
+          <li>{{ result.counts.sessionsRemapped }} session(s) moved to the surviving record</li>
+          <li>{{ result.counts.plansRemapped }} treatment plan(s) moved</li>
+          <li>
+            Caretaker links: {{ result.counts.caretakerLinksRemapped }} moved,
+            {{ result.counts.caretakerLinksDeduped }} duplicate(s) removed,
+            {{ result.counts.syntheticCaretakersDeleted }} placeholder(s) retired
+          </li>
+          <li v-if="result.fieldsFilled.length > 0">
+            Fields inherited by the survivor: {{ result.fieldsFilled.join(', ') }}
+          </li>
+        </ul>
+        <button
+          type="button"
+          class="mt-4 rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-700"
+          @click="reset"
+        >
+          Merge another pair
+        </button>
+      </div>
+
+      <template v-else>
+        <!-- Step 1: pick the pair -->
+        <div class="grid grid-cols-1 md:grid-cols-[1fr,auto,1fr] items-start gap-4">
+          <PatientSearchSelect
+            v-model="survivor"
+            label="Survivor (record to KEEP)"
+            accent="keep"
+            :patients="patients"
+            :exclude-id="eliminated?.patientId ?? null"
+          />
+          <button
+            type="button"
+            class="mt-6 self-center rounded-lg border border-slate-300 p-2 text-slate-500 hover:bg-slate-50 disabled:opacity-40"
+            title="Swap survivor and duplicate"
+            :disabled="!survivor && !eliminated"
+            @click="swap"
+          >
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4" />
+            </svg>
+          </button>
+          <PatientSearchSelect
+            v-model="eliminated"
+            label="Duplicate (record to DELETE)"
+            accent="remove"
+            :patients="patients"
+            :exclude-id="survivor?.patientId ?? null"
+          />
+        </div>
+
+        <div v-if="loadingPatients" class="text-sm text-slate-400">Loading patients…</div>
+
+        <div>
+          <button
+            type="button"
+            class="rounded-lg bg-violet-600 px-4 py-2 text-sm font-medium text-white hover:bg-violet-700 disabled:opacity-40 disabled:cursor-not-allowed"
+            :disabled="!canPreview || previewing"
+            @click="runPreview"
+          >
+            {{ previewing ? 'Analyzing…' : 'Preview merge' }}
+          </button>
+        </div>
+
+        <!-- Step 2: preview -->
+        <div v-if="preview" class="space-y-4" data-testid="merge-preview">
+          <!-- Blockers -->
+          <div
+            v-if="preview.blockers.length > 0"
+            class="rounded-lg border border-rose-200 bg-rose-50 px-4 py-3"
+            data-testid="merge-blockers"
+          >
+            <p class="text-sm font-semibold text-rose-800">This pair cannot be merged:</p>
+            <ul class="mt-1 list-disc pl-5 text-sm text-rose-700">
+              <li v-for="(b, i) in preview.blockers" :key="i">{{ b }}</li>
+            </ul>
+          </div>
+
+          <!-- Warnings -->
+          <div
+            v-if="preview.warnings.length > 0"
+            class="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3"
+          >
+            <ul class="list-disc pl-5 text-sm text-amber-800">
+              <li v-for="(w, i) in preview.warnings" :key="i">{{ w }}</li>
+            </ul>
+          </div>
+
+          <!-- Identity cards -->
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div
+              v-for="side in identitySides"
+              :key="side.key"
+              class="rounded-lg border p-4"
+              :class="side.key === 'survivor' ? 'border-emerald-200 bg-emerald-50/40' : 'border-rose-200 bg-rose-50/40'"
+            >
+              <p class="text-xs font-semibold uppercase tracking-wider"
+                 :class="side.key === 'survivor' ? 'text-emerald-700' : 'text-rose-700'">
+                {{ side.title }}
+              </p>
+              <p class="mt-1 text-sm font-semibold text-slate-800">{{ side.who.patientName }}</p>
+              <dl class="mt-2 grid grid-cols-2 gap-x-3 gap-y-1 text-xs text-slate-600">
+                <dt>MRN</dt><dd class="text-right">{{ side.who.medicalRecordNumber ?? '—' }}</dd>
+                <dt>Cedula</dt><dd class="text-right">{{ side.who.cedula ?? '—' }}</dd>
+                <dt>Date of birth</dt><dd class="text-right">{{ formatDate(side.who.dateOfBirth) }}</dd>
+                <dt>Gender</dt><dd class="text-right">{{ side.who.gender ?? '—' }}</dd>
+                <dt>Status</dt><dd class="text-right">{{ side.who.isActive ? 'Active' : 'Inactive' }}</dd>
+                <dt>Sessions</dt><dd class="text-right font-medium">{{ side.who.sessionCount }}</dd>
+                <dt>Treatment plans</dt><dd class="text-right font-medium">{{ side.who.planCount }}</dd>
+                <dt>Caretakers</dt><dd class="text-right font-medium">{{ side.who.caretakerCount }}</dd>
+              </dl>
+            </div>
+          </div>
+
+          <!-- What will happen -->
+          <div class="rounded-lg border border-slate-200 p-4">
+            <p class="text-xs font-semibold text-slate-500 uppercase tracking-wider">What this merge will do</p>
+            <ul class="mt-2 text-sm text-slate-700 space-y-1">
+              <li>Move <strong>{{ preview.counts.sessionsToRemap }}</strong> session(s) and <strong>{{ preview.counts.plansToRemap }}</strong> treatment plan(s) to {{ preview.survivor.patientName }}</li>
+              <li v-for="c in preview.caretakers" :key="c.caretakerId">
+                Caretaker "{{ c.caretakerName }}"<span v-if="c.isSynthetic"> (placeholder)</span> —
+                <span v-if="c.disposition === 'remap'">moved to the survivor<span v-if="c.primaryFlagDropped"> (as non-primary)</span></span>
+                <span v-else-if="c.disposition === 'dedupe-delete'">already linked to the survivor; duplicate link removed</span>
+                <span v-else>placeholder retired (deleted)</span>
+              </li>
+              <li v-for="f in preview.fieldFills" :key="f.field">
+                Survivor inherits <strong>{{ f.field }}</strong>: {{ f.value }}
+              </li>
+              <li class="text-rose-700">
+                Then <strong>permanently delete</strong> {{ preview.eliminated.patientName }}
+                (#{{ preview.eliminated.patientId }}) and its login identity.
+                An audit record is kept.
+              </li>
+            </ul>
+          </div>
+
+          <!-- Step 3: type-to-confirm -->
+          <div v-if="preview.blockers.length === 0" class="rounded-lg border border-slate-200 p-4">
+            <label class="block text-sm text-slate-700">
+              To confirm, type the duplicate's
+              <template v-if="confirmTarget.kind === 'mrn'">MRN <strong>{{ confirmTarget.value }}</strong></template>
+              <template v-else>full name <strong>{{ confirmTarget.value }}</strong></template>
+            </label>
+            <input
+              v-model="confirmText"
+              type="text"
+              class="mt-2 w-full max-w-md rounded-lg border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-rose-500"
+              :placeholder="confirmTarget.value"
+              data-testid="merge-confirm-input"
+            />
+            <button
+              type="button"
+              class="mt-3 rounded-lg bg-rose-600 px-4 py-2 text-sm font-medium text-white hover:bg-rose-700 disabled:opacity-40 disabled:cursor-not-allowed"
+              :disabled="!confirmMatches || merging"
+              data-testid="merge-execute-button"
+              @click="runMerge"
+            >
+              {{ merging ? 'Merging…' : 'Merge & Delete duplicate' }}
+            </button>
+          </div>
+        </div>
+      </template>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref, computed, onMounted } from 'vue';
+import PatientSearchSelect from '../patients/PatientSearchSelect.vue';
+import { PatientsHttpClient } from '../../services/PatientsHttpClient';
+import type { Patient } from '../../interfaces/Patient';
+import type { PatientMergePreview, PatientMergeResult } from '../../interfaces/PatientMerge';
+
+/**
+ * WP-22 (F2): Admin › Merge Patients — SYSADMIN-only stepper:
+ * pick survivor + duplicate → preview (blockers disable execute) → type-to-confirm → result.
+ */
+export default defineComponent({
+  name: 'PatientMergePanel',
+  components: { PatientSearchSelect },
+  setup() {
+    const client = new PatientsHttpClient();
+
+    const patients = ref<Patient[]>([]);
+    const loadingPatients = ref(false);
+    const survivor = ref<Patient | null>(null);
+    const eliminated = ref<Patient | null>(null);
+    const preview = ref<PatientMergePreview | null>(null);
+    const result = ref<PatientMergeResult | null>(null);
+    const confirmText = ref('');
+    const previewing = ref(false);
+    const merging = ref(false);
+    const error = ref('');
+
+    const loadPatients = async () => {
+      loadingPatients.value = true;
+      try {
+        patients.value = await client.getPatients();
+      } catch (e: unknown) {
+        error.value = e instanceof Error ? e.message : 'Failed to load patients.';
+      } finally {
+        loadingPatients.value = false;
+      }
+    };
+    onMounted(loadPatients);
+
+    const canPreview = computed(
+      () => !!survivor.value && !!eliminated.value
+        && survivor.value.patientId !== eliminated.value.patientId,
+    );
+
+    // Confirmation target: the duplicate's MRN, falling back to its exact name when the
+    // MRN is missing/temporary (TEMP- MRNs are machine-generated and unfamiliar to users).
+    const confirmTarget = computed<{ kind: 'mrn' | 'name'; value: string }>(() => {
+      const who = preview.value?.eliminated;
+      const mrn = who?.medicalRecordNumber ?? '';
+      if (mrn && !mrn.toUpperCase().startsWith('TEMP-')) return { kind: 'mrn', value: mrn };
+      return { kind: 'name', value: who?.patientName ?? '' };
+    });
+
+    const confirmMatches = computed(
+      () => confirmText.value.trim() === confirmTarget.value.value && confirmTarget.value.value !== '',
+    );
+
+    const identitySides = computed(() => preview.value
+      ? [
+          { key: 'survivor', title: 'Keep — Survivor', who: preview.value.survivor },
+          { key: 'eliminated', title: 'Delete — Duplicate', who: preview.value.eliminated },
+        ]
+      : []);
+
+    const swap = () => {
+      const s = survivor.value;
+      survivor.value = eliminated.value;
+      eliminated.value = s;
+      preview.value = null;
+      confirmText.value = '';
+    };
+
+    const runPreview = async () => {
+      if (!survivor.value || !eliminated.value) return;
+      previewing.value = true;
+      error.value = '';
+      preview.value = null;
+      confirmText.value = '';
+      try {
+        preview.value = await client.previewMerge({
+          survivorPatientId: survivor.value.patientId,
+          eliminatedPatientId: eliminated.value.patientId,
+        });
+      } catch (e: unknown) {
+        error.value = e instanceof Error ? e.message : 'Failed to preview the merge.';
+      } finally {
+        previewing.value = false;
+      }
+    };
+
+    const runMerge = async () => {
+      if (!survivor.value || !eliminated.value || !confirmMatches.value) return;
+      merging.value = true;
+      error.value = '';
+      try {
+        result.value = await client.executeMerge({
+          survivorPatientId: survivor.value.patientId,
+          eliminatedPatientId: eliminated.value.patientId,
+        });
+        // The census changed (one record gone, survivor possibly enriched) — reload.
+        await loadPatients();
+      } catch (e: unknown) {
+        error.value = e instanceof Error ? e.message : 'The merge failed — nothing was changed.';
+      } finally {
+        merging.value = false;
+      }
+    };
+
+    const reset = () => {
+      survivor.value = null;
+      eliminated.value = null;
+      preview.value = null;
+      result.value = null;
+      confirmText.value = '';
+      error.value = '';
+    };
+
+    const formatDate = (iso: string | null) => {
+      if (!iso) return '—';
+      const d = new Date(iso);
+      return Number.isNaN(d.getTime()) ? '—' : d.toLocaleDateString();
+    };
+
+    return {
+      patients, loadingPatients, survivor, eliminated, preview, result,
+      confirmText, confirmTarget, confirmMatches, previewing, merging, error,
+      canPreview, identitySides, swap, runPreview, runMerge, reset, formatDate,
+    };
+  },
+});
+</script>

--- a/app-ui/src/components/patients/PatientSearchSelect.vue
+++ b/app-ui/src/components/patients/PatientSearchSelect.vue
@@ -1,0 +1,131 @@
+<template>
+  <div class="relative">
+    <label class="block text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">
+      {{ label }}
+    </label>
+
+    <!-- Selected patient card -->
+    <div
+      v-if="modelValue"
+      class="flex items-center justify-between rounded-lg border px-3 py-2"
+      :class="accentClasses"
+    >
+      <div class="min-w-0">
+        <p class="text-sm font-medium text-slate-800 truncate">{{ modelValue.patientName }}</p>
+        <p class="text-xs text-slate-500 truncate">
+          MRN {{ modelValue.medicalRecordNumber ?? '—' }} · Cedula {{ modelValue.cedula ?? '—' }}
+        </p>
+      </div>
+      <button
+        type="button"
+        class="ml-2 shrink-0 text-slate-400 hover:text-slate-600"
+        :aria-label="`Clear ${label}`"
+        @click="$emit('update:modelValue', null)"
+      >
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </button>
+    </div>
+
+    <!-- Search input + dropdown -->
+    <div v-else>
+      <input
+        v-model="search"
+        type="text"
+        class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-violet-500"
+        :placeholder="placeholder"
+        @focus="open = true"
+        @blur="closeSoon"
+      />
+      <ul
+        v-if="open && filtered.length > 0"
+        class="absolute z-20 mt-1 w-full max-h-64 overflow-auto rounded-lg border border-slate-200 bg-white shadow-lg"
+      >
+        <li v-for="p in filtered" :key="p.patientId">
+          <button
+            type="button"
+            class="w-full px-3 py-2 text-left hover:bg-violet-50"
+            @mousedown.prevent="pick(p)"
+          >
+            <p class="text-sm text-slate-800">{{ p.patientName }}</p>
+            <p class="text-xs text-slate-500">
+              MRN {{ p.medicalRecordNumber ?? '—' }} · Cedula {{ p.cedula ?? '—' }}
+              <span v-if="!p.isActive" class="ml-1 text-amber-600">(inactive)</span>
+            </p>
+          </button>
+        </li>
+      </ul>
+      <p
+        v-if="open && search.trim() && filtered.length === 0"
+        class="absolute z-20 mt-1 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs text-slate-400 shadow-lg"
+      >
+        No patients match "{{ search }}"
+      </p>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref, computed } from 'vue';
+import type { PropType } from 'vue';
+import type { Patient } from '../../interfaces/Patient';
+
+/**
+ * WP-22 (F2): lightweight client-side patient picker — filters an already-loaded patient
+ * list by name / MRN / cedula. Built for the Admin › Merge Patients panel but reusable
+ * anywhere a single patient must be selected from the full census.
+ */
+export default defineComponent({
+  name: 'PatientSearchSelect',
+  props: {
+    label: { type: String, required: true },
+    placeholder: { type: String, default: 'Search by name, MRN, or cedula…' },
+    patients: { type: Array as PropType<Patient[]>, required: true },
+    modelValue: { type: Object as PropType<Patient | null>, default: null },
+    /** Patient ID to exclude from results (the other side of the merge). */
+    excludeId: { type: Number as PropType<number | null>, default: null },
+    /** Border/background accent for the selected card: 'keep' (green) or 'remove' (red). */
+    accent: { type: String as PropType<'keep' | 'remove'>, default: 'keep' },
+  },
+  emits: ['update:modelValue'],
+  setup(props, { emit }) {
+    const search = ref('');
+    const open = ref(false);
+    const maxResults = 8;
+
+    const filtered = computed(() => {
+      const q = search.value.trim().toLowerCase();
+      if (!q) return [];
+      return props.patients
+        .filter((p) => p.patientId !== props.excludeId)
+        .filter(
+          (p) =>
+            p.patientName.toLowerCase().includes(q) ||
+            (p.medicalRecordNumber ?? '').toLowerCase().includes(q) ||
+            (p.cedula ?? '').toLowerCase().includes(q),
+        )
+        .slice(0, maxResults);
+    });
+
+    const accentClasses = computed(() =>
+      props.accent === 'remove'
+        ? 'border-rose-300 bg-rose-50'
+        : 'border-emerald-300 bg-emerald-50',
+    );
+
+    const pick = (p: Patient) => {
+      emit('update:modelValue', p);
+      search.value = '';
+      open.value = false;
+    };
+
+    // Let a mousedown on a result land before the blur closes the list.
+    const closeSoon = () => {
+      window.setTimeout(() => { open.value = false; }, 150);
+    };
+
+    return { search, open, filtered, accentClasses, pick, closeSoon };
+  },
+});
+</script>

--- a/app-ui/src/generated/access-control-matrix.json
+++ b/app-ui/src/generated/access-control-matrix.json
@@ -1,9 +1,9 @@
 {
   "_meta": {
-    "generatedAt": "2026-07-11T15:16:15-05:00",
+    "generatedAt": "2026-07-11T20:33:41-05:00",
     "generator": "tools/generate-access-manifest.sh",
     "hashScope": "sha256 (first 12 hex) of canonical JSON {claims:[{claim,grants}]}, claims+grants sorted; wildcard/restricted cells and all metadata excluded",
-    "semanticHash": "776a7665d67b",
+    "semanticHash": "6c42b5362fbc",
     "source": "access-control-matrix.md"
   },
   "claims": [
@@ -188,6 +188,10 @@
         "FD",
         "MGR"
       ]
+    },
+    {
+      "claim": "Patients.Merge",
+      "grants": []
     },
     {
       "claim": "Patients.StartDiscovery",

--- a/app-ui/src/generated/permissions.ts
+++ b/app-ui/src/generated/permissions.ts
@@ -8,7 +8,7 @@
 //   app-ui/src/generated/access-control-matrix.json, then re-run
 //   tools/generate-ui-permissions.sh.
 //
-//   Access-control manifest semantic hash: 776a7665d67b
+//   Access-control manifest semantic hash: 6c42b5362fbc
 // </auto-generated>
 
 /**
@@ -46,6 +46,7 @@ export const Permissions = {
   PatientsDelinquentView: 'Patients.Delinquent.View',
   PatientsEdit: 'Patients.Edit',
   PatientsLinkCaretaker: 'Patients.LinkCaretaker',
+  PatientsMerge: 'Patients.Merge',
   PatientsStartDiscovery: 'Patients.StartDiscovery',
   PatientsView: 'Patients.View',
   PaymentsAdjust: 'Payments.Adjust',
@@ -76,4 +77,4 @@ export const Permissions = {
 export type Permission = (typeof Permissions)[keyof typeof Permissions];
 
 /** Access-control manifest semantic hash this module was generated from (WP-17 anchor). */
-export const ACCESS_CONTROL_MANIFEST_HASH = '776a7665d67b';
+export const ACCESS_CONTROL_MANIFEST_HASH = '6c42b5362fbc';

--- a/app-ui/src/interfaces/PatientMerge.ts
+++ b/app-ui/src/interfaces/PatientMerge.ts
@@ -1,0 +1,72 @@
+// interfaces/PatientMerge.ts — WP-22 (F2): duplicate-patient merge (SYSADMIN-only).
+// Maps to the API's PatientMergeRequest / PatientMergePreview / PatientMergeResult
+// (contract: patient-care-super/_contracts/patients-api.md § WP-22).
+
+export interface PatientMergeRequest {
+  survivorPatientId: number;
+  eliminatedPatientId: number;
+}
+
+export interface PatientMergeIdentity {
+  patientId: number;
+  userId: number;
+  patientName: string;
+  medicalRecordNumber: string | null;
+  cedula: string | null;
+  dateOfBirth: string | null;
+  gender: string | null;
+  isActive: boolean;
+  sessionCount: number;
+  planCount: number;
+  caretakerCount: number;
+}
+
+export interface PatientMergePlannedCounts {
+  sessionsToRemap: number;
+  plansToRemap: number;
+  caretakerLinksToRemap: number;
+  caretakerLinksToDedupe: number;
+  syntheticCaretakersToDelete: number;
+}
+
+export type PatientMergeDisposition = 'remap' | 'dedupe-delete' | 'retire-synthetic';
+
+export interface PatientMergeCaretakerDisposition {
+  caretakerId: number;
+  caretakerName: string;
+  isSynthetic: boolean;
+  disposition: PatientMergeDisposition;
+  primaryFlagDropped: boolean;
+}
+
+export interface PatientMergeFieldFill {
+  field: string;
+  value: string;
+}
+
+export interface PatientMergePreview {
+  survivor: PatientMergeIdentity;
+  eliminated: PatientMergeIdentity;
+  counts: PatientMergePlannedCounts;
+  caretakers: PatientMergeCaretakerDisposition[];
+  fieldFills: PatientMergeFieldFill[];
+  warnings: string[];
+  blockers: string[];
+}
+
+export interface PatientMergeExecutedCounts {
+  sessionsRemapped: number;
+  plansRemapped: number;
+  caretakerLinksRemapped: number;
+  caretakerLinksDeduped: number;
+  syntheticCaretakersDeleted: number;
+}
+
+export interface PatientMergeResult {
+  survivorPatientId: number;
+  eliminatedPatientId: number;
+  mergeLogId: number;
+  counts: PatientMergeExecutedCounts;
+  fieldsFilled: string[];
+  mergedAtUtc: string;
+}

--- a/app-ui/src/services/PatientsHttpClient.ts
+++ b/app-ui/src/services/PatientsHttpClient.ts
@@ -3,6 +3,7 @@ import { HttpClientBase } from './HttpClientBase';
 import type { Patient, PatientCreateRequest, PatientUpdateRequest, PatientCaretakerSummary } from '../interfaces/Patient';
 import type { DelinquentPatient } from '../interfaces/Delinquency';
 import type { PagedResult, PatientSessionHistorySummary, PatientHistorySession } from '../interfaces/SessionHistory';
+import type { PatientMergeRequest, PatientMergePreview, PatientMergeResult } from '../interfaces/PatientMerge';
 
 export class PatientsHttpClient extends HttpClientBase {
   async getPatients(): Promise<Patient[]> {
@@ -40,5 +41,14 @@ export class PatientsHttpClient extends HttpClientBase {
   async getPatientSessions(patientId: number, page: number, pageSize = 25): Promise<PagedResult<PatientHistorySession>> {
     const params = new URLSearchParams({ page: String(page), pageSize: String(pageSize) });
     return this.get<PagedResult<PatientHistorySession>>(`/api/patients/${patientId}/sessions?${params.toString()}`);
+  }
+
+  // WP-22 (F2): duplicate-patient merge — SYSADMIN-only (Patients.Merge, wildcard-only claim).
+  async previewMerge(request: PatientMergeRequest): Promise<PatientMergePreview> {
+    return this.post<PatientMergePreview>('/api/patients/merge/preview', request);
+  }
+
+  async executeMerge(request: PatientMergeRequest): Promise<PatientMergeResult> {
+    return this.post<PatientMergeResult>('/api/patients/merge', request);
   }
 }

--- a/app-ui/src/views/AdminView.vue
+++ b/app-ui/src/views/AdminView.vue
@@ -53,6 +53,11 @@
                 </div>
               </template>
 
+              <!-- Merge Patients (WP-22, SYSADMIN-only) -->
+              <div v-if="activeSection === 'merge-patients'">
+                <PatientMergePanel />
+              </div>
+
               <!-- About -->
               <div v-if="activeSection === 'about'">
                 <AboutPanel />
@@ -97,6 +102,7 @@ import AdminAccordionNav from '../components/admin/AdminAccordionNav.vue';
 import LookupTableManager from '../components/admin/LookupTableManager.vue';
 import LookupFormModal from '../components/admin/LookupFormModal.vue';
 import AboutPanel from '../components/admin/AboutPanel.vue';
+import PatientMergePanel from '../components/admin/PatientMergePanel.vue';
 import type { FieldDef } from '../components/admin/LookupFormModal.vue';
 import type { ColumnDef } from '../components/admin/LookupTableManager.vue';
 import { SitesHttpClient } from '../services/SitesHttpClient';
@@ -111,7 +117,7 @@ export default defineComponent({
     O2MobileNav, O2Sidebar, O2Header, O2Footer,
     SiteList, SiteFormModal,
     AdminAccordionNav, LookupTableManager, LookupFormModal,
-    AboutPanel,
+    AboutPanel, PatientMergePanel,
   },
   setup() {
     const activeSection = ref('sites');

--- a/test-scenarios/patient-merge-admin.md
+++ b/test-scenarios/patient-merge-admin.md
@@ -1,0 +1,58 @@
+# Test Scenarios — Admin › Merge Patients (WP-22C, F2)
+
+**Pre-req:** API with WP-22B deployed (and DB migration V025 applied — the merge writes an
+audit row). Log in as **SYSADMIN**. Non-SYSADMIN operators (MGR/AM/FD/OWN/ACCT) must never
+see this feature.
+
+## 1. Visibility (SYSADMIN-only)
+
+1. Log in as **SYSADMIN** → Admin. The left accordion shows a **Data Maintenance** group with
+   a **Merge Patients** item between Reference Data and Security.
+2. Log in as **MGR** (or any other operator role). `/admin` redirects away (route is
+   SYSADMIN-only today); even if the Admin page were reachable, the Data Maintenance group
+   would not render — it is gated on the `Patients.Merge` claim, which no granular role holds.
+
+## 2. Pick the pair
+
+1. Admin → Data Maintenance → Merge Patients.
+2. In **Survivor (record to KEEP)** type part of a duplicated child's name (e.g. `bultron`) —
+   a dropdown filters by name, MRN, or cedula (max 8 results; inactive patients labeled).
+3. Pick the record to keep — it renders as a green card with MRN + cedula.
+4. In **Duplicate (record to DELETE)** search again — the already-picked survivor is excluded
+   from results. Pick the misspelled twin — red card.
+5. The **swap** button exchanges the two selections (use when you picked them backwards).
+6. **Preview merge** is disabled until both sides are picked.
+
+## 3. Preview
+
+1. Click **Preview merge**. Two identity cards render side-by-side (green Keep / red Delete)
+   with MRN, cedula, DoB, gender, status, and session / treatment-plan / caretaker counts.
+2. "What this merge will do" lists: sessions + plans moving, each caretaker's fate (moved /
+   duplicate link removed / placeholder retired), any blank survivor fields inherited from the
+   duplicate (DoB, cedula, gender, notes — **never the MRN**), and the final permanent-delete
+   line.
+3. Amber warnings appear where relevant (e.g. survivor has a TEMP- MRN while the duplicate has
+   a real one; both records carry different cedulas; a primary-caretaker designation dropped).
+4. **Blocker case:** preview a duplicate whose login user also holds another role (e.g. is
+   also a Caretaker identity) → a red "This pair cannot be merged" box lists the reason and
+   the confirm/execute step does not render at all.
+
+## 4. Type-to-confirm + execute
+
+1. On a clean preview, the confirm box asks you to type the **duplicate's MRN** (falls back to
+   the exact full name when the MRN is temporary/missing).
+2. Typing anything else keeps **Merge & Delete duplicate** disabled; the exact MRN enables it.
+3. Click it. On success a green result card shows the merge-log id and actual counts
+   (sessions moved, plans moved, caretaker links moved/deduped/placeholders retired, fields
+   inherited). **Merge another pair** resets the panel; the patient list reloads (the deleted
+   duplicate no longer appears anywhere in the app).
+4. Verify the survivor via Patients: session count now includes the duplicate's sessions
+   (Session History tab), and the duplicate's record/name is gone from the All-patients grid.
+
+## 5. Failure surfaces
+
+1. If the API rejects the merge (409 blocker raced in, network error), a red banner shows the
+   message and the preview stays on screen — nothing was changed (the merge is a single
+   transaction server-side).
+2. Preview is side-effect-free: preview repeatedly, navigate away, come back — no data changes
+   until the confirm button is pressed.


### PR DESCRIPTION
- New Data Maintenance accordion group gated on Patients.Merge (wildcard-only claim; belt-and-suspenders on top of the SYSADMIN-only /admin route)
- PatientMergePanel stepper: pick survivor/duplicate (new reusable PatientSearchSelect, client-side name/MRN/cedula filter) -> preview (identity cards, counts, caretaker dispositions, warnings; blockers hide execute) -> type-to-confirm (duplicate's MRN, name fallback for TEMP-) -> result card
- PatientsHttpClient +previewMerge/executeMerge; interfaces/PatientMerge.ts
- Manifest re-vendored + permissions.ts regenerated (hash 6c42b5362fbc)
- vitest 86 -> 101 (15 new: wildcard-only claim matrix incl. empty-grants-row proof, nav gating, stepper behavior incl. blocker + failure paths)
- Scenarios: test-scenarios/patient-merge-admin.md

Plan: patient-care-super planning/active/wp-22-merge-duplicate-patients.md