### PR TITLE
WP-23C (F6+F7+F10): admin per-type Default $ config, booking pre-fill…

### DIFF
--- a/app-ui/src/__tests__/wp23-booking-money.spec.ts
+++ b/app-ui/src/__tests__/wp23-booking-money.spec.ts
@@ -1,0 +1,415 @@
+// WP-23 (F6/F7/F10) — booking money pack:
+//   F6  — Admin gains a per-type "Default $" column/field for specialty-types only; the
+//         booking modal pre-fills Amount from the selected specialty's defaultAmount.
+//   F7  — SENADIS patients get a 20%-of-Amount discount floor at booking (one info toast per
+//         patient selection); the Patient form's flag checkbox is claim-gated on edit.
+//   F10 — booking is hard-blocked (modal + plan wizard) when the patient has no caretaker.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { setActivePinia, createPinia, type Pinia } from 'pinia';
+import { mount, flushPromises } from '@vue/test-utils';
+import { nextTick } from 'vue';
+import manifest from '../generated/access-control-matrix.json';
+import { useAuthStore } from '../stores/auth';
+import { useNotificationsStore } from '../stores/notifications';
+import type { ClaimDto } from '../interfaces/Auth';
+import type { Patient } from '../interfaces/Patient';
+import type { TreatmentPlan } from '../interfaces/TreatmentPlan';
+import BookingFormModal from '../components/appointments/BookingFormModal.vue';
+import PatientFormModal from '../components/patients/PatientFormModal.vue';
+import SchedulePlanWizard from '../components/treatment-plans/SchedulePlanWizard.vue';
+import AdminView from '../views/AdminView.vue';
+
+// ── shared mocks ─────────────────────────────────────────────────────────────
+
+const FLAGGED_ID = 1;
+const UNFLAGGED_ID = 2;
+const CARETAKERLESS_ID = 3;
+
+function patient(overrides: Partial<Patient> = {}): Patient {
+  return {
+    patientId: FLAGGED_ID,
+    userId: 10,
+    patientName: 'Doe, John',
+    medicalRecordNumber: 'MRN-001',
+    cedula: null,
+    dateOfBirth: '2015-01-15T00:00:00',
+    email: 'john@example.com',
+    phoneNumber: '555-0100',
+    gender: 'Male',
+    isActive: true,
+    hasSenadisDiscount: false,
+    hasCompletedDiscovery: true,
+    createdTimestamp: '2025-01-01T00:00:00',
+    caretakers: [],
+    ...overrides,
+  };
+}
+
+const { patientsClientMocks, lookupGetAllMock, createSessionMock, updatePatientMock, createPatientMock } = vi.hoisted(() => ({
+  patientsClientMocks: {
+    getPatients: vi.fn(),
+    getPatient: vi.fn(),
+    getPatientCaretakers: vi.fn(),
+  },
+  lookupGetAllMock: vi.fn(),
+  createSessionMock: vi.fn().mockResolvedValue({}),
+  updatePatientMock: vi.fn().mockResolvedValue(undefined),
+  createPatientMock: vi.fn().mockResolvedValue({ patientId: 99, medicalRecordNumber: 'MRN-099' }),
+}));
+
+vi.mock('../services/PatientsHttpClient', () => ({
+  PatientsHttpClient: vi.fn().mockImplementation(() => ({
+    getPatients: patientsClientMocks.getPatients,
+    getPatient: patientsClientMocks.getPatient,
+    getPatientCaretakers: patientsClientMocks.getPatientCaretakers,
+    updatePatient: updatePatientMock,
+    createPatient: createPatientMock,
+  })),
+}));
+
+vi.mock('../services/TherapistsHttpClient', () => ({
+  TherapistsHttpClient: vi.fn().mockImplementation(() => ({
+    getTherapists: vi.fn().mockResolvedValue([
+      { therapistId: 7, id: 7, therapistName: 'Therapist, Test', specialties: [] },
+    ]),
+  })),
+}));
+
+vi.mock('../services/LookupHttpClient', () => ({
+  LookupHttpClient: vi.fn().mockImplementation(() => ({
+    getAll: lookupGetAllMock,
+    create: vi.fn().mockResolvedValue({}),
+    update: vi.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+vi.mock('../services/SessionsHttpClient', () => ({
+  SessionsHttpClient: vi.fn().mockImplementation(() => ({
+    createSession: createSessionMock,
+  })),
+}));
+
+vi.mock('../services/SitesHttpClient', () => ({
+  SitesHttpClient: vi.fn().mockImplementation(() => ({
+    getSites: vi.fn().mockResolvedValue([{ siteId: 1, siteName: 'Main' }]),
+  })),
+}));
+
+vi.mock('../services/TreatmentPlansHttpClient', () => ({
+  TreatmentPlansHttpClient: vi.fn().mockImplementation(() => ({
+    schedule: vi.fn().mockResolvedValue({ planId: 1, sessionsCreated: 0, sessions: [], conflicts: [] }),
+  })),
+}));
+
+function claimsForRole(role: string): ClaimDto[] {
+  return (manifest.claims as Array<{ claim: string; grants: string[] }>)
+    .filter((c) => c.grants.includes(role))
+    .map((c) => ({ type: 'Permission', value: c.claim }));
+}
+
+function authAs(role: string): Pinia {
+  const pinia = createPinia();
+  setActivePinia(pinia);
+  const store = useAuthStore();
+  store.user = {
+    userId: 1,
+    email: 'test@example.com',
+    fullName: 'Test User',
+    mustChangePassword: false,
+    roles: [role],
+    claims: claimsForRole(role),
+    isSystemAdmin: false,
+  };
+  return pinia;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  patientsClientMocks.getPatients.mockResolvedValue([
+    patient({ patientId: FLAGGED_ID, patientName: 'Flagged, Fay', hasSenadisDiscount: true }),
+    patient({ patientId: UNFLAGGED_ID, patientName: 'Plain, Pete' }),
+    patient({ patientId: CARETAKERLESS_ID, patientName: 'Alone, Al' }),
+  ]);
+  patientsClientMocks.getPatient.mockImplementation(async (id: number) =>
+    patient({ patientId: id, hasSenadisDiscount: id === FLAGGED_ID }));
+  patientsClientMocks.getPatientCaretakers.mockImplementation(async (id: number) =>
+    id === CARETAKERLESS_ID
+      ? []
+      : [{ caretakerId: 1, caretakerName: 'Care, Cara', isPrimaryCaretaker: true, relationshipToPatient: 'Mother' }]);
+  lookupGetAllMock.mockResolvedValue([
+    { id: 6, abbreviation: 'TL', name: 'Language Therapy', description: null, sortOrder: 1, defaultAmount: 65, createdTimestamp: '', lastUpdatedTimestamp: '' },
+    { id: 2, abbreviation: 'FS', name: 'Physiotherapy', description: null, sortOrder: 2, defaultAmount: null, createdTimestamp: '', lastUpdatedTimestamp: '' },
+  ]);
+});
+
+// ── BookingFormModal ─────────────────────────────────────────────────────────
+
+type BookingVm = {
+  form: { patientId: number; specialtyTypeId: number; amount: number; discount: number };
+  senadisPatient: boolean;
+  senadisFloor: number;
+  caretakerWarning: boolean;
+  isValid: boolean;
+};
+
+async function openBookingModal(pinia: Pinia) {
+  const wrapper = mount(BookingFormModal, {
+    props: { visible: false },
+    global: { plugins: [pinia], stubs: { teleport: true } },
+  });
+  await wrapper.setProps({ visible: true });
+  await flushPromises();
+  return wrapper;
+}
+
+describe('BookingFormModal — F6 default-price pre-fill', () => {
+  it('pre-fills Amount from the specialty defaultAmount and refills on change', async () => {
+    const wrapper = await openBookingModal(authAs('MGR'));
+    const vm = wrapper.vm as unknown as BookingVm;
+
+    vm.form.specialtyTypeId = 6; // TL, defaultAmount 65
+    await flushPromises();
+    expect(vm.form.amount).toBe(65);
+
+    // NULL default leaves the amount alone (user may have typed one already)
+    vm.form.amount = 42;
+    vm.form.specialtyTypeId = 2; // FS, defaultAmount null
+    await flushPromises();
+    expect(vm.form.amount).toBe(42);
+  });
+});
+
+describe('BookingFormModal — F7 SENADIS floor + toast', () => {
+  it('flags the patient, toasts once, and clamps the discount to 20% of amount', async () => {
+    const pinia = authAs('MGR');
+    const wrapper = await openBookingModal(pinia);
+    const vm = wrapper.vm as unknown as BookingVm;
+    const notifications = useNotificationsStore();
+
+    vm.form.patientId = FLAGGED_ID;
+    await flushPromises();
+
+    expect(vm.senadisPatient).toBe(true);
+    const senadisToasts = notifications.items.filter((n) => n.message.includes('SENADIS'));
+    expect(senadisToasts).toHaveLength(1);
+
+    vm.form.amount = 100;
+    await flushPromises();
+    expect(vm.senadisFloor).toBe(20);
+    expect(vm.form.discount).toBe(20); // re-clamped when the amount moved the floor
+
+    // submit clamps a below-floor discount before sending; server floors too
+    vm.form.discount = 5;
+    (wrapper.vm as unknown as { handleSubmit: () => Promise<void> }).handleSubmit();
+    await flushPromises();
+    expect(createSessionMock).toHaveBeenCalledWith(expect.objectContaining({ discount: 20 }));
+  });
+
+  it('leaves unflagged patients untouched', async () => {
+    const wrapper = await openBookingModal(authAs('MGR'));
+    const vm = wrapper.vm as unknown as BookingVm;
+
+    vm.form.patientId = UNFLAGGED_ID;
+    await flushPromises();
+    vm.form.amount = 100;
+    vm.form.discount = 5;
+    await flushPromises();
+
+    expect(vm.senadisPatient).toBe(false);
+    expect(vm.form.discount).toBe(5);
+  });
+});
+
+describe('BookingFormModal — F10 caretaker hard block', () => {
+  it('blocks submit and shows the red blocker for a caretaker-less patient', async () => {
+    const wrapper = await openBookingModal(authAs('MGR'));
+    const vm = wrapper.vm as unknown as BookingVm;
+
+    vm.form.patientId = CARETAKERLESS_ID;
+    await flushPromises();
+
+    expect(vm.caretakerWarning).toBe(true);
+    expect(wrapper.text()).toContain('Booking blocked');
+    // even with everything else selected, the form stays invalid
+    vm.form.specialtyTypeId = 6;
+    (wrapper.vm as unknown as { form: { therapistId: number } }).form.therapistId = 7;
+    await nextTick();
+    expect(vm.isValid).toBe(false);
+  });
+});
+
+// ── SchedulePlanWizard ───────────────────────────────────────────────────────
+
+function makePlan(patientId: number): TreatmentPlan {
+  return {
+    id: 11,
+    patientId,
+    patientName: 'Doe, John',
+    displayTitle: 'Plan #11',
+    planStatus: 'Active',
+    weeklyFrequency: 1,
+    durationWeeks: 2,
+    lines: [
+      {
+        id: 1,
+        specialtyAbbreviation: 'TL',
+        duration: 60, // amount 65.00 ⇒ floor 13.00
+        preferredTherapistId: null,
+        dayOfWeek: 1,
+        preferredTime: '09:00',
+      },
+    ],
+  } as unknown as TreatmentPlan;
+}
+
+type WizardVm = {
+  caretakerBlocked: boolean;
+  senadisPatient: boolean;
+  canProceedStep1: boolean;
+  startDate: string;
+  siteId: number;
+  lineEdits: Array<{ discountAmount: number; discountPct: number }>;
+};
+
+async function openWizard(pinia: Pinia, patientId: number) {
+  const wrapper = mount(SchedulePlanWizard, {
+    props: { visible: false, plan: makePlan(patientId) },
+    global: { plugins: [pinia], stubs: { teleport: true } },
+  });
+  await wrapper.setProps({ visible: true });
+  await flushPromises();
+  return wrapper;
+}
+
+describe('SchedulePlanWizard — WP-23', () => {
+  it('F10: blocks step 1 with a banner when the patient has no caretaker', async () => {
+    const wrapper = await openWizard(authAs('MGR'), CARETAKERLESS_ID);
+    const vm = wrapper.vm as unknown as WizardVm;
+
+    expect(vm.caretakerBlocked).toBe(true);
+    expect(wrapper.text()).toContain('Scheduling blocked');
+    vm.startDate = '2026-07-20';
+    vm.siteId = 1;
+    await nextTick();
+    expect(vm.canProceedStep1).toBe(false);
+  });
+
+  it('F7: initializes each line discount to the 20% floor for SENADIS patients', async () => {
+    const wrapper = await openWizard(authAs('MGR'), FLAGGED_ID);
+    const vm = wrapper.vm as unknown as WizardVm;
+
+    expect(vm.senadisPatient).toBe(true);
+    expect(vm.caretakerBlocked).toBe(false);
+    expect(vm.lineEdits[0].discountAmount).toBe(13); // 20% of the 65.00 line amount
+    expect(vm.lineEdits[0].discountPct).toBe(20);
+  });
+
+  it('leaves lines untouched for unflagged patients', async () => {
+    const wrapper = await openWizard(authAs('MGR'), UNFLAGGED_ID);
+    const vm = wrapper.vm as unknown as WizardVm;
+
+    expect(vm.senadisPatient).toBe(false);
+    expect(vm.lineEdits[0].discountAmount).toBe(0);
+  });
+});
+
+// ── PatientFormModal — F7 claim-gated checkbox ───────────────────────────────
+
+async function openPatientModal(pinia: Pinia, p: Patient | null) {
+  const wrapper = mount(PatientFormModal, {
+    props: { visible: false, patient: p },
+    global: { plugins: [pinia], stubs: { teleport: true } },
+  });
+  await wrapper.setProps({ visible: true });
+  return wrapper;
+}
+
+const senadisCheckbox = (wrapper: ReturnType<typeof mount>) =>
+  wrapper.find('input[type="checkbox"]');
+
+describe('PatientFormModal — F7 SENADIS checkbox claim gating', () => {
+  it('FD on EDIT: checkbox disabled and the payload omits the field', async () => {
+    const wrapper = await openPatientModal(authAs('FD'), patient({ hasSenadisDiscount: true }));
+
+    expect((senadisCheckbox(wrapper).element as HTMLInputElement).disabled).toBe(true);
+    expect(wrapper.text()).toContain('Only Managers / Assistant Managers');
+
+    await wrapper.find('form').trigger('submit');
+    await vi.waitFor(() => expect(updatePatientMock).toHaveBeenCalled());
+    expect(updatePatientMock.mock.calls[0][1].hasSenadisDiscount).toBeUndefined();
+  });
+
+  it('MGR on EDIT: checkbox enabled and the changed value is sent', async () => {
+    const wrapper = await openPatientModal(authAs('MGR'), patient({ hasSenadisDiscount: false }));
+
+    const checkbox = senadisCheckbox(wrapper);
+    expect((checkbox.element as HTMLInputElement).disabled).toBe(false);
+    await checkbox.setValue(true);
+
+    await wrapper.find('form').trigger('submit');
+    await vi.waitFor(() => expect(updatePatientMock).toHaveBeenCalled());
+    expect(updatePatientMock).toHaveBeenCalledWith(
+      FLAGGED_ID,
+      expect.objectContaining({ hasSenadisDiscount: true })
+    );
+  });
+
+  it('FD on CREATE: checkbox enabled (Questionnaire E gates edits only) and value sent', async () => {
+    const wrapper = await openPatientModal(authAs('FD'), null);
+
+    const checkbox = senadisCheckbox(wrapper);
+    expect((checkbox.element as HTMLInputElement).disabled).toBe(false);
+    await checkbox.setValue(true);
+
+    await wrapper.find('input[type="email"]').setValue('new@example.com');
+    await wrapper.find('input[type="tel"]').setValue('555-0101');
+    await wrapper.find('input[type="date"]').setValue('2015-01-15');
+    await wrapper.find('select').setValue('Male');
+    const textInputs = wrapper.findAll('input[type="text"]');
+    await textInputs[0].setValue('First');
+    await textInputs[2].setValue('Last');
+
+    await wrapper.find('form').trigger('submit');
+    await vi.waitFor(() => expect(createPatientMock).toHaveBeenCalled());
+    expect(createPatientMock).toHaveBeenCalledWith(
+      expect.objectContaining({ hasSenadisDiscount: true })
+    );
+  });
+});
+
+// ── AdminView — F6 per-type lookup column ────────────────────────────────────
+
+describe('AdminView — F6 per-type Default $ column', () => {
+  async function mountAdmin(pinia: Pinia, section: string) {
+    const wrapper = mount(AdminView, {
+      global: {
+        plugins: [pinia],
+        stubs: {
+          O2MobileNav: true, O2Sidebar: true, O2Header: true, O2Footer: true,
+          AdminAccordionNav: true, SiteList: true, SiteFormModal: true,
+          LookupTableManager: true, LookupFormModal: true, AboutPanel: true,
+          PatientMergePanel: true,
+        },
+      },
+    });
+    (wrapper.vm as unknown as { activeSection: string }).activeSection = section;
+    await nextTick();
+    return wrapper;
+  }
+
+  it('specialty-types table gains the Default $ column', async () => {
+    const wrapper = await mountAdmin(authAs('SYSADMIN'), 'specialty-types');
+    const manager = wrapper.findComponent({ name: 'LookupTableManager' });
+    const keys = (manager.props('columns') as Array<{ key: string }>).map((c) => c.key);
+    expect(keys).toContain('defaultAmount');
+  });
+
+  it('other lookup tables keep the base 4 columns', async () => {
+    const wrapper = await mountAdmin(authAs('SYSADMIN'), 'payment-types');
+    const manager = wrapper.findComponent({ name: 'LookupTableManager' });
+    const keys = (manager.props('columns') as Array<{ key: string }>).map((c) => c.key);
+    expect(keys).not.toContain('defaultAmount');
+    expect(keys).toHaveLength(4);
+  });
+});

--- a/app-ui/src/components/appointments/BookingFormModal.vue
+++ b/app-ui/src/components/appointments/BookingFormModal.vue
@@ -26,8 +26,9 @@
                 {{ p.patientName }}
               </option>
             </select>
-            <p v-if="caretakerWarning" class="mt-1 text-xs text-amber-600">
-              This patient has no caretaker assigned. Please assign one first.
+            <!-- WP-23 (F10): hard block — was a soft amber warning pre-WP-23 -->
+            <p v-if="caretakerWarning" class="mt-1 text-xs font-medium text-red-600">
+              Booking blocked — this patient has no caretaker on file. Link a caretaker first.
             </p>
           </div>
 
@@ -92,7 +93,9 @@
             </div>
             <div>
               <label class="block text-sm font-medium text-slate-700 mb-1">Discount</label>
-              <input v-model.number="form.discount" type="number" min="0" step="0.01" class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:ring-2 focus:ring-violet-500 focus:border-violet-500" />
+              <!-- WP-23 (F7): min rides the SENADIS floor; the clamp re-applies on amount/patient change and at submit -->
+              <input v-model.number="form.discount" type="number" :min="senadisFloor" step="0.01" class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:ring-2 focus:ring-violet-500 focus:border-violet-500" />
+              <p v-if="senadisPatient" class="mt-1 text-xs text-violet-600">SENADIS: min {{ senadisFloor.toFixed(2) }} (20%)</p>
             </div>
             <!-- WP-17C: cosmetic only — the API still returns ProviderAmount to anyone with Appointments.View; true field-level enforcement needs API response-shaping (deferred). -->
             <div v-if="hasClaim('Permission', Permissions.AppointmentsProviderAmount)">
@@ -151,6 +154,7 @@ import type { LookupItem } from '../../interfaces/Lookups';
 import { isDiscoverySpecialty } from '../../interfaces/TreatmentPlan';
 import { TIME_MIN, TIME_MAX, TIME_STEP } from '../../utils/timeSlots';
 import { useClaims, Permissions } from '../../composables/useClaims';
+import { useNotificationsStore } from '../../stores/notifications';
 
 export default defineComponent({
   name: 'BookingFormModal',
@@ -174,6 +178,8 @@ export default defineComponent({
     const saveError = ref('');
     const caretakerWarning = ref(false);
     const needsDiscovery = ref(false);
+    const senadisPatient = ref(false);
+    const notifications = useNotificationsStore();
 
     const today = new Date().toISOString().split('T')[0];
     const nowTime = new Date().toTimeString().slice(0, 5);
@@ -236,14 +242,36 @@ export default defineComponent({
       }
     });
 
-    watch(() => form.value.specialtyTypeId, () => {
+    watch(() => form.value.specialtyTypeId, (id) => {
       if (form.value.therapistId > 0 && !filteredTherapists.value.some(t => t.therapistId === form.value.therapistId)) {
         form.value.therapistId = 0;
       }
+      // WP-23 (F6): pre-fill Amount from the specialty's default price — refills on every
+      // specialty change (user-editable after; NULL default = leave the amount alone).
+      if (id > 0) {
+        const specialty = specialtyTypes.value.find(s => s.id === id);
+        if (specialty?.defaultAmount != null) {
+          form.value.amount = specialty.defaultAmount;
+        }
+      }
     });
 
+    // WP-23 (F7): statutory SENADIS floor — 20% of Amount, 2dp; 0 for unflagged patients.
+    const senadisFloor = computed(() =>
+      senadisPatient.value ? Math.round(0.20 * form.value.amount * 100) / 100 : 0
+    );
+
+    const applySenadisFloor = () => {
+      if (senadisPatient.value && form.value.discount < senadisFloor.value) {
+        form.value.discount = senadisFloor.value;
+      }
+    };
+
+    // WP-23 (F10): the caretaker check is now a hard block (was a soft warning) — the API
+    // enforces the same rule with a 400, this keeps the modal honest before submit.
     const isValid = computed(() => {
-      return form.value.patientId > 0 && form.value.therapistId > 0 && form.value.specialtyTypeId > 0;
+      return form.value.patientId > 0 && form.value.therapistId > 0 && form.value.specialtyTypeId > 0
+        && !caretakerWarning.value;
     });
 
     const loadDropdowns = async () => {
@@ -272,16 +300,26 @@ export default defineComponent({
     };
 
     const checkDiscovery = async (patientId: number) => {
-      if (patientId <= 0) { needsDiscovery.value = false; return; }
+      if (patientId <= 0) { needsDiscovery.value = false; senadisPatient.value = false; return; }
       try {
         const patient = await patientsClient.getPatient(patientId);
         needsDiscovery.value = patient.hasCompletedDiscovery === false;
+        // WP-23 (F7): same fetched profile carries the SENADIS flag — one toast per
+        // patient selection, then clamp the discount up to the floor.
+        senadisPatient.value = patient.hasSenadisDiscount === true;
+        if (senadisPatient.value) {
+          notifications.info('SENADIS: statutory 20% discount applied — it cannot be reduced.');
+          applySenadisFloor();
+        }
       } catch {
         needsDiscovery.value = false; // Fail open — don't block booking
+        senadisPatient.value = false; // (the API floors server-side regardless)
       }
     };
 
     watch(() => form.value.patientId, (id) => { checkCaretaker(id); checkDiscovery(id); });
+    // WP-23 (F7): re-clamp when the amount moves the floor.
+    watch(() => form.value.amount, applySenadisFloor);
     watch(form, () => { saveError.value = ''; }, { deep: true });
 
     watch(() => props.visible, (val) => {
@@ -289,6 +327,7 @@ export default defineComponent({
         loadDropdowns();
         saveError.value = '';
         needsDiscovery.value = false;
+        senadisPatient.value = false;
         form.value = {
           patientId: props.preSelectPatientId || 0,
           therapistId: 0,
@@ -307,6 +346,7 @@ export default defineComponent({
     const handleSubmit = async () => {
       saving.value = true;
       saveError.value = '';
+      applySenadisFloor(); // WP-23 (F7): last-line clamp; the API floors server-side too
       try {
         const request: SessionEventRequest = {
           sessionDate: form.value.sessionDate,
@@ -333,7 +373,7 @@ export default defineComponent({
       }
     };
 
-    return { form, patients, filteredTherapists, filteredSpecialties, saving, saveError, caretakerWarning, needsDiscovery, isValid, handleSubmit, timeMin: TIME_MIN, timeMax: TIME_MAX, timeStep: TIME_STEP, hasClaim, Permissions };
+    return { form, patients, filteredTherapists, filteredSpecialties, saving, saveError, caretakerWarning, needsDiscovery, senadisPatient, senadisFloor, isValid, handleSubmit, timeMin: TIME_MIN, timeMax: TIME_MAX, timeStep: TIME_STEP, hasClaim, Permissions };
   },
 });
 </script>

--- a/app-ui/src/components/patients/PatientFormModal.vue
+++ b/app-ui/src/components/patients/PatientFormModal.vue
@@ -74,6 +74,26 @@
             />
           </div>
 
+          <!-- WP-23 (F7): SENADIS flag — free at create; on edit this is the app's first
+               in-modal claim gate (Patients.SenadisDiscount.Edit, MGR/AM only) -->
+          <div class="space-y-1">
+            <label class="flex items-center space-x-2 cursor-pointer" :class="{ 'cursor-not-allowed opacity-60': !canEditSenadis }">
+              <input
+                v-model="form.hasSenadisDiscount"
+                type="checkbox"
+                :disabled="!canEditSenadis"
+                class="rounded border-slate-300 text-blue-600 focus:ring-blue-500 disabled:cursor-not-allowed"
+              />
+              <span class="text-sm font-medium text-slate-700">SENADIS discount (statutory 20%)</span>
+            </label>
+            <p v-if="form.hasSenadisDiscount && canEditSenadis" class="text-xs text-slate-400">
+              A 20% discount floor auto-applies to this patient's bookings.
+            </p>
+            <p v-if="!canEditSenadis" class="text-xs text-slate-400">
+              Only Managers / Assistant Managers can change the SENADIS flag.
+            </p>
+          </div>
+
           <div>
             <label class="block text-sm font-medium text-slate-700 mb-1">Email *</label>
             <input
@@ -204,6 +224,7 @@ import { useModalForm } from '../../composables/useModalForm';
 import FormErrorBanner from '../shared/FormErrorBanner.vue';
 import { PatientsHttpClient } from '../../services/PatientsHttpClient';
 import { formatAge } from '../../utils/age';
+import { useClaims, Permissions } from '../../composables/useClaims';
 
 function parseName(patientName: string) {
   const [last, rest] = patientName.split(', ');
@@ -244,6 +265,7 @@ export default defineComponent({
   emits: ['close', 'saved', 'created-temp-mrn'],
   setup(props, { emit }) {
     const { error, hasError, saving, setError, clearError, submit } = useModalForm();
+    const { hasClaim } = useClaims();
 
     const form = reactive({
       firstName: '',
@@ -255,10 +277,18 @@ export default defineComponent({
       gender: '',
       medicalRecordNumber: '',
       cedula: '',
+      hasSenadisDiscount: false,
       activeStatus: true,
     });
 
     const isEdit = ref(false);
+
+    // WP-23 (F7): anyone who can create patients may SET the flag at create; changing it on an
+    // existing patient needs the claim (Questionnaire E). The payload omits the field when
+    // disabled — the API's field-level gate would 403 a change from an unauthorized role anyway.
+    const canEditSenadis = computed(
+      () => !isEdit.value || hasClaim('Permission', Permissions.PatientsSenadisDiscountEdit)
+    );
 
     // Blank on edit means "keep the current MRN", so temp-ness is judged on the effective value.
     const effectiveMrn = computed(
@@ -287,6 +317,7 @@ export default defineComponent({
           form.gender = props.patient.gender ?? '';
           form.medicalRecordNumber = props.patient.medicalRecordNumber ?? '';
           form.cedula = props.patient.cedula ?? '';
+          form.hasSenadisDiscount = props.patient.hasSenadisDiscount === true;
           form.activeStatus = props.patient.isActive;
         } else {
           isEdit.value = false;
@@ -299,6 +330,7 @@ export default defineComponent({
           form.gender = '';
           form.medicalRecordNumber = '';
           form.cedula = '';
+          form.hasSenadisDiscount = false;
           form.activeStatus = true;
         }
       }
@@ -334,6 +366,8 @@ export default defineComponent({
             // Always send the field on update: '' expresses an explicit clear-to-NULL (the API
             // treats omitted = leave as-is, blank = erase — intake 2026-06-29-001 item 3).
             cedula: form.cedula.trim(),
+            // WP-23 (F7): only send when this user may edit it — omitted = unchanged server-side.
+            hasSenadisDiscount: canEditSenadis.value ? form.hasSenadisDiscount : undefined,
           };
 
           if (assigningPermanentMrn && form.activeStatus) {
@@ -365,6 +399,7 @@ export default defineComponent({
             gender: form.gender,
             medicalRecordNumber: form.medicalRecordNumber || undefined,
             cedula: form.cedula || undefined,
+            hasSenadisDiscount: form.hasSenadisDiscount,
           });
           if (isTemporaryMrn(created.medicalRecordNumber ?? '')) {
             emit('created-temp-mrn', created);
@@ -375,7 +410,7 @@ export default defineComponent({
       });
     };
 
-    return { form, isEdit, saving, error, hasError, hasTemporaryMrn, cannotActivate, age, handleSubmit };
+    return { form, isEdit, saving, error, hasError, hasTemporaryMrn, cannotActivate, canEditSenadis, age, handleSubmit };
   },
 });
 </script>

--- a/app-ui/src/components/treatment-plans/SchedulePlanWizard.vue
+++ b/app-ui/src/components/treatment-plans/SchedulePlanWizard.vue
@@ -32,6 +32,13 @@
               </p>
             </div>
 
+            <!-- WP-23 (F10): proactive hard block — the API rejects caretaker-less bookings with 400 -->
+            <div v-if="caretakerBlocked" class="bg-red-50 border border-red-200 rounded-lg p-3">
+              <p class="text-sm font-medium text-red-700">
+                Scheduling blocked — this patient has no caretaker on file. Link a caretaker first.
+              </p>
+            </div>
+
             <div>
               <label class="block text-sm font-medium text-slate-700 mb-1">Start Date</label>
               <input
@@ -111,10 +118,11 @@
                   <div class="flex items-center space-x-2">
                     <div class="relative flex-1">
                       <span class="absolute left-2 top-1.5 text-xs text-slate-400">$</span>
+                      <!-- WP-23 (F7): min rides the per-line SENADIS floor; submit clamps, API floors -->
                       <input
                         type="number"
                         step="0.01"
-                        min="0"
+                        :min="senadisPatient ? lineFloor(line) : 0"
                         v-model.number="line.discountAmount"
                         @input="updateDiscountPct(line)"
                         class="w-full pl-5 pr-2 py-1.5 border border-slate-200 rounded-lg text-sm"
@@ -125,7 +133,7 @@
                       <input
                         type="number"
                         step="0.1"
-                        min="0"
+                        :min="senadisPatient ? 20 : 0"
                         max="100"
                         v-model.number="line.discountPct"
                         @input="updateDiscountAmt(line)"
@@ -139,6 +147,9 @@
                     <template v-if="line.discountAmount > 0">
                       &rarr; Net: ${{ (lineAmount(line) - line.discountAmount).toFixed(2) }}
                     </template>
+                  </p>
+                  <p v-if="senadisPatient" class="text-xs text-violet-600 mt-0.5">
+                    SENADIS: min ${{ lineFloor(line).toFixed(2) }} (20%)
                   </p>
                 </div>
               </div>
@@ -298,6 +309,7 @@ import { DAY_OF_WEEK_LABELS } from '../../interfaces/TreatmentPlan';
 import { TreatmentPlansHttpClient } from '../../services/TreatmentPlansHttpClient';
 import { SitesHttpClient } from '../../services/SitesHttpClient';
 import { TherapistsHttpClient } from '../../services/TherapistsHttpClient';
+import { PatientsHttpClient } from '../../services/PatientsHttpClient';
 import type { Site } from '../../interfaces/Site';
 import type { Therapist } from '../../interfaces/Therapist';
 import { useClaims, Permissions } from '../../composables/useClaims';
@@ -327,6 +339,7 @@ export default defineComponent({
     const plansClient = new TreatmentPlansHttpClient();
     const sitesClient = new SitesHttpClient();
     const therapistsClient = new TherapistsHttpClient();
+    const patientsClient = new PatientsHttpClient();
 
     const step = ref(1);
     const startDate = ref('');
@@ -338,6 +351,9 @@ export default defineComponent({
     const errorMsg = ref('');
     const result = ref<BulkScheduleResult | null>(null);
     const dayLabels = DAY_OF_WEEK_LABELS;
+    // WP-23: F10 hard block + F7 per-line SENADIS floor.
+    const caretakerBlocked = ref(false);
+    const senadisPatient = ref(false);
 
     // Alternative selection for conflict resolution
     // Key: "conflictIdx-altIdx", Value: { lineId, alternative }
@@ -384,10 +400,39 @@ export default defineComponent({
       step.value--;
     };
 
-    const canProceedStep1 = computed(() => startDate.value !== '' && siteId.value > 0);
+    const canProceedStep1 = computed(() => startDate.value !== '' && siteId.value > 0 && !caretakerBlocked.value);
 
     const lineAmount = (line: LineEdit) => {
       return Math.round(HOURLY_RATE * line.duration / 60 * 100) / 100;
+    };
+
+    // WP-23 (F7): per-line statutory floor — 20% of the line amount, 2dp.
+    const lineFloor = (line: LineEdit) => Math.round(0.20 * lineAmount(line) * 100) / 100;
+
+    // WP-23: one profile + caretaker fetch per wizard open; on failure fail open — the API
+    // enforces both rules server-side (caretaker 400, discount floored).
+    const checkPatientFlags = async () => {
+      caretakerBlocked.value = false;
+      senadisPatient.value = false;
+      if (!props.plan) return;
+      try {
+        const [patient, caretakers] = await Promise.all([
+          patientsClient.getPatient(props.plan.patientId),
+          patientsClient.getPatientCaretakers(props.plan.patientId),
+        ]);
+        caretakerBlocked.value = caretakers.length === 0;
+        senadisPatient.value = patient.hasSenadisDiscount === true;
+        if (senadisPatient.value) {
+          for (const line of lineEdits.value) {
+            if (line.discountAmount < lineFloor(line)) {
+              line.discountAmount = lineFloor(line);
+              updateDiscountPct(line);
+            }
+          }
+        }
+      } catch {
+        // fail open (see above)
+      }
     };
 
     const updateDiscountPct = (line: LineEdit) => {
@@ -471,6 +516,7 @@ export default defineComponent({
 
     const submitSchedule = async () => {
       if (!props.plan) return;
+      if (caretakerBlocked.value) return; // WP-23 (F10); the API would 400 anyway
       submitting.value = true;
       errorMsg.value = '';
 
@@ -479,7 +525,10 @@ export default defineComponent({
         therapistId: le.therapistId > 0 ? le.therapistId : null,
         dayOfWeek: le.dayOfWeek > 0 ? le.dayOfWeek : null,
         time: le.time || null,
-        discountAmount: le.discountAmount > 0 ? le.discountAmount : null,
+        // WP-23 (F7): last-line clamp to the SENADIS floor; the API floors server-side too.
+        discountAmount: senadisPatient.value
+          ? Math.max(le.discountAmount, lineFloor(le))
+          : (le.discountAmount > 0 ? le.discountAmount : null),
       }));
 
       try {
@@ -507,6 +556,7 @@ export default defineComponent({
       if (val) {
         initForm();
         loadDropdowns();
+        checkPatientFlags(); // WP-23: caretaker block + SENADIS floor
       }
     });
 
@@ -523,6 +573,9 @@ export default defineComponent({
       dayLabels,
       canProceedStep1,
       lineAmount,
+      lineFloor,
+      caretakerBlocked,
+      senadisPatient,
       updateDiscountPct,
       updateDiscountAmt,
       sessionsByWeek,

--- a/app-ui/src/generated/access-control-matrix.json
+++ b/app-ui/src/generated/access-control-matrix.json
@@ -1,9 +1,9 @@
 {
   "_meta": {
-    "generatedAt": "2026-07-11T20:33:41-05:00",
+    "generatedAt": "2026-07-12T08:29:39-05:00",
     "generator": "tools/generate-access-manifest.sh",
     "hashScope": "sha256 (first 12 hex) of canonical JSON {claims:[{claim,grants}]}, claims+grants sorted; wildcard/restricted cells and all metadata excluded",
-    "semanticHash": "6c42b5362fbc",
+    "semanticHash": "10ad6ddcd5dd",
     "source": "access-control-matrix.md"
   },
   "claims": [
@@ -192,6 +192,13 @@
     {
       "claim": "Patients.Merge",
       "grants": []
+    },
+    {
+      "claim": "Patients.SenadisDiscount.Edit",
+      "grants": [
+        "AM",
+        "MGR"
+      ]
     },
     {
       "claim": "Patients.StartDiscovery",

--- a/app-ui/src/generated/permissions.ts
+++ b/app-ui/src/generated/permissions.ts
@@ -8,7 +8,7 @@
 //   app-ui/src/generated/access-control-matrix.json, then re-run
 //   tools/generate-ui-permissions.sh.
 //
-//   Access-control manifest semantic hash: 6c42b5362fbc
+//   Access-control manifest semantic hash: 10ad6ddcd5dd
 // </auto-generated>
 
 /**
@@ -47,6 +47,7 @@ export const Permissions = {
   PatientsEdit: 'Patients.Edit',
   PatientsLinkCaretaker: 'Patients.LinkCaretaker',
   PatientsMerge: 'Patients.Merge',
+  PatientsSenadisDiscountEdit: 'Patients.SenadisDiscount.Edit',
   PatientsStartDiscovery: 'Patients.StartDiscovery',
   PatientsView: 'Patients.View',
   PaymentsAdjust: 'Payments.Adjust',
@@ -77,4 +78,4 @@ export const Permissions = {
 export type Permission = (typeof Permissions)[keyof typeof Permissions];
 
 /** Access-control manifest semantic hash this module was generated from (WP-17 anchor). */
-export const ACCESS_CONTROL_MANIFEST_HASH = '6c42b5362fbc';
+export const ACCESS_CONTROL_MANIFEST_HASH = '10ad6ddcd5dd';

--- a/app-ui/src/interfaces/Lookups.ts
+++ b/app-ui/src/interfaces/Lookups.ts
@@ -6,6 +6,9 @@ export interface LookupItem {
   name: string;
   description: string | null;
   sortOrder: number;
+  // WP-23 (F6): per-type field — populated only for specialty-types (default session price
+  // pre-filled at booking; null = no default); null on every other table.
+  defaultAmount?: number | null;
   createdTimestamp: string;
   lastUpdatedTimestamp: string;
 }
@@ -15,6 +18,8 @@ export interface LookupCreateRequest {
   name: string;
   description?: string | null;
   sortOrder?: number;
+  // WP-23 (F6): specialty-types only; ignored by the API for other tables.
+  defaultAmount?: number | null;
 }
 
 export interface LookupUpdateRequest {
@@ -22,4 +27,6 @@ export interface LookupUpdateRequest {
   name?: string | null;
   description?: string | null;
   sortOrder?: number | null;
+  // WP-23 (F6): specialty-types only; null/omitted = unchanged.
+  defaultAmount?: number | null;
 }

--- a/app-ui/src/interfaces/Patient.ts
+++ b/app-ui/src/interfaces/Patient.ts
@@ -12,6 +12,10 @@ export interface Patient {
   phoneNumber: string | null;
   gender: string | null;
   isActive: boolean;
+  // WP-23 (F7): statutory SENADIS 20% discount — booking applies a 20%-of-amount discount
+  // floor; edit gated by Patients.SenadisDiscount.Edit (MGR/AM). Optional so the UI
+  // tolerates an older deployed API (absent ⇒ treated as false).
+  hasSenadisDiscount?: boolean;
   hasCompletedDiscovery: boolean | null;
   createdTimestamp: string;
   caretakers?: PatientCaretakerSummary[];
@@ -35,6 +39,7 @@ export interface PatientCreateRequest {
   gender: string;
   medicalRecordNumber?: string;
   cedula?: string;
+  hasSenadisDiscount?: boolean;
 }
 
 // Maps to API's PatientProfileUpdateRequest (PUT)
@@ -49,6 +54,8 @@ export interface PatientUpdateRequest {
   activeStatus: boolean;
   medicalRecordNumber?: string;
   cedula?: string;
+  // Omit when the caller may not edit it (claim-gated) — omitted/null = unchanged server-side.
+  hasSenadisDiscount?: boolean;
 }
 
 // Temporary MRN helper

--- a/app-ui/src/views/AdminView.vue
+++ b/app-ui/src/views/AdminView.vue
@@ -41,7 +41,7 @@
                     :title="section.title"
                     :subtitle="section.subtitle"
                     :add-button-label="section.addButtonLabel"
-                    :columns="lookupColumns"
+                    :columns="columnsFor(section.key)"
                     id-key="id"
                     :items="(crudMap[section.key].items.value as unknown as Record<string, unknown>[])"
                     :loading="crudMap[section.key].loading.value"
@@ -164,6 +164,18 @@ export default defineComponent({
       { key: 'sortOrder', label: 'Sort Order', type: 'number' },
     ];
 
+    // WP-23 (F6): first PER-TYPE lookup config — specialty-types alone gains the default
+    // session price column/field (pre-filled into the booking form; blank = no default).
+    const columnsFor = (tableKey: string): ColumnDef[] =>
+      tableKey === 'specialty-types'
+        ? [...lookupColumns, { key: 'defaultAmount', label: 'Default $' }]
+        : lookupColumns;
+
+    const fieldsFor = (tableKey: string): FieldDef[] =>
+      tableKey === 'specialty-types'
+        ? [...lookupFields, { key: 'defaultAmount', label: 'Default $ (session price)', type: 'number' }]
+        : lookupFields;
+
     // ── Lookup section metadata ─────────────────────────────────
     const lookupSections = [
       { key: 'appointment-statuses', title: 'Appointment Statuses', subtitle: 'Status workflow for therapy sessions', addButtonLabel: 'Add Status', addTitle: 'Add Status', editTitle: 'Edit Status' },
@@ -179,6 +191,9 @@ export default defineComponent({
       if (data.name?.trim()) payload.name = data.name.trim();
       if (data.description?.trim()) payload.description = data.description.trim();
       if (data.sortOrder !== undefined && data.sortOrder !== '') payload.sortOrder = Number(data.sortOrder);
+      // WP-23 (F6): specialty-types only (the field is absent from other tables' forms);
+      // omitted when blank = unchanged server-side.
+      if (data.defaultAmount !== undefined && data.defaultAmount !== '') payload.defaultAmount = Number(data.defaultAmount);
       return payload;
     };
 
@@ -214,7 +229,7 @@ export default defineComponent({
       crud.openAdd = () => {
         originalOpenAdd();
         lookupModalTitle.value = section.addTitle;
-        lookupModalFields.value = lookupFields;
+        lookupModalFields.value = fieldsFor(section.key);
         lookupModalInitialValues.value = null;
         lookupModalEditId.value = undefined;
         lookupModalReadonlyFields.value = [];
@@ -226,9 +241,9 @@ export default defineComponent({
         originalOpenEdit(item);
         const record = item as Record<string, unknown>;
         lookupModalTitle.value = section.editTitle;
-        lookupModalFields.value = lookupFields;
+        lookupModalFields.value = fieldsFor(section.key);
         lookupModalInitialValues.value = {};
-        for (const field of lookupFields) {
+        for (const field of fieldsFor(section.key)) {
           lookupModalInitialValues.value[field.key] = String(record[field.key] ?? '');
         }
         lookupModalEditId.value = record.id as number;
@@ -258,7 +273,7 @@ export default defineComponent({
       sites, siteLoading, siteError, siteModalVisible, editingSite,
       loadSites, openSiteAdd, openSiteEdit, onSiteSaved,
       // Lookup tables
-      lookupSections, lookupColumns, crudMap,
+      lookupSections, lookupColumns, columnsFor, crudMap,
       // Modal
       lookupModalVisible, lookupModalTitle, lookupModalFields,
       lookupModalInitialValues, lookupModalReadonlyFields, handleLookupSubmit,

--- a/app-ui/test-scenarios/wp-23-booking-money-pack.md
+++ b/app-ui/test-scenarios/wp-23-booking-money-pack.md
@@ -1,0 +1,49 @@
+# WP-23 — Booking Money Pack (F6 default pricing · F7 SENADIS · F10 caretaker guard)
+
+Prereqs: API > v125 deployed with V026/V027 + RoleClaim reseed applied; log in per scenario role.
+
+## F6 — Specialty default price
+
+1. **Set a price (SYSADMIN)** — Admin › Reference Data › Specialty Types: the table shows a new
+   **Default $** column. Edit "TL — Language Therapy", a **Default $ (session price)** field
+   appears in the modal; enter `65` and save. The row shows 65. Other lookup sections
+   (Payment Types, Roles, Appointment Statuses) show **no** Default $ column or field.
+2. **Booking pre-fill (any booking role)** — Appointments › Book Appointment: pick any patient,
+   then specialty TL → **Amount auto-fills 65**. Switch to a specialty with no default → the
+   amount you last had stays (no wipe). Switch back to TL → refills 65. Manually type a
+   different amount after selecting → it sticks (pre-fill only fires on specialty change).
+
+## F7 — SENADIS discount
+
+3. **Flag at create (FD)** — Patients › Add Patient: the **SENADIS discount (statutory 20%)**
+   checkbox is enabled; create a patient with it checked.
+4. **Edit gate (FD)** — edit any existing patient as FD: the checkbox is **disabled** with the
+   hint "Only Managers / Assistant Managers can change the SENADIS flag." Saving other edits
+   still works (the flag is simply not sent).
+5. **Edit gate (MGR/AM)** — same modal as MGR or AM: checkbox enabled; toggling + saving
+   persists (reopen to confirm).
+6. **Floor at booking** — book for a flagged patient: on selecting the patient a toast appears —
+   "SENADIS: statutory 20% discount applied — it cannot be reduced." Set Amount 100 → the
+   Discount clamps up to 20.00 and shows "SENADIS: min 20.00 (20%)". Type a discount of 30 →
+   kept (more is allowed). Type 5 and submit → the created session still carries discount
+   20.00 (submit + server both clamp). Unflagged patients see no toast and keep any discount.
+7. **Floor in the plan wizard** — Treatment Plans › Schedule for a flagged patient: each line's
+   Discount initializes to 20% of the line amount (60 min ⇒ $13.00 of $65.00) with a
+   "SENADIS: min $13.00 (20%)" hint; entering less gets raised back at submit.
+
+## F10 — Caretaker hard block
+
+8. **Booking modal** — pick a patient with no caretakers: the amber warning is now a **red
+   blocker** — "Booking blocked — this patient has no caretaker on file. Link a caretaker
+   first." — and the Book button stays disabled no matter what else is filled.
+9. **Plan wizard** — open Schedule Sessions for a caretaker-less patient: step 1 shows the red
+   "Scheduling blocked" banner and **Next** is disabled even with date + site chosen.
+10. **API backstop** — any client bypassing the UI gets `400 — "A caretaker must be linked to
+    this patient before booking."` on both create paths. Synthetic `-SH (LEGACY)` caretakers
+    satisfy the rule (they are real links).
+
+## Regression sweep
+
+11. Booking an unflagged patient with a caretaker: unchanged behavior end-to-end.
+12. Admin lookup CRUD on non-specialty tables: unchanged (4 columns, 4 fields).
+13. FD full-profile round-trip edits (name/phone/etc.) on flagged patients save without 403.


### PR DESCRIPTION
… + SENADIS floor + toast, caretaker hard block, claim-gated SENADIS checkbox

- F6: first PER-TYPE lookup config in AdminView - specialty-types alone gains the Default $ column + number field (columnsFor/fieldsFor; toPayload sends defaultAmount only when non-blank); BookingFormModal pre-fills Amount from the selected specialty's defaultAmount (refills per specialty change, user-editable after; NULL = leave alone)
- F7: booking modal flags SENADIS patients off the same profile fetch as the discovery check - one info toast per patient selection, discount input min rides the 20% floor, re-clamp on amount change + at submit (server floors too); SchedulePlanWizard initializes each line discount to the per-line floor w/ hint + submit clamp; PatientFormModal gains the SENADIS checkbox - enabled at create, claim-gated on edit (first in-modal claim gate; disabled + field omitted from payload without Patients.SenadisDiscount.Edit)
- F10: caretakerWarning is now a HARD BLOCK in the booking modal (isValid requires caretakers; red copy) + proactive wizard check on open (red banner, Next/submit blocked); API 400 as backstop
- interfaces: Patient/+requests gain hasSenadisDiscount (optional on read - tolerates older APIs), Lookups gain defaultAmount x3; matrix re-vendored + permissions.ts regen (hash 6c42b5362fbc -> 10ad6ddcd5dd, 52 claims)
- vitest 113 green (was 101; 12 new in wp23-booking-money.spec.ts); vue-tsc + eslint clean
- Scenarios: test-scenarios/wp-23-booking-money-pack.md