### PR TITLE
WP-27C (F8+F9): cross-add chained flows — sequential hand-off in both…

### DIFF
--- a/app-ui/src/__tests__/wp27-cross-add-flows.spec.ts
+++ b/app-ui/src/__tests__/wp27-cross-add-flows.spec.ts
@@ -1,0 +1,361 @@
+// WP-27 (F8/F9) — cross-add chained flows, Option A sequential hand-off (owner ruling 2026-07-13):
+//   F8 — creating a patient offers "link/create a caretaker now" (bookings are F10-blocked
+//        until a caretaker is linked).
+//   F9 — creating a caretaker offers the mirror ("link/create a patient").
+// Both directions link through the caretaker-side endpoint (POST /api/caretakers/{id}/patients)
+// and gate on the claims the API enforces: Caretakers.LinkPatient (+ Caretakers.Edit /
+// Patients.Edit for create-new). Create-then-link is two calls — a failed link keeps the chain
+// open with a retry.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { setActivePinia, createPinia, type Pinia } from 'pinia';
+import { mount, flushPromises } from '@vue/test-utils';
+import manifest from '../generated/access-control-matrix.json';
+import { useAuthStore } from '../stores/auth';
+import type { ClaimDto } from '../interfaces/Auth';
+import type { Patient } from '../interfaces/Patient';
+import type { Caretaker } from '../interfaces/Caretaker';
+import PatientFormModal from '../components/patients/PatientFormModal.vue';
+import CaretakerFormModal from '../components/caretakers/CaretakerFormModal.vue';
+import CrossAddChainModal from '../components/shared/CrossAddChainModal.vue';
+
+// ── shared mocks (wp23/wp24 spec pattern) ────────────────────────────────────
+
+function patient(overrides: Partial<Patient> = {}): Patient {
+  return {
+    patientId: 42,
+    userId: 10,
+    patientName: 'Gómez, Valentina',
+    medicalRecordNumber: 'L26-0921',
+    cedula: '8-999-1234',
+    dateOfBirth: '2019-03-14T00:00:00',
+    email: 'vgomez@example.com',
+    phoneNumber: '555-0101',
+    gender: 'Female',
+    isActive: true,
+    hasSenadisDiscount: false,
+    requiresDiscovery: true,
+    hasCompletedDiscovery: false,
+    createdTimestamp: '2026-07-13T00:00:00',
+    caretakers: [],
+    ...overrides,
+  };
+}
+
+function caretaker(overrides: Partial<Caretaker> = {}): Caretaker {
+  return {
+    caretakerId: 7,
+    caretakerName: 'Delgado, María',
+    email: 'mdelgado@example.com',
+    phoneNumber: '555-0202',
+    notes: '',
+    isActive: true,
+    ...overrides,
+  } as Caretaker;
+}
+
+const {
+  getCaretakersMock,
+  createCaretakerMock,
+  linkPatientMock,
+  getPatientsMock,
+  createPatientMock,
+  updatePatientMock,
+} = vi.hoisted(() => ({
+  getCaretakersMock: vi.fn(),
+  createCaretakerMock: vi.fn(),
+  linkPatientMock: vi.fn(),
+  getPatientsMock: vi.fn(),
+  createPatientMock: vi.fn(),
+  updatePatientMock: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../services/CaretakersHttpClient', () => ({
+  CaretakersHttpClient: vi.fn().mockImplementation(() => ({
+    getCaretakers: getCaretakersMock,
+    createCaretaker: createCaretakerMock,
+    linkPatient: linkPatientMock,
+  })),
+}));
+
+vi.mock('../services/PatientsHttpClient', () => ({
+  PatientsHttpClient: vi.fn().mockImplementation(() => ({
+    getPatients: getPatientsMock,
+    createPatient: createPatientMock,
+    updatePatient: updatePatientMock,
+  })),
+}));
+
+function claimsForRole(role: string): ClaimDto[] {
+  return (manifest.claims as Array<{ claim: string; grants: string[] }>)
+    .filter((c) => c.grants.includes(role))
+    .map((c) => ({ type: 'Permission', value: c.claim }));
+}
+
+function authAs(role: string): Pinia {
+  const pinia = createPinia();
+  setActivePinia(pinia);
+  const store = useAuthStore();
+  store.user = {
+    userId: 1,
+    email: 'test@example.com',
+    fullName: 'Test User',
+    mustChangePassword: false,
+    roles: [role],
+    claims: claimsForRole(role),
+    isSystemAdmin: false,
+  };
+  return pinia;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getCaretakersMock.mockResolvedValue([caretaker()]);
+  getPatientsMock.mockResolvedValue([patient({ patientId: 55, patientName: 'Herrera, Lucas' })]);
+  createCaretakerMock.mockResolvedValue(caretaker({ caretakerId: 77 }));
+  createPatientMock.mockResolvedValue(patient({ patientId: 99, patientName: 'Martínez, Diego', medicalRecordNumber: 'MRN-099' }));
+  linkPatientMock.mockResolvedValue(undefined);
+});
+
+// ── form modals: `created` emit (the chain trigger) ──────────────────────────
+
+async function openModal(component: typeof PatientFormModal | typeof CaretakerFormModal, pinia: Pinia, props: Record<string, unknown>) {
+  const wrapper = mount(component, {
+    props: { visible: false, ...props },
+    global: { plugins: [pinia], stubs: { teleport: true } },
+  });
+  await wrapper.setProps({ visible: true });
+  return wrapper;
+}
+
+async function fillPatientCreateFields(wrapper: ReturnType<typeof mount>) {
+  await wrapper.find('input[type="email"]').setValue('new@example.com');
+  await wrapper.find('input[type="tel"]').setValue('555-0101');
+  await wrapper.find('input[type="date"]').setValue('2019-03-14');
+  await wrapper.find('select').setValue('Female'); // first select = gender
+  const textInputs = wrapper.findAll('input[type="text"]');
+  await textInputs[0].setValue('Valentina');
+  await textInputs[2].setValue('Gómez');
+  await textInputs[3].setValue('8-999-1234'); // cedula — required at create (WP-25)
+}
+
+describe('PatientFormModal — chain trigger `created` emit (F8)', () => {
+  it('CREATE emits `created` with the record and a null link (no chain context)', async () => {
+    const wrapper = await openModal(PatientFormModal, authAs('FD'), { patient: null });
+    await fillPatientCreateFields(wrapper);
+    await wrapper.find('form').trigger('submit');
+    await vi.waitFor(() => expect(createPatientMock).toHaveBeenCalled());
+
+    const created = wrapper.emitted('created');
+    expect(created).toHaveLength(1);
+    expect(created![0][0]).toMatchObject({
+      record: { patientId: 99, patientName: 'Martínez, Diego' },
+      link: null,
+    });
+  });
+
+  it('EDIT does not emit `created`', async () => {
+    const wrapper = await openModal(PatientFormModal, authAs('MGR'), { patient: patient() });
+    await wrapper.find('form').trigger('submit');
+    await vi.waitFor(() => expect(updatePatientMock).toHaveBeenCalled());
+    expect(wrapper.emitted('created')).toBeUndefined();
+  });
+
+  it('as a chain create-step (linkTo set): banner shown, link fields ride the `created` emit', async () => {
+    const wrapper = await openModal(PatientFormModal, authAs('MGR'), {
+      patient: null,
+      linkTo: { name: 'Martínez, Rosa' },
+    });
+
+    expect(wrapper.find('[data-testid="chain-context-banner"]').text()).toContain('Martínez, Rosa');
+
+    await fillPatientCreateFields(wrapper);
+    await wrapper.find('[data-testid="chain-relationship-select"]').setValue('Mother');
+    await wrapper.find('form').trigger('submit');
+    await vi.waitFor(() => expect(createPatientMock).toHaveBeenCalled());
+
+    expect(wrapper.emitted('created')![0][0]).toMatchObject({
+      record: { patientId: 99 },
+      link: { relationship: 'Mother', isPrimary: true },
+    });
+  });
+});
+
+describe('CaretakerFormModal — chain trigger `created` emit (F9) + create-step fields (F8)', () => {
+  async function fillCaretakerCreateFields(wrapper: ReturnType<typeof mount>) {
+    const textInputs = wrapper.findAll('input[type="text"]');
+    await textInputs[0].setValue('María');
+    await textInputs[2].setValue('Delgado');
+    await wrapper.find('input[type="email"]').setValue('mdelgado@example.com');
+    await wrapper.find('input[type="tel"]').setValue('555-0202');
+  }
+
+  it('CREATE emits `created` with the record and a null link', async () => {
+    const wrapper = await openModal(CaretakerFormModal, authAs('FD'), { caretaker: null });
+    await fillCaretakerCreateFields(wrapper);
+    await wrapper.find('form').trigger('submit');
+    await vi.waitFor(() => expect(createCaretakerMock).toHaveBeenCalled());
+
+    expect(wrapper.emitted('created')![0][0]).toMatchObject({
+      record: { caretakerId: 77 },
+      link: null,
+    });
+  });
+
+  it('as a chain create-step (linkTo set): banner + relationship/primary in the payload', async () => {
+    const wrapper = await openModal(CaretakerFormModal, authAs('FD'), {
+      caretaker: null,
+      linkTo: { name: 'Gómez, Valentina' },
+    });
+
+    expect(wrapper.find('[data-testid="chain-context-banner"]').text()).toContain('Gómez, Valentina');
+
+    await fillCaretakerCreateFields(wrapper);
+    await wrapper.find('[data-testid="chain-relationship-select"]').setValue('Mother');
+    await wrapper.find('[data-testid="chain-primary-checkbox"]').setValue(false);
+    await wrapper.find('form').trigger('submit');
+    await vi.waitFor(() => expect(createCaretakerMock).toHaveBeenCalled());
+
+    expect(wrapper.emitted('created')![0][0]).toMatchObject({
+      record: { caretakerId: 77 },
+      link: { relationship: 'Mother', isPrimary: false },
+    });
+  });
+});
+
+// ── CrossAddChainModal ───────────────────────────────────────────────────────
+
+const F8_TARGET = { id: 42, name: 'Gómez, Valentina' };
+const F9_TARGET = { id: 9, name: 'Martínez, Rosa' };
+
+async function openChain(pinia: Pinia, mode: 'add-caretaker' | 'add-patient', target = mode === 'add-caretaker' ? F8_TARGET : F9_TARGET) {
+  const wrapper = mount(CrossAddChainModal, {
+    props: { visible: false, mode, target },
+    global: { plugins: [pinia], stubs: { teleport: true } },
+  });
+  await wrapper.setProps({ visible: true });
+  await flushPromises();
+  return wrapper;
+}
+
+describe('CrossAddChainModal — chooser', () => {
+  it('MGR sees link-existing, create-new, and Later; "Later" closes clean with no API calls', async () => {
+    const wrapper = await openChain(authAs('MGR'), 'add-caretaker');
+
+    expect(wrapper.find('[data-testid="chain-chooser"]').text()).toContain('bookings are blocked');
+    expect(wrapper.find('[data-testid="chain-link-existing"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="chain-create-new"]').exists()).toBe(true);
+
+    await wrapper.find('[data-testid="chain-later"]').trigger('click');
+    expect(wrapper.emitted('close')).toHaveLength(1);
+    expect(linkPatientMock).not.toHaveBeenCalled();
+    expect(createCaretakerMock).not.toHaveBeenCalled();
+  });
+
+  it('OWN (read-only oversight) sees no link/create affordances, only Later', async () => {
+    const wrapper = await openChain(authAs('OWN'), 'add-caretaker');
+
+    expect(wrapper.find('[data-testid="chain-link-existing"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="chain-create-new"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="chain-later"]').exists()).toBe(true);
+  });
+});
+
+describe('CrossAddChainModal — link existing', () => {
+  it('F8: links the selected caretaker TO the new patient — linkPatient(caretakerId, patientId, isPrimary, relationship)', async () => {
+    const wrapper = await openChain(authAs('MGR'), 'add-caretaker');
+    await wrapper.find('[data-testid="chain-link-existing"]').trigger('click');
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="chain-link-banner"]').text()).toContain('Gómez, Valentina');
+
+    await wrapper.find('[data-testid="link-entity-select"]').setValue(7);
+    await wrapper.find('[data-testid="link-relationship-select"]').setValue('Mother');
+    await wrapper.find('[data-testid="link-submit"]').trigger('click');
+    await flushPromises();
+
+    expect(linkPatientMock).toHaveBeenCalledWith(7, 42, true, 'Mother');
+    expect(wrapper.find('[data-testid="chain-success"]').text()).toContain('is now bookable');
+    expect(wrapper.emitted('linked')).toHaveLength(1);
+  });
+
+  it('F9: mirrored orientation — the new caretaker is the link owner', async () => {
+    const wrapper = await openChain(authAs('MGR'), 'add-patient');
+    await wrapper.find('[data-testid="chain-link-existing"]').trigger('click');
+    await flushPromises();
+
+    await wrapper.find('[data-testid="link-entity-select"]').setValue(55);
+    await wrapper.find('[data-testid="link-relationship-select"]').setValue('Relative');
+    await wrapper.find('[data-testid="link-submit"]').trigger('click');
+    await flushPromises();
+
+    expect(linkPatientMock).toHaveBeenCalledWith(9, 55, true, 'Relative');
+  });
+
+  it('link failure keeps the form open with the error (retry affordance)', async () => {
+    linkPatientMock.mockRejectedValueOnce(new Error('Network error'));
+    const wrapper = await openChain(authAs('MGR'), 'add-caretaker');
+    await wrapper.find('[data-testid="chain-link-existing"]').trigger('click');
+    await flushPromises();
+
+    await wrapper.find('[data-testid="link-entity-select"]').setValue(7);
+    await wrapper.find('[data-testid="link-submit"]').trigger('click');
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="chain-error"]').text()).toContain('Network error');
+    expect(wrapper.find('[data-testid="link-submit"]').exists()).toBe(true); // still on the link step
+
+    // Note: the teleport STUB recreates the link form on re-render, dropping the selection —
+    // verified against a real (unstubbed) teleport that the selection survives a failed link and
+    // a plain second click retries. Re-select here to keep the stub-based test honest.
+    await wrapper.find('[data-testid="link-entity-select"]').setValue(7);
+    await wrapper.find('[data-testid="link-submit"]').trigger('click');
+    await flushPromises();
+    expect(linkPatientMock).toHaveBeenCalledTimes(2);
+    expect(wrapper.find('[data-testid="chain-success"]').exists()).toBe(true);
+  });
+});
+
+describe('CrossAddChainModal — create new', () => {
+  async function runF8CreateNew(wrapper: Awaited<ReturnType<typeof openChain>>) {
+    await wrapper.find('[data-testid="chain-create-new"]').trigger('click');
+    await flushPromises();
+
+    // The real CaretakerFormModal renders as the create step, with the chain context banner
+    expect(wrapper.find('[data-testid="chain-context-banner"]').text()).toContain('Gómez, Valentina');
+
+    const textInputs = wrapper.findAll('input[type="text"]');
+    await textInputs[0].setValue('María');
+    await textInputs[2].setValue('Delgado');
+    await wrapper.find('input[type="email"]').setValue('mdelgado@example.com');
+    await wrapper.find('input[type="tel"]').setValue('555-0202');
+    await wrapper.find('[data-testid="chain-relationship-select"]').setValue('Mother');
+    await wrapper.find('form').trigger('submit');
+    await flushPromises();
+  }
+
+  it('F8: fires create then link with the new caretaker id and the captured link fields', async () => {
+    const wrapper = await openChain(authAs('MGR'), 'add-caretaker');
+    await runF8CreateNew(wrapper);
+
+    expect(createCaretakerMock).toHaveBeenCalledTimes(1);
+    expect(linkPatientMock).toHaveBeenCalledWith(77, 42, true, 'Mother');
+    expect(wrapper.find('[data-testid="chain-success"]').text()).toContain('created and linked');
+  });
+
+  it('F8: created-but-link-failed shows the retry card; retry completes the link', async () => {
+    linkPatientMock.mockRejectedValueOnce(new Error('409 already linked'));
+    const wrapper = await openChain(authAs('MGR'), 'add-caretaker');
+    await runF8CreateNew(wrapper);
+
+    const failed = wrapper.find('[data-testid="chain-link-failed"]');
+    expect(failed.exists()).toBe(true);
+    expect(failed.text()).toContain('was created, but linking failed');
+
+    await wrapper.find('[data-testid="chain-retry-link"]').trigger('click');
+    await flushPromises();
+    expect(linkPatientMock).toHaveBeenCalledTimes(2);
+    expect(linkPatientMock).toHaveBeenLastCalledWith(77, 42, true, 'Mother');
+    expect(wrapper.find('[data-testid="chain-success"]').exists()).toBe(true);
+  });
+});

--- a/app-ui/src/components/caretakers/CaretakerFormModal.vue
+++ b/app-ui/src/components/caretakers/CaretakerFormModal.vue
@@ -23,6 +23,15 @@
 
         <!-- Form -->
         <form class="flex-1 overflow-y-auto px-6 py-4 space-y-4" @submit.prevent="handleSubmit">
+          <!-- WP-27 (F8): create-new step of a cross-add chain — the saved caretaker auto-links -->
+          <div
+            v-if="linkTo && !isEdit"
+            class="bg-amber-50 border border-amber-200 rounded-lg px-3 py-2 text-xs text-amber-800"
+            data-testid="chain-context-banner"
+          >
+            Will be linked to patient <strong>{{ linkTo.name }}</strong>
+          </div>
+
           <div class="grid grid-cols-2 gap-4">
             <div>
               <label class="block text-sm font-medium text-slate-700 mb-1">First Name *</label>
@@ -80,6 +89,36 @@
               rows="3"
               class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
             ></textarea>
+          </div>
+
+          <!-- WP-27 (F8): link fields captured with the create and passed back on the `created`
+               emit — the chain performs the actual link call after the caretaker exists. -->
+          <div v-if="linkTo && !isEdit" class="space-y-3">
+            <div>
+              <label class="block text-sm font-medium text-slate-700 mb-1">
+                Relationship to {{ linkTo.name }}
+              </label>
+              <select
+                v-model="linkRelationship"
+                data-testid="chain-relationship-select"
+                class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              >
+                <option :value="null">None</option>
+                <option value="Father">Father</option>
+                <option value="Mother">Mother</option>
+                <option value="Relative">Relative</option>
+                <option value="HiredHelp">Hired Help</option>
+              </select>
+            </div>
+            <label class="flex items-center space-x-2 cursor-pointer">
+              <input
+                v-model="linkIsPrimary"
+                type="checkbox"
+                data-testid="chain-primary-checkbox"
+                class="rounded border-slate-300 text-blue-600 focus:ring-blue-500"
+              />
+              <span class="text-sm font-medium text-slate-700">Primary caretaker</span>
+            </label>
           </div>
 
           <div v-if="isEdit" class="space-y-1">
@@ -150,8 +189,11 @@ export default defineComponent({
   props: {
     visible: { type: Boolean, required: true },
     caretaker: { type: Object as PropType<Caretaker | null>, default: null },
+    // WP-27 (F8): set when this modal is the create-new step of a cross-add chain — shows the
+    // context banner + relationship/primary fields and enriches the `created` emit.
+    linkTo: { type: Object as PropType<{ name: string } | null>, default: null },
   },
-  emits: ['close', 'saved'],
+  emits: ['close', 'saved', 'created'],
   setup(props, { emit }) {
     const { error, hasError, saving, setError, clearError, submit } = useModalForm();
 
@@ -166,6 +208,10 @@ export default defineComponent({
     });
 
     const isEdit = ref(false);
+
+    // WP-27 (F8): link fields shown only when opened as a chain's create-new step (linkTo set).
+    const linkRelationship = ref<string | null>(null);
+    const linkIsPrimary = ref(true);
 
     watch(form, () => clearError(), { deep: true });
 
@@ -193,6 +239,8 @@ export default defineComponent({
           form.phoneNumber = '';
           form.notes = '';
           form.isActive = true;
+          linkRelationship.value = null;
+          linkIsPrimary.value = true;
         }
       }
     );
@@ -215,7 +263,7 @@ export default defineComponent({
             isActive: form.isActive,
           });
         } else {
-          await client.createCaretaker({
+          const created = await client.createCaretaker({
             firstName: form.firstName,
             middleName: form.middleName || undefined,
             lastName: form.lastName,
@@ -224,13 +272,19 @@ export default defineComponent({
             notes: form.notes || undefined,
             isActive: true,
           });
+          // WP-27: hand the created record (plus chain link fields when applicable) to the
+          // parent — CaretakersView starts the F9 chain; CrossAddChainModal performs the F8 link.
+          emit('created', {
+            record: created,
+            link: props.linkTo ? { relationship: linkRelationship.value, isPrimary: linkIsPrimary.value } : null,
+          });
         }
         emit('saved');
         emit('close');
       });
     };
 
-    return { form, isEdit, saving, error, hasError, handleSubmit };
+    return { form, isEdit, saving, error, hasError, linkRelationship, linkIsPrimary, handleSubmit };
   },
 });
 </script>

--- a/app-ui/src/components/caretakers/CaretakerPatientsList.vue
+++ b/app-ui/src/components/caretakers/CaretakerPatientsList.vue
@@ -100,61 +100,15 @@
         <span>Link Patient</span>
       </button>
 
-      <div v-if="showLinkForm" class="space-y-3">
-        <div>
-          <label class="block text-xs font-medium text-slate-600 mb-1">Patient</label>
-          <select
-            v-model="linkPatientId"
-            class="w-full rounded-lg border border-slate-300 text-sm px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-          >
-            <option :value="0" disabled>Select a patient...</option>
-            <option
-              v-for="p in availablePatients"
-              :key="p.patientId"
-              :value="p.patientId"
-            >
-              {{ p.patientName }}
-            </option>
-          </select>
-        </div>
-        <div>
-          <label class="block text-xs font-medium text-slate-600 mb-1">Relationship</label>
-          <select
-            v-model="linkRelationship"
-            class="w-full rounded-lg border border-slate-300 text-sm px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-          >
-            <option :value="null">None</option>
-            <option value="Father">Father</option>
-            <option value="Mother">Mother</option>
-            <option value="Relative">Relative</option>
-            <option value="HiredHelp">Hired Help</option>
-          </select>
-        </div>
-        <div class="flex items-center space-x-2">
-          <input
-            id="link-primary"
-            v-model="linkIsPrimary"
-            type="checkbox"
-            class="rounded border-slate-300 text-blue-600 focus:ring-blue-500"
-          />
-          <label for="link-primary" class="text-sm text-slate-700">Primary caretaker</label>
-        </div>
-        <div class="flex items-center space-x-2">
-          <button
-            class="px-4 py-2 rounded-lg text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 transition-colors disabled:opacity-50"
-            :disabled="linkPatientId === 0 || saving"
-            @click="doLink"
-          >
-            Link
-          </button>
-          <button
-            class="px-4 py-2 rounded-lg text-sm font-medium text-slate-600 hover:bg-slate-100 transition-colors"
-            @click="resetLinkForm"
-          >
-            Cancel
-          </button>
-        </div>
-      </div>
+      <!-- WP-27: shared link form (also used by PatientCaretakerPanel + the cross-add chain) -->
+      <CaretakerLinkForm
+        v-if="showLinkForm"
+        entity-label="Patient"
+        :options="patientOptions"
+        :saving="saving"
+        @submit="doLink"
+        @cancel="showLinkForm = false"
+      />
     </div>
 
     <!-- Error message -->
@@ -183,9 +137,11 @@ import type { Patient } from '../../interfaces/Patient';
 import { CaretakersHttpClient } from '../../services/CaretakersHttpClient';
 import { PatientsHttpClient } from '../../services/PatientsHttpClient';
 import { useClaims, Permissions } from '../../composables/useClaims';
+import CaretakerLinkForm from '../shared/CaretakerLinkForm.vue';
 
 export default defineComponent({
   name: 'CaretakerPatientsList',
+  components: { CaretakerLinkForm },
   props: {
     caretaker: { type: Object as PropType<Caretaker>, required: true },
   },
@@ -202,13 +158,12 @@ export default defineComponent({
     const errorMsg = ref('');
     const unlinkTarget = ref<CaretakerPatientSummary | null>(null);
     const showLinkForm = ref(false);
-    const linkPatientId = ref(0);
-    const linkRelationship = ref<string | null>(null);
-    const linkIsPrimary = ref(true);
 
-    const availablePatients = computed(() => {
+    const patientOptions = computed(() => {
       const linkedIds = new Set(linkedPatients.value.map((lp) => lp.patientId));
-      return allPatients.value.filter((p) => !linkedIds.has(p.patientId));
+      return allPatients.value
+        .filter((p) => !linkedIds.has(p.patientId))
+        .map((p) => ({ id: p.patientId, name: p.patientName }));
     });
 
     const loadData = async () => {
@@ -240,17 +195,17 @@ export default defineComponent({
       }
     };
 
-    const doLink = async () => {
+    const doLink = async (payload: { id: number; relationship: string | null; isPrimary: boolean }) => {
       saving.value = true;
       errorMsg.value = '';
       try {
         await caretakerClient.linkPatient(
           props.caretaker.caretakerId,
-          linkPatientId.value,
-          linkIsPrimary.value,
-          linkRelationship.value,
+          payload.id,
+          payload.isPrimary,
+          payload.relationship,
         );
-        resetLinkForm();
+        showLinkForm.value = false;
         await loadData();
         emit('updated');
       } catch (e: unknown) {
@@ -258,13 +213,6 @@ export default defineComponent({
       } finally {
         saving.value = false;
       }
-    };
-
-    const resetLinkForm = () => {
-      showLinkForm.value = false;
-      linkPatientId.value = 0;
-      linkRelationship.value = null;
-      linkIsPrimary.value = true;
     };
 
     const viewPlans = (patientId: number) => {
@@ -275,18 +223,14 @@ export default defineComponent({
 
     return {
       linkedPatients,
-      availablePatients,
+      patientOptions,
       saving,
       errorMsg,
       unlinkTarget,
       showLinkForm,
-      linkPatientId,
-      linkRelationship,
-      linkIsPrimary,
       confirmUnlink,
       doUnlink,
       doLink,
-      resetLinkForm,
       viewPlans,
       hasClaim,
       Permissions,

--- a/app-ui/src/components/patients/PatientCaretakerPanel.vue
+++ b/app-ui/src/components/patients/PatientCaretakerPanel.vue
@@ -43,8 +43,10 @@
             Primary
           </span>
         </div>
+        <!-- WP-27 claim hygiene: gate on the claim the API enforces — link/unlink is
+             caretaker-side (Caretakers.LinkPatient), not Patients.LinkCaretaker -->
         <button
-          v-if="hasClaim('Permission', Permissions.PatientsLinkCaretaker)"
+          v-if="hasClaim('Permission', Permissions.CaretakersLinkPatient)"
           class="px-3 py-1 rounded-lg text-xs font-medium text-red-600 hover:bg-red-50 transition-colors"
           @click="confirmRemove(lc)"
         >
@@ -82,7 +84,7 @@
     <!-- Add caretaker section -->
     <div class="border-t border-slate-200 pt-4">
       <button
-        v-if="!showAddForm && hasClaim('Permission', Permissions.PatientsLinkCaretaker)"
+        v-if="!showAddForm && hasClaim('Permission', Permissions.CaretakersLinkPatient)"
         class="flex items-center space-x-2 px-4 py-2 rounded-lg text-sm font-medium text-blue-600 hover:bg-blue-50 transition-colors"
         @click="showAddForm = true"
       >
@@ -92,61 +94,16 @@
         <span>Add Caretaker</span>
       </button>
 
-      <div v-if="showAddForm" class="space-y-3">
-        <div>
-          <label class="block text-xs font-medium text-slate-600 mb-1">Caretaker</label>
-          <select
-            v-model="addCaretakerId"
-            class="w-full rounded-lg border border-slate-300 text-sm px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-          >
-            <option :value="0" disabled>Select a caretaker...</option>
-            <option
-              v-for="c in availableCaretakers"
-              :key="c.caretakerId"
-              :value="c.caretakerId"
-            >
-              {{ c.caretakerName }}
-            </option>
-          </select>
-        </div>
-        <div>
-          <label class="block text-xs font-medium text-slate-600 mb-1">Relationship</label>
-          <select
-            v-model="addRelationship"
-            class="w-full rounded-lg border border-slate-300 text-sm px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-          >
-            <option :value="null">None</option>
-            <option value="Father">Father</option>
-            <option value="Mother">Mother</option>
-            <option value="Relative">Relative</option>
-            <option value="HiredHelp">Hired Help</option>
-          </select>
-        </div>
-        <div class="flex items-center space-x-2">
-          <input
-            id="add-primary"
-            v-model="addIsPrimary"
-            type="checkbox"
-            class="rounded border-slate-300 text-blue-600 focus:ring-blue-500"
-          />
-          <label for="add-primary" class="text-sm text-slate-700">Primary caretaker</label>
-        </div>
-        <div class="flex items-center space-x-2">
-          <button
-            class="px-4 py-2 rounded-lg text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 transition-colors disabled:opacity-50"
-            :disabled="addCaretakerId === 0 || saving"
-            @click="doAdd"
-          >
-            Add
-          </button>
-          <button
-            class="px-4 py-2 rounded-lg text-sm font-medium text-slate-600 hover:bg-slate-100 transition-colors"
-            @click="resetAddForm"
-          >
-            Cancel
-          </button>
-        </div>
-      </div>
+      <!-- WP-27: shared link form (also used by CaretakerPatientsList + the cross-add chain) -->
+      <CaretakerLinkForm
+        v-if="showAddForm"
+        entity-label="Caretaker"
+        :options="caretakerOptions"
+        :saving="saving"
+        submit-label="Add"
+        @submit="doAdd"
+        @cancel="showAddForm = false"
+      />
     </div>
 
     <!-- Error message -->
@@ -174,9 +131,11 @@ import type { Caretaker } from '../../interfaces/Caretaker';
 import { CaretakersHttpClient } from '../../services/CaretakersHttpClient';
 import { PatientsHttpClient } from '../../services/PatientsHttpClient';
 import { useClaims, Permissions } from '../../composables/useClaims';
+import CaretakerLinkForm from '../shared/CaretakerLinkForm.vue';
 
 export default defineComponent({
   name: 'PatientCaretakerPanel',
+  components: { CaretakerLinkForm },
   props: {
     patient: { type: Object as PropType<Patient>, required: true },
   },
@@ -192,13 +151,12 @@ export default defineComponent({
     const errorMsg = ref('');
     const removeTarget = ref<PatientCaretakerSummary | null>(null);
     const showAddForm = ref(false);
-    const addCaretakerId = ref(0);
-    const addRelationship = ref<string | null>(null);
-    const addIsPrimary = ref(true);
 
-    const availableCaretakers = computed(() => {
+    const caretakerOptions = computed(() => {
       const linkedIds = new Set(linkedCaretakers.value.map((lc) => lc.caretakerId));
-      return allCaretakers.value.filter((c) => !linkedIds.has(c.caretakerId));
+      return allCaretakers.value
+        .filter((c) => !linkedIds.has(c.caretakerId))
+        .map((c) => ({ id: c.caretakerId, name: c.caretakerName }));
     });
 
     const loadData = async () => {
@@ -230,17 +188,17 @@ export default defineComponent({
       }
     };
 
-    const doAdd = async () => {
+    const doAdd = async (payload: { id: number; relationship: string | null; isPrimary: boolean }) => {
       saving.value = true;
       errorMsg.value = '';
       try {
         await caretakerClient.linkPatient(
-          addCaretakerId.value,
+          payload.id,
           props.patient.patientId,
-          addIsPrimary.value,
-          addRelationship.value,
+          payload.isPrimary,
+          payload.relationship,
         );
-        resetAddForm();
+        showAddForm.value = false;
         await loadData();
         emit('updated');
       } catch (e: unknown) {
@@ -250,29 +208,18 @@ export default defineComponent({
       }
     };
 
-    const resetAddForm = () => {
-      showAddForm.value = false;
-      addCaretakerId.value = 0;
-      addRelationship.value = null;
-      addIsPrimary.value = true;
-    };
-
     onMounted(loadData);
 
     return {
       linkedCaretakers,
-      availableCaretakers,
+      caretakerOptions,
       saving,
       errorMsg,
       removeTarget,
       showAddForm,
-      addCaretakerId,
-      addRelationship,
-      addIsPrimary,
       confirmRemove,
       doRemove,
       doAdd,
-      resetAddForm,
       hasClaim,
       Permissions,
     };

--- a/app-ui/src/components/patients/PatientFormModal.vue
+++ b/app-ui/src/components/patients/PatientFormModal.vue
@@ -23,6 +23,15 @@
 
         <!-- Form -->
         <form class="flex-1 overflow-y-auto px-6 py-4 space-y-4" @submit.prevent="handleSubmit">
+          <!-- WP-27 (F9): create-new step of a cross-add chain — the saved patient auto-links -->
+          <div
+            v-if="linkTo && !isEdit"
+            class="bg-amber-50 border border-amber-200 rounded-lg px-3 py-2 text-xs text-amber-800"
+            data-testid="chain-context-banner"
+          >
+            Will be linked to caretaker <strong>{{ linkTo.name }}</strong>
+          </div>
+
           <div class="grid grid-cols-2 gap-4">
             <div>
               <label class="block text-sm font-medium text-slate-700 mb-1">First Name *</label>
@@ -196,6 +205,36 @@
             </p>
           </div>
 
+          <!-- WP-27 (F9): link fields captured with the create and passed back on the `created`
+               emit — the chain performs the actual link call after the patient exists. -->
+          <div v-if="linkTo && !isEdit" class="space-y-3">
+            <div>
+              <label class="block text-sm font-medium text-slate-700 mb-1">
+                Relationship of {{ linkTo.name }} to this patient
+              </label>
+              <select
+                v-model="linkRelationship"
+                data-testid="chain-relationship-select"
+                class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              >
+                <option :value="null">None</option>
+                <option value="Father">Father</option>
+                <option value="Mother">Mother</option>
+                <option value="Relative">Relative</option>
+                <option value="HiredHelp">Hired Help</option>
+              </select>
+            </div>
+            <label class="flex items-center space-x-2 cursor-pointer">
+              <input
+                v-model="linkIsPrimary"
+                type="checkbox"
+                data-testid="chain-primary-checkbox"
+                class="rounded border-slate-300 text-blue-600 focus:ring-blue-500"
+              />
+              <span class="text-sm font-medium text-slate-700">Primary caretaker</span>
+            </label>
+          </div>
+
           <div v-if="isEdit" class="space-y-1">
             <div class="flex items-center space-x-3">
               <label class="text-sm font-medium text-slate-700">Active Status</label>
@@ -295,8 +334,11 @@ export default defineComponent({
   props: {
     visible: { type: Boolean, required: true },
     patient: { type: Object as PropType<Patient | null>, default: null },
+    // WP-27 (F9): set when this modal is the create-new step of a cross-add chain — shows the
+    // context banner + relationship/primary fields and enriches the `created` emit.
+    linkTo: { type: Object as PropType<{ name: string } | null>, default: null },
   },
-  emits: ['close', 'saved', 'created-temp-mrn'],
+  emits: ['close', 'saved', 'created', 'created-temp-mrn'],
   setup(props, { emit }) {
     const { error, hasError, saving, setError, clearError, submit } = useModalForm();
     const { hasClaim } = useClaims();
@@ -319,6 +361,10 @@ export default defineComponent({
     });
 
     const isEdit = ref(false);
+
+    // WP-27 (F9): link fields shown only when opened as a chain's create-new step (linkTo set).
+    const linkRelationship = ref<string | null>(null);
+    const linkIsPrimary = ref(true);
 
     // WP-25 (F5): whether the patient being edited already had a cedula/passport stored when the
     // modal opened — an on-file value can never be cleared; a legacy NULL stays tolerated.
@@ -390,6 +436,8 @@ export default defineComponent({
           form.hasSenadisDiscount = false;
           form.requiresDiscovery = true; // WP-24: default CHECKED at create
           form.activeStatus = true;
+          linkRelationship.value = null;
+          linkIsPrimary.value = true;
         }
       }
     );
@@ -470,6 +518,12 @@ export default defineComponent({
             hasSenadisDiscount: form.hasSenadisDiscount,
             requiresDiscovery: form.requiresDiscovery,
           });
+          // WP-27: hand the created record (plus chain link fields when applicable) to the
+          // parent — PatientsView starts the F8 chain; CrossAddChainModal performs the F9 link.
+          emit('created', {
+            record: created,
+            link: props.linkTo ? { relationship: linkRelationship.value, isPrimary: linkIsPrimary.value } : null,
+          });
           if (isTemporaryMrn(created.medicalRecordNumber ?? '')) {
             emit('created-temp-mrn', created);
           }
@@ -479,7 +533,7 @@ export default defineComponent({
       });
     };
 
-    return { form, isEdit, saving, error, hasError, hasTemporaryMrn, cannotActivate, canEditSenadis, canEditRequiresDiscovery, age, hadCedulaOnFile, showLegacyCedulaNag, handleSubmit };
+    return { form, isEdit, saving, error, hasError, hasTemporaryMrn, cannotActivate, canEditSenadis, canEditRequiresDiscovery, age, hadCedulaOnFile, showLegacyCedulaNag, linkRelationship, linkIsPrimary, handleSubmit };
   },
 });
 </script>

--- a/app-ui/src/components/shared/CaretakerLinkForm.vue
+++ b/app-ui/src/components/shared/CaretakerLinkForm.vue
@@ -1,0 +1,88 @@
+<template>
+  <div class="space-y-3">
+    <div>
+      <label class="block text-xs font-medium text-slate-600 mb-1">{{ entityLabel }}</label>
+      <select
+        v-model="selectedId"
+        data-testid="link-entity-select"
+        class="w-full rounded-lg border border-slate-300 text-sm px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+      >
+        <option :value="0" disabled>Select a {{ entityLabel.toLowerCase() }}...</option>
+        <option v-for="o in options" :key="o.id" :value="o.id">
+          {{ o.name }}
+        </option>
+      </select>
+    </div>
+    <div>
+      <label class="block text-xs font-medium text-slate-600 mb-1">Relationship</label>
+      <select
+        v-model="relationship"
+        data-testid="link-relationship-select"
+        class="w-full rounded-lg border border-slate-300 text-sm px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+      >
+        <option :value="null">None</option>
+        <option value="Father">Father</option>
+        <option value="Mother">Mother</option>
+        <option value="Relative">Relative</option>
+        <option value="HiredHelp">Hired Help</option>
+      </select>
+    </div>
+    <div class="flex items-center space-x-2">
+      <input
+        :id="primaryInputId"
+        v-model="isPrimary"
+        type="checkbox"
+        data-testid="link-primary-checkbox"
+        class="rounded border-slate-300 text-blue-600 focus:ring-blue-500"
+      />
+      <label :for="primaryInputId" class="text-sm text-slate-700">Primary caretaker</label>
+    </div>
+    <div class="flex items-center space-x-2">
+      <button
+        data-testid="link-submit"
+        class="px-4 py-2 rounded-lg text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 transition-colors disabled:opacity-50"
+        :disabled="selectedId === 0 || saving"
+        @click="$emit('submit', { id: selectedId, relationship, isPrimary })"
+      >
+        {{ submitLabel }}
+      </button>
+      <button
+        class="px-4 py-2 rounded-lg text-sm font-medium text-slate-600 hover:bg-slate-100 transition-colors"
+        @click="$emit('cancel')"
+      >
+        Cancel
+      </button>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+// WP-27: the caretaker↔patient link form (entity dropdown + relationship + primary), extracted
+// from PatientCaretakerPanel / CaretakerPatientsList so the cross-add chain isn't a third copy.
+// The parent owns the API call; this form only collects { id, relationship, isPrimary }.
+// State resets by unmount — parents render it under v-if.
+import { defineComponent, ref, computed, type PropType } from 'vue';
+
+export interface LinkOption {
+  id: number;
+  name: string;
+}
+
+export default defineComponent({
+  name: 'CaretakerLinkForm',
+  props: {
+    entityLabel: { type: String, required: true }, // 'Caretaker' | 'Patient' — what the dropdown lists
+    options: { type: Array as PropType<LinkOption[]>, required: true },
+    saving: { type: Boolean, default: false },
+    submitLabel: { type: String, default: 'Link' },
+  },
+  emits: ['submit', 'cancel'],
+  setup(props) {
+    const selectedId = ref(0);
+    const relationship = ref<string | null>(null);
+    const isPrimary = ref(true);
+    const primaryInputId = computed(() => `link-primary-${props.entityLabel.toLowerCase()}`);
+    return { selectedId, relationship, isPrimary, primaryInputId };
+  },
+});
+</script>

--- a/app-ui/src/components/shared/CrossAddChainModal.vue
+++ b/app-ui/src/components/shared/CrossAddChainModal.vue
@@ -1,0 +1,321 @@
+<template>
+  <div>
+    <teleport to="body">
+      <!-- Chooser: offered right after the origin record is created (Option A hand-off) -->
+      <div v-if="visible && step === 'chooser'" class="fixed inset-0 z-50 flex items-center justify-center p-4">
+        <div class="absolute inset-0 bg-black/50" @click="dismiss"></div>
+        <div class="relative w-full max-w-md bg-white rounded-xl shadow-2xl p-6" data-testid="chain-chooser">
+          <div class="flex items-start space-x-3">
+            <span class="mt-0.5 w-7 h-7 flex items-center justify-center rounded-full bg-green-100 text-green-700 text-sm shrink-0">✓</span>
+            <p class="text-sm font-semibold text-slate-800">
+              {{ addingCaretaker ? 'Patient created' : 'Caretaker created' }} — {{ target?.name }}
+            </p>
+          </div>
+          <div
+            v-if="addingCaretaker"
+            class="mt-4 bg-amber-50 border border-amber-200 rounded-lg p-3 text-xs text-amber-800"
+          >
+            This patient has no caretaker on file — <strong>bookings are blocked until one is linked</strong>.
+          </div>
+          <div v-else class="mt-4 bg-sky-50 border border-sky-200 rounded-lg p-3 text-xs text-sky-800">
+            No patients linked yet — link the patient this caretaker is responsible for, or create one now.
+          </div>
+          <div class="mt-4 space-y-2">
+            <button
+              v-if="canLink"
+              data-testid="chain-link-existing"
+              class="w-full px-4 py-2.5 rounded-lg text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 text-left transition-colors"
+              @click="openLink"
+            >
+              Link an existing {{ otherNoun }}
+            </button>
+            <button
+              v-if="canCreate"
+              data-testid="chain-create-new"
+              class="w-full px-4 py-2.5 rounded-lg text-sm font-medium text-blue-700 bg-blue-50 border border-blue-200 hover:bg-blue-100 text-left transition-colors"
+              @click="step = 'create'"
+            >
+              Create a new {{ otherNoun }}
+            </button>
+            <button
+              data-testid="chain-later"
+              class="w-full px-4 py-2 rounded-lg text-xs text-slate-500 hover:bg-slate-50 transition-colors"
+              @click="dismiss"
+            >
+              Later{{ addingCaretaker ? " — I'll link one from the patient's page" : '' }}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Link existing: its own slide-over with the context banner -->
+      <div v-if="visible && step === 'link'" class="fixed inset-0 z-50 flex justify-end">
+        <div class="absolute inset-0 bg-black/30" @click="step = 'chooser'"></div>
+        <div class="relative w-full max-w-md bg-white shadow-xl flex flex-col">
+          <div class="px-6 py-4 border-b border-slate-200">
+            <h2 class="text-lg font-semibold text-slate-800">Link {{ otherLabel }}</h2>
+          </div>
+          <div class="px-6 pt-4">
+            <div class="bg-amber-50 border border-amber-200 rounded-lg px-3 py-2 text-xs text-amber-800" data-testid="chain-link-banner">
+              <template v-if="addingCaretaker">Linking to patient <strong>{{ target?.name }}</strong></template>
+              <template v-else>Linking caretaker <strong>{{ target?.name }}</strong> to a patient</template>
+            </div>
+          </div>
+          <div class="flex-1 overflow-y-auto px-6 py-4">
+            <CaretakerLinkForm
+              :entity-label="otherLabel"
+              :options="options"
+              :saving="saving"
+              @submit="doLink"
+              @cancel="step = 'chooser'"
+            />
+            <p v-if="errorMsg" class="text-sm text-red-600 mt-3" data-testid="chain-error">{{ errorMsg }}</p>
+          </div>
+        </div>
+      </div>
+
+      <!-- Success -->
+      <div v-if="visible && step === 'success'" class="fixed inset-0 z-50 flex items-center justify-center p-4">
+        <div class="absolute inset-0 bg-black/50" @click="finish"></div>
+        <div class="relative w-full max-w-md bg-white rounded-xl shadow-2xl p-6 text-center" data-testid="chain-success">
+          <p class="text-sm font-semibold text-green-700">✓ {{ successMsg }}</p>
+          <p v-if="addingCaretaker" class="text-xs text-slate-500 mt-1">{{ target?.name }} is now bookable.</p>
+          <button
+            class="mt-4 px-4 py-2 rounded-lg text-sm font-medium text-slate-700 bg-slate-100 hover:bg-slate-200 transition-colors"
+            @click="finish"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+
+      <!-- Created but the link call failed: keep the chain open with a retry (non-atomic by design) -->
+      <div v-if="visible && step === 'link-failed'" class="fixed inset-0 z-50 flex items-center justify-center p-4">
+        <div class="absolute inset-0 bg-black/50"></div>
+        <div class="relative w-full max-w-md bg-white rounded-xl shadow-2xl p-6" data-testid="chain-link-failed">
+          <p class="text-sm font-semibold text-amber-700">
+            {{ otherLabel }} <strong>{{ createdName }}</strong> was created, but linking failed.
+          </p>
+          <p class="text-xs text-red-600 mt-2">{{ errorMsg }}</p>
+          <div class="mt-4 flex items-center space-x-2">
+            <button
+              data-testid="chain-retry-link"
+              class="px-4 py-2 rounded-lg text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 transition-colors disabled:opacity-50"
+              :disabled="saving"
+              @click="doPendingLink"
+            >
+              Retry link
+            </button>
+            <button
+              class="px-4 py-2 rounded-lg text-sm font-medium text-slate-600 hover:bg-slate-100 transition-colors"
+              @click="finish"
+            >
+              Link manually later
+            </button>
+          </div>
+        </div>
+      </div>
+    </teleport>
+
+    <!-- Create new: reuse the real form modals so WP-24/25 behavior rides along; they teleport themselves -->
+    <CaretakerFormModal
+      v-if="addingCaretaker"
+      :visible="visible && step === 'create'"
+      :caretaker="null"
+      :link-to="linkToCtx"
+      @created="onCreated"
+      @close="onCreateClosed"
+    />
+    <PatientFormModal
+      v-else
+      :visible="visible && step === 'create'"
+      :patient="null"
+      :link-to="linkToCtx"
+      @created="onCreated"
+      @close="onCreateClosed"
+    />
+  </div>
+</template>
+
+<script lang="ts">
+// WP-27 (F8/F9) — Option A sequential hand-off chain (owner ruling 2026-07-13, both directions).
+// Opened by PatientsView (mode=add-caretaker, F8) / CaretakersView (mode=add-patient, F9) right
+// after a create. All affordances gate on the claims the API actually enforces: linking is
+// caretaker-side ONLY (POST /api/caretakers/{id}/patients ⇒ Caretakers.LinkPatient), create-new
+// additionally needs Caretakers.Edit / Patients.Edit.
+import { defineComponent, ref, computed, watch, type PropType } from 'vue';
+import CaretakerLinkForm, { type LinkOption } from './CaretakerLinkForm.vue';
+import CaretakerFormModal from '../caretakers/CaretakerFormModal.vue';
+import PatientFormModal from '../patients/PatientFormModal.vue';
+import { CaretakersHttpClient } from '../../services/CaretakersHttpClient';
+import { PatientsHttpClient } from '../../services/PatientsHttpClient';
+import { useClaims, Permissions } from '../../composables/useClaims';
+import type { Caretaker } from '../../interfaces/Caretaker';
+import type { Patient } from '../../interfaces/Patient';
+import type { CreatedForChain } from '../../interfaces/CrossAdd';
+
+type ChainStep = 'chooser' | 'link' | 'create' | 'success' | 'link-failed';
+
+export interface ChainTarget {
+  id: number;
+  name: string;
+}
+
+export default defineComponent({
+  name: 'CrossAddChainModal',
+  components: { CaretakerLinkForm, CaretakerFormModal, PatientFormModal },
+  props: {
+    visible: { type: Boolean, required: true },
+    // 'add-caretaker' = F8 (a patient was just created); 'add-patient' = F9 (a caretaker was)
+    mode: { type: String as PropType<'add-caretaker' | 'add-patient'>, required: true },
+    target: { type: Object as PropType<ChainTarget | null>, default: null },
+  },
+  emits: ['close', 'linked'],
+  setup(props, { emit }) {
+    const { hasClaim } = useClaims();
+    const caretakerClient = new CaretakersHttpClient();
+    const patientClient = new PatientsHttpClient();
+
+    const step = ref<ChainStep>('chooser');
+    const options = ref<LinkOption[]>([]);
+    const saving = ref(false);
+    const errorMsg = ref('');
+    const successMsg = ref('');
+    const createdName = ref('');
+    const pendingLink = ref<{ id: number; relationship: string | null; isPrimary: boolean } | null>(null);
+
+    const addingCaretaker = computed(() => props.mode === 'add-caretaker');
+    const otherNoun = computed(() => (addingCaretaker.value ? 'caretaker' : 'patient'));
+    const otherLabel = computed(() => (addingCaretaker.value ? 'Caretaker' : 'Patient'));
+
+    const canLink = computed(() => hasClaim('Permission', Permissions.CaretakersLinkPatient));
+    const canCreate = computed(
+      () =>
+        canLink.value &&
+        hasClaim('Permission', addingCaretaker.value ? Permissions.CaretakersEdit : Permissions.PatientsEdit)
+    );
+
+    const linkToCtx = computed(() => (props.target ? { name: props.target.name } : null));
+
+    watch(
+      () => props.visible,
+      (val) => {
+        if (!val) return;
+        step.value = 'chooser';
+        options.value = [];
+        errorMsg.value = '';
+        successMsg.value = '';
+        createdName.value = '';
+        pendingLink.value = null;
+      }
+    );
+
+    const openLink = async () => {
+      step.value = 'link';
+      errorMsg.value = '';
+      try {
+        options.value = addingCaretaker.value
+          ? (await caretakerClient.getCaretakers()).map((c) => ({ id: c.caretakerId, name: c.caretakerName }))
+          : (await patientClient.getPatients()).map((p) => ({ id: p.patientId, name: p.patientName }));
+      } catch (e: unknown) {
+        errorMsg.value = e instanceof Error ? e.message : 'Failed to load data.';
+      }
+    };
+
+    const link = async (otherId: number, isPrimary: boolean, relationship: string | null) => {
+      if (!props.target) return;
+      // Both directions call the caretaker-side endpoint — orient the ids by mode.
+      const caretakerId = addingCaretaker.value ? otherId : props.target.id;
+      const patientId = addingCaretaker.value ? props.target.id : otherId;
+      await caretakerClient.linkPatient(caretakerId, patientId, isPrimary, relationship);
+    };
+
+    const doLink = async (payload: { id: number; relationship: string | null; isPrimary: boolean }) => {
+      saving.value = true;
+      errorMsg.value = '';
+      try {
+        await link(payload.id, payload.isPrimary, payload.relationship);
+        const name = options.value.find((o) => o.id === payload.id)?.name ?? otherLabel.value;
+        successMsg.value = `${name} linked${payload.isPrimary ? ' as primary' : ''}`;
+        step.value = 'success';
+        emit('linked');
+      } catch (e: unknown) {
+        // Stay on the link step — the form itself is the retry affordance.
+        errorMsg.value = e instanceof Error ? e.message : `Failed to link ${otherNoun.value}.`;
+      } finally {
+        saving.value = false;
+      }
+    };
+
+    const onCreated = (payload: CreatedForChain<Caretaker> | CreatedForChain<Patient>) => {
+      if (addingCaretaker.value) {
+        const c = (payload as CreatedForChain<Caretaker>).record;
+        createdName.value = c.caretakerName;
+        pendingLink.value = {
+          id: c.caretakerId,
+          relationship: payload.link?.relationship ?? null,
+          isPrimary: payload.link?.isPrimary ?? true,
+        };
+      } else {
+        const p = (payload as CreatedForChain<Patient>).record;
+        createdName.value = p.patientName;
+        pendingLink.value = {
+          id: p.patientId,
+          relationship: payload.link?.relationship ?? null,
+          isPrimary: payload.link?.isPrimary ?? true,
+        };
+      }
+      doPendingLink();
+    };
+
+    const doPendingLink = async () => {
+      if (!pendingLink.value) return;
+      saving.value = true;
+      errorMsg.value = '';
+      try {
+        await link(pendingLink.value.id, pendingLink.value.isPrimary, pendingLink.value.relationship);
+        successMsg.value = `${createdName.value} created and linked${pendingLink.value.isPrimary ? ' as primary' : ''}`;
+        step.value = 'success';
+        emit('linked');
+      } catch (e: unknown) {
+        errorMsg.value = e instanceof Error ? e.message : 'The record was created but linking failed.';
+        step.value = 'link-failed';
+      } finally {
+        saving.value = false;
+      }
+    };
+
+    const onCreateClosed = () => {
+      // The form modal closes itself after a successful create — the pending link is already in
+      // flight then. Only a user-cancelled form returns to the chooser.
+      if (pendingLink.value) return;
+      step.value = 'chooser';
+    };
+
+    const dismiss = () => emit('close');
+    const finish = () => emit('close');
+
+    return {
+      step,
+      options,
+      saving,
+      errorMsg,
+      successMsg,
+      createdName,
+      addingCaretaker,
+      otherNoun,
+      otherLabel,
+      canLink,
+      canCreate,
+      linkToCtx,
+      openLink,
+      doLink,
+      onCreated,
+      onCreateClosed,
+      doPendingLink,
+      dismiss,
+      finish,
+    };
+  },
+});
+</script>

--- a/app-ui/src/interfaces/CrossAdd.ts
+++ b/app-ui/src/interfaces/CrossAdd.ts
@@ -1,0 +1,15 @@
+// interfaces/CrossAdd.ts
+//
+// WP-27 (F8/F9) — cross-add chain shapes. When a form modal is opened as the create-new step of
+// a cross-add chain (linkTo prop set), its `created` emit carries the caretaker↔patient link
+// fields captured in the form alongside the created record; outside a chain `link` is null.
+
+export interface CrossAddLink {
+  relationship: string | null;
+  isPrimary: boolean;
+}
+
+export interface CreatedForChain<TRecord> {
+  record: TRecord;
+  link: CrossAddLink | null;
+}

--- a/app-ui/src/views/CaretakersView.vue
+++ b/app-ui/src/views/CaretakersView.vue
@@ -40,6 +40,15 @@
       :caretaker="editingCaretaker"
       @close="modalVisible = false"
       @saved="onSaved"
+      @created="onCaretakerCreated"
+    />
+
+    <!-- WP-27 (F9): a just-created caretaker has no patients — offer to link/create one now -->
+    <CrossAddChainModal
+      :visible="chainVisible"
+      mode="add-patient"
+      :target="chainTarget"
+      @close="onChainClose"
     />
   </div>
 </template>
@@ -54,15 +63,19 @@ import O2Footer from '../components/option02/O2Footer.vue';
 import CaretakerList from '../components/caretakers/CaretakerList.vue';
 import CaretakerFormModal from '../components/caretakers/CaretakerFormModal.vue';
 import CaretakerPatientsList from '../components/caretakers/CaretakerPatientsList.vue';
+import CrossAddChainModal, { type ChainTarget } from '../components/shared/CrossAddChainModal.vue';
 import { CaretakersHttpClient } from '../services/CaretakersHttpClient';
 import type { Caretaker } from '../interfaces/Caretaker';
+import type { CreatedForChain } from '../interfaces/CrossAdd';
+import { useClaims, Permissions } from '../composables/useClaims';
 
 export default defineComponent({
   name: 'CaretakersView',
-  components: { O2MobileNav, O2Sidebar, O2Header, O2Footer, CaretakerList, CaretakerFormModal, CaretakerPatientsList },
+  components: { O2MobileNav, O2Sidebar, O2Header, O2Footer, CaretakerList, CaretakerFormModal, CaretakerPatientsList, CrossAddChainModal },
   setup() {
     const route = useRoute();
     const client = new CaretakersHttpClient();
+    const { hasClaim } = useClaims();
 
     const validTabs = ['all', 'active', 'inactive'] as const;
     type TabValue = typeof validTabs[number];
@@ -134,6 +147,22 @@ export default defineComponent({
       loadCaretakers();
     };
 
+    const chainVisible = ref(false);
+    const chainTarget = ref<ChainTarget | null>(null);
+
+    // WP-27 (F9): every create lands patient-less — open the chain when this user holds the
+    // claim the link endpoint enforces (Caretakers.LinkPatient).
+    const onCaretakerCreated = (payload: CreatedForChain<Caretaker>) => {
+      if (!hasClaim('Permission', Permissions.CaretakersLinkPatient)) return;
+      chainTarget.value = { id: payload.record.caretakerId, name: payload.record.caretakerName };
+      chainVisible.value = true;
+    };
+
+    const onChainClose = () => {
+      chainVisible.value = false;
+      loadCaretakers(); // a patient may have been created/linked — refresh
+    };
+
     onMounted(loadCaretakers);
 
     return {
@@ -151,6 +180,10 @@ export default defineComponent({
       viewPatients,
       onPatientsUpdated,
       onSaved,
+      chainVisible,
+      chainTarget,
+      onCaretakerCreated,
+      onChainClose,
       onTabChange,
     };
   },

--- a/app-ui/src/views/PatientsView.vue
+++ b/app-ui/src/views/PatientsView.vue
@@ -45,7 +45,16 @@
       :patient="editingPatient"
       @close="modalVisible = false"
       @saved="onSaved"
+      @created="onPatientCreated"
       @created-temp-mrn="onCreatedTempMrn"
+    />
+
+    <!-- WP-27 (F8): a just-created patient has no caretaker — offer to link/create one now -->
+    <CrossAddChainModal
+      :visible="chainVisible"
+      mode="add-caretaker"
+      :target="chainTarget"
+      @close="onChainClose"
     />
 
     <PaymentFormModal
@@ -97,19 +106,23 @@ import PatientList from '../components/patients/PatientList.vue';
 import PatientFormModal from '../components/patients/PatientFormModal.vue';
 import PatientCaretakerPanel from '../components/patients/PatientCaretakerPanel.vue';
 import PaymentFormModal from '../components/payments/PaymentFormModal.vue';
+import CrossAddChainModal, { type ChainTarget } from '../components/shared/CrossAddChainModal.vue';
 import { PatientsHttpClient } from '../services/PatientsHttpClient';
 import type { Patient } from '../interfaces/Patient';
 import { isTemporaryMrn } from '../interfaces/Patient';
+import type { CreatedForChain } from '../interfaces/CrossAdd';
 import type { DelinquentPatient } from '../interfaces/Delinquency';
 import { useFormError } from '../composables/useFormError';
+import { useClaims, Permissions } from '../composables/useClaims';
 
 export default defineComponent({
   name: 'PatientsView',
-  components: { O2MobileNav, O2Sidebar, O2Header, O2Footer, PatientList, PatientFormModal, PatientCaretakerPanel, PaymentFormModal },
+  components: { O2MobileNav, O2Sidebar, O2Header, O2Footer, PatientList, PatientFormModal, PatientCaretakerPanel, PaymentFormModal, CrossAddChainModal },
   setup() {
     const route = useRoute();
     const router = useRouter();
     const client = new PatientsHttpClient();
+    const { hasClaim } = useClaims();
 
     const validTabs = ['all', 'active', 'inactive', 'delinquent', 'sessions'] as const;
     type TabValue = typeof validTabs[number];
@@ -227,6 +240,22 @@ export default defineComponent({
       loadPastDuePatients();
     };
 
+    const chainVisible = ref(false);
+    const chainTarget = ref<ChainTarget | null>(null);
+
+    // WP-27 (F8): every create lands caretaker-less — open the chain when this user holds the
+    // claim the link endpoint enforces (Caretakers.LinkPatient; linking is caretaker-side only).
+    const onPatientCreated = (payload: CreatedForChain<Patient>) => {
+      if (!hasClaim('Permission', Permissions.CaretakersLinkPatient)) return;
+      chainTarget.value = { id: payload.record.patientId, name: payload.record.patientName };
+      chainVisible.value = true;
+    };
+
+    const onChainClose = () => {
+      chainVisible.value = false;
+      loadPatients(); // a caretaker may have been created/linked — refresh booking-readiness
+    };
+
     const onCreatedTempMrn = (patient: Patient) => {
       tempMrnBanner.value = patient.medicalRecordNumber ?? '';
       setTimeout(() => { tempMrnBanner.value = ''; }, 8000);
@@ -256,6 +285,10 @@ export default defineComponent({
       onCaretakersUpdated,
       onSaved,
       onCreatedTempMrn,
+      chainVisible,
+      chainTarget,
+      onPatientCreated,
+      onChainClose,
       onTabChange,
       payFormVisible,
       preSelectedCaretakerId,

--- a/app-ui/test-scenarios/wp-27-cross-add-flows.md
+++ b/app-ui/test-scenarios/wp-27-cross-add-flows.md
@@ -1,0 +1,81 @@
+# WP-27 — Cross-Add Flows (F8 + F9) — User-Facing Test Scenarios
+
+Owner ruling 2026-07-13: **Option A — sequential hand-off** in both directions.
+No API/DB changes; both directions link through `POST /api/caretakers/{id}/patients`.
+
+## Setup
+
+- Log in as **MGR** (or AM/FD — all hold `Caretakers.LinkPatient`, `Caretakers.Edit`, `Patients.Edit`).
+- Have at least one existing caretaker and one existing patient in the system.
+
+## F8 — New patient → caretaker chain
+
+### 1. End-to-end: new patient → create caretaker → immediately bookable (the arc F10 used to block)
+1. Patients → Add Patient → fill all required fields (incl. Cedula | Passport) → Save Patient.
+2. **Expect** the modal closes and a chooser dialog appears: "Patient created — {name}" with the
+   amber nudge *"This patient has no caretaker on file — bookings are blocked until one is linked."*
+3. Click **Create a new caretaker**. **Expect** the Add Caretaker slide-over opens with an amber
+   banner "Will be linked to patient {name}", plus **Relationship to {name}** dropdown and a
+   **Primary caretaker** checkbox (pre-checked).
+4. Fill the caretaker fields, pick Relationship = Mother, Save Caretaker.
+5. **Expect** a success dialog: "{caretaker} created and linked as primary — {patient} is now bookable."
+6. Go to Appointments → book a session for the new patient. **Expect** the caretaker-less booking
+   guard does NOT block (patient has a primary caretaker). The discovery-first rule still applies
+   as usual (default: discovery required).
+
+### 2. Link an existing caretaker instead
+1. Add Patient → Save. In the chooser click **Link an existing caretaker**.
+2. **Expect** a slide-over "Link Caretaker" with the amber "Linking to patient {name}" banner,
+   a caretaker dropdown, Relationship dropdown, and Primary checkbox (pre-checked).
+3. Pick a caretaker + relationship → Link. **Expect** the success dialog; the patient's caretaker
+   panel (Patients → View Caretakers) now lists the caretaker with the Primary badge.
+
+### 3. "Later" escape hatch
+1. Add Patient → Save. In the chooser click **Later**.
+2. **Expect** the dialog closes with no other prompt. The patient has no caretaker; attempting to
+   book them still hard-blocks with the caretaker-required message (F10 guard unchanged).
+
+## F9 — New caretaker → patient chain
+
+### 4. Create a caretaker, then create its patient in the chain
+1. Caretakers → Add Caretaker → fill fields → Save Caretaker.
+2. **Expect** the chooser: "Caretaker created — {name}" with the blue nudge about linking a patient.
+3. Click **Create a new patient**. **Expect** the FULL Add Patient slide-over (Cedula | Passport
+   required, "Requires discovery session" checkbox — WP-25/24 behavior intact) plus the amber
+   "Will be linked to caretaker {name}" banner and relationship/primary fields.
+4. Save. **Expect** success dialog "…created and linked as primary". The caretaker's patient list
+   (Caretakers → View Patients) shows the new patient.
+
+### 5. Link an existing patient
+1. Add Caretaker → Save → chooser → **Link an existing patient** → pick patient + relationship →
+   Link. **Expect** success; the link appears in both panels.
+
+## Claim gating
+
+### 6. Read-only roles see no chain
+1. Log in as **OWN** (read-only oversight) — OWN cannot create patients/caretakers, so the chain
+   never triggers for it. (Component-level: an OWN user shown the chooser would see only "Later";
+   covered by unit test.)
+2. As MGR/AM/FD, verify the chain's Link/Create buttons appear (all three roles hold the claims).
+
+## Failure handling (non-atomic create-then-link)
+
+### 7. Link fails after create
+1. Simulate a link failure (e.g., stop the API between the caretaker save and the link, or link a
+   pair that is already linked via a second browser tab to force a 400).
+2. **Expect** a card: "{Caretaker} was created, but linking failed" with **Retry link** and
+   **Link manually later**. Retry after restoring the API completes the link; "Link manually
+   later" closes the chain — the created record exists and can be linked from its panel.
+
+## Regression checks
+
+### 8. Existing link panels still work (now on the shared form)
+1. Patients → View Caretakers → Add Caretaker: dropdown + relationship + primary → Add works;
+   Cancel closes the form. Same for Caretakers → View Patients → Link Patient.
+2. The panel's link/remove buttons now gate on `Caretakers.LinkPatient` (the claim the API
+   actually enforces) — MGR/AM/FD see no behavior change.
+
+### 9. Edit flows unaffected
+1. Editing an existing patient or caretaker and saving does NOT open the chain (create-only).
+2. Temp-MRN banner still appears when creating a patient with a blank MRN (chain and banner
+   coexist — banner top-right, chooser centered).


### PR DESCRIPTION
… directions

- CrossAddChainModal: post-create chooser (link existing / create new / Later), link slide-over with context banner, success + created-but-link-failed retry states
- PatientFormModal / CaretakerFormModal: linkTo prop (chain create-step banner + relationship/primary fields) and a 'created' emit carrying the created record
- PatientsView (F8) / CaretakersView (F9): open the chain after create when the user holds Caretakers.LinkPatient; reload on chain close
- CaretakerLinkForm extracted (shared by both link panels + the chain)
- Claim hygiene: PatientCaretakerPanel gates on Caretakers.LinkPatient (the claim the API enforces) instead of Patients.LinkCaretaker
- vitest 138 green (12 new in wp27-cross-add-flows.spec.ts); scenarios doc added