### PR TITLE
WP-33C: personalized salutation — first name in the greeting, highest…

### DIFF
--- a/app-ui/src/__tests__/salutation.spec.ts
+++ b/app-ui/src/__tests__/salutation.spec.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createPinia, setActivePinia, type Pinia } from 'pinia';
+import manifest from '../generated/access-control-matrix.json';
+import { useAuthStore } from '../stores/auth';
+import type { ClaimDto } from '../interfaces/Auth';
+import O2Header from '../components/option02/O2Header.vue';
+
+// O2Header calls useRouter() for logout/quick-actions — no real router in component specs.
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+function claimsForRole(role: string): ClaimDto[] {
+  return (manifest.claims as Array<{ claim: string; grants: string[] }>)
+    .filter((c) => c.grants.includes(role))
+    .map((c) => ({ type: 'Permission', value: c.claim }));
+}
+
+// WP-33 variant of the canonical authAs: fullName, roles (plural), and isSystemAdmin are the
+// inputs under test, so they're parameters here.
+function authWith(options: {
+  fullName?: string;
+  roles?: string[];
+  isSystemAdmin?: boolean;
+}): Pinia {
+  const pinia = createPinia();
+  setActivePinia(pinia);
+  const store = useAuthStore();
+  store.user = {
+    userId: 1,
+    email: 'test@example.com',
+    fullName: options.fullName ?? 'Velarde, Anibal',
+    mustChangePassword: false,
+    roles: options.roles ?? ['FD'],
+    claims: (options.roles ?? ['FD']).flatMap(claimsForRole),
+    isSystemAdmin: options.isSystemAdmin ?? false,
+  };
+  return pinia;
+}
+
+function mountHeader(options: Parameters<typeof authWith>[0]) {
+  return mount(O2Header, { global: { plugins: [authWith(options)] } });
+}
+
+function salutationName(wrapper: ReturnType<typeof mountHeader>) {
+  return wrapper.find('[data-testid="salutation-name"]').text();
+}
+
+function salutationRole(wrapper: ReturnType<typeof mountHeader>) {
+  return wrapper.find('[data-testid="salutation-role"]').text();
+}
+
+describe('O2Header salutation (WP-33)', () => {
+  // ── first name parse: auth.fullName is "LastName, FirstName Middle" ──────────
+  it('greets with the token after the comma', () => {
+    const wrapper = mountHeader({ fullName: 'Velarde, Anibal' });
+    expect(salutationName(wrapper)).toBe('Anibal');
+  });
+
+  it('drops a middle name from the greeting', () => {
+    const wrapper = mountHeader({ fullName: 'Gomez, Ana Maria' });
+    expect(salutationName(wrapper)).toBe('Ana');
+  });
+
+  it('falls back to the first token when there is no comma', () => {
+    const wrapper = mountHeader({ fullName: 'Anibal Velarde' });
+    expect(salutationName(wrapper)).toBe('Anibal');
+  });
+
+  it('never renders an empty greeting name', () => {
+    const wrapper = mountHeader({ fullName: '' });
+    expect(salutationName(wrapper)).toBe('there');
+  });
+
+  // ── role label: highest role, fixed precedence, standard labels ──────────────
+  it('shows Front Desk for an FD user, before the date', () => {
+    const wrapper = mountHeader({ roles: ['FD'] });
+    expect(salutationRole(wrapper)).toBe('Front Desk');
+    expect(wrapper.find('p.text-xs').text()).toMatch(/^Front Desk · /);
+  });
+
+  it('shows only the highest role for a multi-role user (MGR outranks FD)', () => {
+    const wrapper = mountHeader({ roles: ['FD', 'MGR'] });
+    expect(salutationRole(wrapper)).toBe('Manager');
+  });
+
+  it('OWN outranks MGR', () => {
+    const wrapper = mountHeader({ roles: ['MGR', 'OWN'] });
+    expect(salutationRole(wrapper)).toBe('Owner');
+  });
+
+  it.each([
+    ['AM', 'Assistant Manager'],
+    ['ACCT', 'Accountant'],
+  ])('labels %s as %s', (role, label) => {
+    const wrapper = mountHeader({ roles: [role] });
+    expect(salutationRole(wrapper)).toBe(label);
+  });
+
+  it('System Administrator outranks everything, even with roles present', () => {
+    const wrapper = mountHeader({ roles: ['OWN', 'MGR'], isSystemAdmin: true });
+    expect(salutationRole(wrapper)).toBe('System Administrator');
+  });
+
+  it('shows a raw unknown role code rather than blank', () => {
+    const wrapper = mountHeader({ roles: ['XYZ'] });
+    expect(salutationRole(wrapper)).toBe('XYZ');
+  });
+
+  it('omits the role segment (and separator) entirely when there is no role at all', () => {
+    const wrapper = mountHeader({ roles: [] });
+    expect(wrapper.find('[data-testid="salutation-role"]').exists()).toBe(false);
+    expect(wrapper.find('p.text-xs').text()).not.toContain('·');
+  });
+});

--- a/app-ui/src/components/option02/O2Header.vue
+++ b/app-ui/src/components/option02/O2Header.vue
@@ -3,9 +3,11 @@
     <!-- Left: Greeting -->
     <div>
       <h1 class="text-lg font-semibold text-gray-800">
-        {{ greeting }}, <span class="text-violet-600">Front Desk</span>
+        {{ greeting }}, <span class="text-violet-600" data-testid="salutation-name">{{ firstName }}</span>
       </h1>
-      <p class="text-xs text-gray-400">{{ todayFormatted }}</p>
+      <p class="text-xs text-gray-400 truncate">
+        <template v-if="roleLabel"><span data-testid="salutation-role">{{ roleLabel }}</span> · </template>{{ todayFormatted }}
+      </p>
     </div>
 
     <!-- Right: Actions + Avatar -->
@@ -116,6 +118,31 @@ export default defineComponent({
       return (letters[0] ?? '') + (letters[1] ?? '') || '?';
     });
 
+    // WP-33: auth.fullName is "LastName, FirstName Middle" (API GetFullName()) — the first
+    // name is the token after the comma; comma-less values fall back to their first token.
+    const firstName = computed(() => {
+      const name = auth.fullName.trim();
+      const afterComma = name.includes(',') ? name.split(',')[1] : name;
+      return afterComma.trim().split(/\s+/)[0] || name || 'there';
+    });
+
+    // WP-33 (owner rulings 2026-07-11/15): highest role only, fixed precedence, hard-coded
+    // standard labels — labels are a UI concern (DB RoleName sourcing explicitly declined).
+    const ROLE_PRECEDENCE = ['OWN', 'MGR', 'AM', 'ACCT', 'FD'];
+    const ROLE_LABELS: Record<string, string> = {
+      OWN: 'Owner',
+      MGR: 'Manager',
+      AM: 'Assistant Manager',
+      ACCT: 'Accountant',
+      FD: 'Front Desk',
+    };
+    const roleLabel = computed(() => {
+      if (auth.isSystemAdmin) return 'System Administrator';
+      const roles = auth.roles;
+      const top = ROLE_PRECEDENCE.find((r) => roles.includes(r)) ?? roles[0];
+      return top ? (ROLE_LABELS[top] ?? top) : '';
+    });
+
     const onLogout = () => {
       auth.logout();
       router.push({ name: 'login' });
@@ -134,7 +161,7 @@ export default defineComponent({
       }
     };
 
-    return { greeting, todayFormatted, quickActions, handleAction, fullName, initials, onLogout };
+    return { greeting, todayFormatted, quickActions, handleAction, fullName, initials, firstName, roleLabel, onLogout };
   },
 });
 </script>

--- a/app-ui/test-scenarios/wp-33-personalized-salutation.md
+++ b/app-ui/test-scenarios/wp-33-personalized-salutation.md
@@ -1,0 +1,34 @@
+# WP-33 — Personalized Salutation: Owner Walkthrough
+
+UI-only change to the header greeting (renders on every page, not just the dashboard).
+No API deploy, no re-login required — name and roles already come from `/auth/me`.
+
+## Scenario 1 — Front Desk user
+
+1. Log in as an FD user (e.g. the front-desk account).
+2. **Expect line 1:** "Good morning/afternoon/evening, **<FirstName>**" — first name only
+   (no last name, no middle name), in the violet accent where "Front Desk" used to be.
+3. **Expect line 2 (small gray text):** `Front Desk · <Weekday, Month D, YYYY>`.
+
+## Scenario 2 — Multi-role user shows only the highest role
+
+1. Log in as a user holding more than one role (e.g. MGR + FD).
+2. **Expect:** the small line shows `Manager · <date>` — the higher role wins.
+   Precedence: System Administrator > Owner > Manager > Assistant Manager > Accountant > Front Desk.
+
+## Scenario 3 — System Administrator
+
+1. Log in as the SA account.
+2. **Expect:** `System Administrator · <date>` — regardless of any other roles held.
+
+## Scenario 4 — Everywhere, and on mobile
+
+1. Navigate Patients → Payments → Admin: the personalized greeting follows on every page.
+2. Narrow the window to phone width: the role+date line **truncates with "…"** rather than
+   wrapping the header taller (header stays two lines / same height).
+
+## Notes
+
+- Labels are the standard set (owner ruling 2026-07-15): Front Desk, Manager,
+  Assistant Manager, Owner, Accountant, System Administrator.
+- A role code the UI doesn't recognize shows as its raw code (never a blank line).


### PR DESCRIPTION
…-role label on the 'Role · Date' line

Rulings 2026-07-11/15: first name only (comma-aware parse of 'Last, First Middle'); highest role by fixed precedence SYSADMIN > OWN > MGR > AM > ACCT
> FD; standard labels hard-coded in the component (DB RoleName sourcing
declined - UI-only). Unknown code shows raw; no-role hides the separator. vitest 155 -> 167 green; vue-tsc + lint clean. UI-only: CI deploys on merge, no API deploy, no re-login. Walkthrough:
app-ui/test-scenarios/wp-33-personalized-salutation.md