### PR TITLE
WP-32C (U4): idle auto-logoff UI — warning countdown + Admin Sites se…

### DIFF
--- a/app-ui/docs/testing-guide.md
+++ b/app-ui/docs/testing-guide.md
@@ -197,6 +197,30 @@ await wrapper.find('[data-testid="link-entity-option"]').trigger('mousedown'); /
   not `getPatients`/`getCaretakers` — those now return the `PagedResult` envelope and pickers
   no longer call them.
 
+## Idle auto-logoff (WP-32) — fake timers + wall-clock idle
+
+`useIdleLogoff` (armed at the app root in `App.vue`) doesn't count ticks — it compares
+`Date.now()` against a `pc_last_activity` timestamp in localStorage. vitest fake timers mock
+**Date too**, so `vi.advanceTimersByTimeAsync(ms)` moves the interval AND the clock together and
+the timestamp math stays honest. Drive it by mounting a tiny host that returns the composable:
+
+```ts
+const Host = defineComponent({ setup: () => useIdleLogoff(), template: '<div/>' });
+// mount with a real memory router (logout does router.push('login')) + a pinia whose auth.user
+// carries idleLogoffMinutes. Use a REAL router, not a mock — matches login-view.spec.ts.
+```
+
+- `beforeEach`: `localStorage.clear()` then `vi.useFakeTimers()`; `afterEach`: `vi.useRealTimers()`.
+- Use the **`*Async`** timer helpers (`advanceTimersByTimeAsync`) so the `router.push()` inside
+  logout resolves between ticks; follow the final advance with `await flushPromises()`.
+- Warning shows at `N·60_000 − 60_000` ms of idle; expiry at `N·60_000`. The background poll is
+  30s, so advance in 30s steps to land on a poll boundary when asserting the warning appears.
+- Simulate **another tab** by writing `localStorage.setItem('pc_last_activity', String(Date.now()))`
+  — the next 1s countdown tick re-reads it and dismisses the warning. Simulate **same-tab
+  activity** with `window.dispatchEvent(new Event('keydown'))` (ignored once the warning is up —
+  by design, only the buttons/another tab reset it then).
+- `0` minutes = disabled: the composable never arms, so no warning/logout no matter how far you advance.
+
 ## Known gotchas (append as discovered)
 
 | Date | Gotcha | Spec that documents it |
@@ -205,3 +229,4 @@ await wrapper.find('[data-testid="link-entity-option"]').trigger('mousedown'); /
 | 2026-07-12 | `vi.clearAllMocks()` in `beforeEach` wipes `mockResolvedValue` seeds — re-seed after clearing | (pattern in `wp23`/`wp24` specs) |
 | 2026-07-14 | `LookupSelect` needs focus→type→advance(300)→flush→**mousedown** (see section above); a `.setValue` alone never opens the list | `wp30-list-paging.spec.ts` |
 | 2026-07-14 | An aborted test can leave a `mockRejectedValueOnce` unconsumed — `vi.clearAllMocks()` does NOT drop once-queues, so a later test eats the stale rejection | (bitten during WP-30 in `wp27-cross-add-flows.spec.ts`) |
+| 2026-07-15 | Idle logoff computes idle from a localStorage wall-clock timestamp, not tick counting — fake timers mock Date so `advanceTimersByTimeAsync` moves both; use `*Async` helpers so logout's `router.push` resolves | `wp32-idle-logoff.spec.ts` |

--- a/app-ui/src/App.vue
+++ b/app-ui/src/App.vue
@@ -1,14 +1,28 @@
 <template>
   <router-view />
   <GlobalErrorToast />
+  <IdleWarningModal
+    :visible="warningVisible"
+    :seconds-remaining="secondsRemaining"
+    @stay="stayActive"
+    @signout="signOutNow"
+  />
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue';
 import GlobalErrorToast from './components/shared/GlobalErrorToast.vue';
+import IdleWarningModal from './components/shared/IdleWarningModal.vue';
+import { useIdleLogoff } from './composables/useIdleLogoff';
 
 export default defineComponent({
   name: 'App',
-  components: { GlobalErrorToast },
+  components: { GlobalErrorToast, IdleWarningModal },
+  setup() {
+    // WP-32 (U4): arm the idle auto-logoff watcher at the app root. It self-disarms whenever the
+    // user isn't authenticated or the site's timeout is 0, so it's safe to mount unconditionally.
+    const { warningVisible, secondsRemaining, stayActive, signOutNow } = useIdleLogoff();
+    return { warningVisible, secondsRemaining, stayActive, signOutNow };
+  },
 });
 </script>

--- a/app-ui/src/__tests__/wp32-idle-logoff.spec.ts
+++ b/app-ui/src/__tests__/wp32-idle-logoff.spec.ts
@@ -1,0 +1,295 @@
+// WP-32 (U4) — idle auto-logoff: composable timing, warning modal, and the Sites setting field.
+//
+// Fake-timers note (see testing-guide.md "Idle auto-logoff"): idle is computed from a wall-clock
+// timestamp in localStorage, and vitest's fake timers mock Date too — so advancing timers advances
+// both the interval ticks AND Date.now(), and the timestamp math stays consistent. Use the *Async
+// timer helpers so the router.push() inside logout resolves between ticks.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { createPinia, setActivePinia, type Pinia } from 'pinia';
+import { createRouter, createMemoryHistory, type Router } from 'vue-router';
+import { defineComponent } from 'vue';
+import { useAuthStore } from '../stores/auth';
+import { useNotificationsStore } from '../stores/notifications';
+import { useIdleLogoff } from '../composables/useIdleLogoff';
+import IdleWarningModal from '../components/shared/IdleWarningModal.vue';
+import SiteFormModal from '../components/sites/SiteFormModal.vue';
+import type { Site } from '../interfaces/Site';
+
+// ---- SitesHttpClient mock (for the SiteFormModal block) -------------------------------------
+const { updateSiteMock, createSiteMock } = vi.hoisted(() => ({
+  updateSiteMock: vi.fn(),
+  createSiteMock: vi.fn(),
+}));
+vi.mock('../services/SitesHttpClient', () => ({
+  SitesHttpClient: vi.fn().mockImplementation(() => ({
+    updateSite: updateSiteMock,
+    createSite: createSiteMock,
+  })),
+}));
+
+// ============================================================================================
+// useIdleLogoff — timing behavior
+// ============================================================================================
+
+const Host = defineComponent({
+  name: 'IdleHost',
+  setup() {
+    return useIdleLogoff();
+  },
+  template: '<div />',
+});
+
+interface IdleHostVm {
+  warningVisible: boolean;
+  secondsRemaining: number;
+  stayActive: () => void;
+  signOutNow: () => void;
+}
+
+function makeRouter(): Router {
+  return createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: '/', name: 'dashboard', component: { template: '<div/>' } },
+      { path: '/login', name: 'login', component: { template: '<div/>' } },
+    ],
+  });
+}
+
+function authPinia(idleLogoffMinutes: number): Pinia {
+  const pinia = createPinia();
+  setActivePinia(pinia);
+  const store = useAuthStore();
+  store.accessToken = 'test-token';
+  store.user = {
+    userId: 1,
+    email: 'test@example.com',
+    fullName: 'Test User',
+    mustChangePassword: false,
+    roles: ['MGR'],
+    claims: [],
+    isSystemAdmin: false,
+    idleLogoffMinutes,
+  };
+  return pinia;
+}
+
+async function mountIdle(minutes: number) {
+  const pinia = authPinia(minutes);
+  const router = makeRouter();
+  router.push('/');
+  await router.isReady();
+  const wrapper = mount(Host, { global: { plugins: [pinia, router] } });
+  return {
+    wrapper,
+    router,
+    auth: useAuthStore(),
+    notifications: useNotificationsStore(),
+    vm: wrapper.vm as unknown as IdleHostVm,
+  };
+}
+
+describe('useIdleLogoff', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('shows the warning 60s before expiry, not before', async () => {
+    const { wrapper, vm } = await mountIdle(2); // 120s expiry, warn at 60s idle
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(vm.warningVisible).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(30_000); // now at 60s idle
+    expect(vm.warningVisible).toBe(true);
+    expect(vm.secondsRemaining).toBe(60);
+
+    wrapper.unmount();
+  });
+
+  it('logs the user out at expiry with an inactivity notice', async () => {
+    const { wrapper, auth, router, notifications } = await mountIdle(2);
+
+    await vi.advanceTimersByTimeAsync(120_000);
+    await flushPromises();
+
+    expect(auth.isAuthenticated).toBe(false);
+    expect(router.currentRoute.value.name).toBe('login');
+    expect(notifications.items.some((n) => n.kind === 'error' && /inactivity/i.test(n.message))).toBe(true);
+
+    wrapper.unmount();
+  });
+
+  it('"I\'m still here" resets the clock and prevents the logout', async () => {
+    const { wrapper, vm, auth } = await mountIdle(2);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(vm.warningVisible).toBe(true);
+
+    vm.stayActive();
+    await flushPromises();
+    expect(vm.warningVisible).toBe(false);
+
+    // 59s more: still short of a fresh 60s idle window — no warning, still signed in.
+    await vi.advanceTimersByTimeAsync(59_000);
+    expect(vm.warningVisible).toBe(false);
+    expect(auth.isAuthenticated).toBe(true);
+
+    wrapper.unmount();
+  });
+
+  it('"Sign out now" logs out immediately without an inactivity toast', async () => {
+    const { wrapper, vm, auth, router, notifications } = await mountIdle(2);
+
+    vm.signOutNow();
+    await flushPromises();
+
+    expect(auth.isAuthenticated).toBe(false);
+    expect(router.currentRoute.value.name).toBe('login');
+    expect(notifications.items.some((n) => /inactivity/i.test(n.message))).toBe(false);
+
+    wrapper.unmount();
+  });
+
+  it('user activity resets the idle clock (delays the warning)', async () => {
+    const { wrapper, vm } = await mountIdle(2);
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    window.dispatchEvent(new Event('keydown')); // activity at 30s resets lastActivity
+
+    await vi.advanceTimersByTimeAsync(30_000); // 60s absolute, but only 30s idle
+    expect(vm.warningVisible).toBe(false);
+
+    wrapper.unmount();
+  });
+
+  it('activity in another tab (localStorage) dismisses the warning', async () => {
+    const { wrapper, vm, auth } = await mountIdle(2);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(vm.warningVisible).toBe(true);
+
+    // Simulate a second tab recording activity: bump the shared timestamp to "now".
+    localStorage.setItem('pc_last_activity', String(Date.now()));
+
+    await vi.advanceTimersByTimeAsync(1_000); // next countdown tick re-reads localStorage
+    expect(vm.warningVisible).toBe(false);
+    expect(auth.isAuthenticated).toBe(true);
+
+    wrapper.unmount();
+  });
+
+  it('0 minutes disables the feature — never warns or logs out', async () => {
+    const { wrapper, vm, auth } = await mountIdle(0);
+
+    await vi.advanceTimersByTimeAsync(600_000); // 10 minutes
+    expect(vm.warningVisible).toBe(false);
+    expect(auth.isAuthenticated).toBe(true);
+
+    wrapper.unmount();
+  });
+});
+
+// ============================================================================================
+// IdleWarningModal — presentation
+// ============================================================================================
+
+describe('IdleWarningModal', () => {
+  it('renders the countdown and both buttons when visible', () => {
+    const wrapper = mount(IdleWarningModal, {
+      props: { visible: true, secondsRemaining: 42 },
+      global: { stubs: { teleport: true } },
+    });
+    expect(wrapper.find('[data-testid="idle-warning-modal"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="idle-countdown"]').text()).toBe('42');
+    expect(wrapper.find('[data-testid="idle-stay-button"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="idle-signout-button"]').exists()).toBe(true);
+  });
+
+  it('renders nothing when not visible', () => {
+    const wrapper = mount(IdleWarningModal, {
+      props: { visible: false, secondsRemaining: 10 },
+      global: { stubs: { teleport: true } },
+    });
+    expect(wrapper.find('[data-testid="idle-warning-modal"]').exists()).toBe(false);
+  });
+
+  it('emits stay / signout on the respective buttons', async () => {
+    const wrapper = mount(IdleWarningModal, {
+      props: { visible: true, secondsRemaining: 30 },
+      global: { stubs: { teleport: true } },
+    });
+    await wrapper.find('[data-testid="idle-stay-button"]').trigger('click');
+    await wrapper.find('[data-testid="idle-signout-button"]').trigger('click');
+    expect(wrapper.emitted('stay')).toHaveLength(1);
+    expect(wrapper.emitted('signout')).toHaveLength(1);
+  });
+});
+
+// ============================================================================================
+// SiteFormModal — the admin setting field
+// ============================================================================================
+
+function site(overrides: Partial<Site> = {}): Site {
+  return {
+    siteId: 1,
+    siteName: 'Main Clinic',
+    ruc: '123',
+    inceptionDate: '2020-01-15',
+    address: 'Somewhere',
+    latitude: null,
+    longitude: null,
+    idleLogoffMinutes: 60,
+    ...overrides,
+  };
+}
+
+describe('SiteFormModal idle-logoff field', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    updateSiteMock.mockResolvedValue(undefined);
+    createSiteMock.mockResolvedValue(site());
+  });
+
+  async function openEdit(s: Site) {
+    const wrapper = mount(SiteFormModal, {
+      props: { visible: false, site: s },
+      global: { stubs: { teleport: true } },
+    });
+    await wrapper.setProps({ visible: true });
+    await flushPromises();
+    return wrapper;
+  }
+
+  it('populates the idle input from the site on edit', async () => {
+    const wrapper = await openEdit(site({ idleLogoffMinutes: 15 }));
+    const input = wrapper.find('[data-testid="site-idle-logoff-input"]');
+    expect((input.element as HTMLInputElement).value).toBe('15');
+  });
+
+  it('sends idleLogoffMinutes in the update payload', async () => {
+    const wrapper = await openEdit(site({ idleLogoffMinutes: 60 }));
+    await wrapper.find('[data-testid="site-idle-logoff-input"]').setValue(30);
+    await wrapper.find('form').trigger('submit');
+    await flushPromises();
+
+    expect(updateSiteMock).toHaveBeenCalledTimes(1);
+    expect(updateSiteMock.mock.calls[0][1]).toMatchObject({ idleLogoffMinutes: 30 });
+  });
+
+  it('rejects an out-of-range value client-side (no API call)', async () => {
+    const wrapper = await openEdit(site());
+    await wrapper.find('[data-testid="site-idle-logoff-input"]').setValue(500);
+    await wrapper.find('form').trigger('submit');
+    await flushPromises();
+
+    expect(updateSiteMock).not.toHaveBeenCalled();
+    expect(wrapper.text()).toContain('between 0 and 480');
+  });
+});

--- a/app-ui/src/components/shared/IdleWarningModal.vue
+++ b/app-ui/src/components/shared/IdleWarningModal.vue
@@ -1,0 +1,76 @@
+<template>
+  <teleport to="body">
+    <div
+      v-if="visible"
+      class="fixed inset-0 z-[60] flex items-center justify-center p-4"
+      role="alertdialog"
+      aria-modal="true"
+      aria-labelledby="idle-warning-title"
+    >
+      <!-- Backdrop (no click-to-dismiss: the choice must be explicit) -->
+      <div class="absolute inset-0 bg-black/40"></div>
+
+      <!-- Card -->
+      <div
+        data-testid="idle-warning-modal"
+        class="relative w-full max-w-sm rounded-xl bg-white shadow-2xl p-6 text-center"
+      >
+        <div class="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-amber-100">
+          <svg class="h-6 w-6 text-amber-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M12 8v4m0 4h.01M12 3a9 9 0 100 18 9 9 0 000-18z"
+            />
+          </svg>
+        </div>
+
+        <h2 id="idle-warning-title" class="text-lg font-semibold text-slate-800">
+          Still there?
+        </h2>
+        <p class="mt-2 text-sm text-slate-600">
+          You'll be signed out in
+          <span data-testid="idle-countdown" class="font-semibold text-slate-900">
+            {{ secondsRemaining }}
+          </span>
+          second<span v-if="secondsRemaining !== 1">s</span> due to inactivity.
+        </p>
+
+        <div class="mt-6 flex items-center justify-center gap-3">
+          <button
+            type="button"
+            data-testid="idle-signout-button"
+            class="px-4 py-2 rounded-lg text-sm font-medium text-slate-700 bg-white border border-slate-300 hover:bg-slate-50"
+            @click="$emit('signout')"
+          >
+            Sign out now
+          </button>
+          <button
+            type="button"
+            data-testid="idle-stay-button"
+            class="px-4 py-2 rounded-lg text-sm font-medium text-white bg-blue-600 hover:bg-blue-700"
+            @click="$emit('stay')"
+          >
+            I'm still here
+          </button>
+        </div>
+      </div>
+    </div>
+  </teleport>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+
+// WP-32 (U4): the idle-logoff countdown. State/timing lives in useIdleLogoff; this component is
+// purely presentational — it renders the remaining seconds and emits the user's choice.
+export default defineComponent({
+  name: 'IdleWarningModal',
+  props: {
+    visible: { type: Boolean, required: true },
+    secondsRemaining: { type: Number, default: 0 },
+  },
+  emits: ['stay', 'signout'],
+});
+</script>

--- a/app-ui/src/components/sites/SiteFormModal.vue
+++ b/app-ui/src/components/sites/SiteFormModal.vue
@@ -86,6 +86,23 @@
             </div>
           </div>
 
+          <div>
+            <label class="block text-sm font-medium text-slate-700 mb-1">Idle auto-logoff (minutes)</label>
+            <input
+              v-model.number="form.idleLogoffMinutes"
+              type="number"
+              min="0"
+              max="480"
+              step="1"
+              data-testid="site-idle-logoff-input"
+              class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            />
+            <p class="mt-1 text-xs text-slate-500">
+              Sign users out after this many minutes of inactivity (a 60-second warning shows first).
+              <span class="font-medium">0 = disabled.</span>
+            </p>
+          </div>
+
         </form>
 
         <!-- Footer -->
@@ -150,6 +167,7 @@ export default defineComponent({
       address: '',
       latitude: null as number | null,
       longitude: null as number | null,
+      idleLogoffMinutes: 60,
     });
 
     const isEdit = ref(false);
@@ -169,6 +187,7 @@ export default defineComponent({
           form.address = props.site.address || '';
           form.latitude = props.site.latitude;
           form.longitude = props.site.longitude;
+          form.idleLogoffMinutes = props.site.idleLogoffMinutes ?? 60;
         } else {
           isEdit.value = false;
           form.siteName = '';
@@ -177,6 +196,7 @@ export default defineComponent({
           form.address = '';
           form.latitude = null;
           form.longitude = null;
+          form.idleLogoffMinutes = 60;
         }
       }
     );
@@ -184,6 +204,11 @@ export default defineComponent({
     const handleSubmit = () => {
       if (!form.siteName || !form.inceptionDate) {
         setError('Please fill in all required fields.');
+        return;
+      }
+      const idle = form.idleLogoffMinutes;
+      if (!Number.isInteger(idle) || idle < 0 || idle > 480) {
+        setError('Idle auto-logoff must be a whole number between 0 and 480 minutes.');
         return;
       }
       return submit(async () => {
@@ -194,6 +219,7 @@ export default defineComponent({
           address: form.address || undefined,
           latitude: form.latitude ?? undefined,
           longitude: form.longitude ?? undefined,
+          idleLogoffMinutes: form.idleLogoffMinutes,
         };
 
         if (isEdit.value && props.site) {

--- a/app-ui/src/composables/useIdleLogoff.ts
+++ b/app-ui/src/composables/useIdleLogoff.ts
@@ -1,0 +1,223 @@
+// composables/useIdleLogoff.ts
+//
+// WP-32 (U4): client-side idle auto-logoff. After N minutes without user activity we show a
+// 60-second warning countdown, then log the user out locally and send them to the login screen.
+// N comes from /auth/me (`idleLogoffMinutes`, a Site attribute); 0 disables the feature entirely.
+//
+// This is UX hygiene, NOT token security — the access token is not invalidated server-side
+// (documented limitation; server-enforced idle expiry is a follow-up). We deliberately mirror the
+// authBridge session-expiry landing (auth.logout() -> router push 'login' -> notification) rather
+// than call authBridge.notifyUnauthorized(), because that path hard-codes the "session expired"
+// copy and we want the "inactivity" variant.
+//
+// Correctness under tab-sleep: idle is computed from a wall-clock timestamp in localStorage
+// (`pc_last_activity`), not by counting ticks — so throttled/slept timers still resolve correctly
+// when they next fire. That same shared key makes it multi-tab aware: activity in ANY tab keeps
+// all tabs alive, and a logout in one tab cascades (refresh token cleared -> other tabs die on
+// their next 401/refresh).
+
+import { computed, onScopeDispose, ref, watch, type Ref } from 'vue';
+import { useRouter } from 'vue-router';
+import { storeToRefs } from 'pinia';
+import { useAuthStore } from '../stores/auth';
+import { useNotificationsStore } from '../stores/notifications';
+
+const LAST_ACTIVITY_KEY = 'pc_last_activity';
+const POLL_INTERVAL_MS = 30_000; // background idle poll — coarse on purpose (survives tab sleep)
+const COUNTDOWN_INTERVAL_MS = 1_000; // fine-grained ticker, only runs while the warning shows
+const WARNING_LEAD_MS = 60_000; // show the warning this long before expiry
+const ACTIVITY_THROTTLE_MS = 5_000; // don't rewrite localStorage on every pointermove
+const ACTIVITY_EVENTS = ['keydown', 'pointerdown', 'pointermove', 'touchstart', 'scroll'] as const;
+
+export interface IdleLogoffController {
+  /** Whether the warning countdown modal should be shown. */
+  warningVisible: Ref<boolean>;
+  /** Seconds left before automatic logout while the warning is visible. */
+  secondsRemaining: Ref<number>;
+  /** "I'm still here" — resets the idle clock and dismisses the warning. */
+  stayActive: () => void;
+  /** "Sign out now" — logs out immediately (no inactivity toast; the user chose this). */
+  signOutNow: () => void;
+}
+
+export function useIdleLogoff(): IdleLogoffController {
+  const router = useRouter();
+  const auth = useAuthStore();
+  const notifications = useNotificationsStore();
+  const { isAuthenticated, idleLogoffMinutes } = storeToRefs(auth);
+
+  const warningVisible = ref(false);
+  const secondsRemaining = ref(0);
+
+  const expiryMs = computed(() => idleLogoffMinutes.value * 60_000);
+
+  let armed = false;
+  let loggingOut = false;
+  let pollId: ReturnType<typeof setInterval> | undefined;
+  let countdownId: ReturnType<typeof setInterval> | undefined;
+  let lastWrite = 0;
+
+  function now(): number {
+    return Date.now();
+  }
+
+  function writeActivity(ts: number): void {
+    try {
+      localStorage.setItem(LAST_ACTIVITY_KEY, String(ts));
+    } catch {
+      // localStorage can throw in private mode; degrade to same-tab-only via a fallback below.
+    }
+  }
+
+  function idleMs(): number {
+    let last: number;
+    try {
+      const raw = localStorage.getItem(LAST_ACTIVITY_KEY);
+      last = raw ? Number(raw) : now();
+    } catch {
+      last = now();
+    }
+    if (!Number.isFinite(last)) return 0;
+    return now() - last;
+  }
+
+  function recordActivity(): void {
+    // While the warning is up, only the explicit buttons (or another tab) reset the clock —
+    // passive movement in THIS tab must not silently cancel the countdown.
+    if (warningVisible.value) return;
+    const ts = now();
+    if (ts - lastWrite < ACTIVITY_THROTTLE_MS) return;
+    lastWrite = ts;
+    writeActivity(ts);
+  }
+
+  function onVisibility(): void {
+    if (typeof document !== 'undefined' && document.visibilityState === 'visible') {
+      recordActivity();
+    }
+  }
+
+  function attachListeners(): void {
+    ACTIVITY_EVENTS.forEach((e) => window.addEventListener(e, recordActivity, { passive: true }));
+    if (typeof document !== 'undefined') {
+      document.addEventListener('visibilitychange', onVisibility);
+    }
+  }
+
+  function detachListeners(): void {
+    ACTIVITY_EVENTS.forEach((e) => window.removeEventListener(e, recordActivity));
+    if (typeof document !== 'undefined') {
+      document.removeEventListener('visibilitychange', onVisibility);
+    }
+  }
+
+  function stopCountdown(): void {
+    if (countdownId !== undefined) {
+      clearInterval(countdownId);
+      countdownId = undefined;
+    }
+  }
+
+  function hideWarning(): void {
+    warningVisible.value = false;
+    stopCountdown();
+  }
+
+  function showWarning(): void {
+    warningVisible.value = true;
+    tickCountdown(); // seed secondsRemaining immediately so the modal opens with a real number
+    if (countdownId === undefined) {
+      countdownId = setInterval(tickCountdown, COUNTDOWN_INTERVAL_MS);
+    }
+  }
+
+  // Runs once per second while the warning is visible: refreshes the countdown, dismisses if
+  // activity (possibly from another tab) pushed us back out of the window, and fires the logout
+  // when the clock runs out.
+  function tickCountdown(): void {
+    const remaining = expiryMs.value - idleMs();
+    if (remaining <= 0) {
+      expireLogout();
+      return;
+    }
+    if (idleMs() < expiryMs.value - WARNING_LEAD_MS) {
+      hideWarning();
+      return;
+    }
+    secondsRemaining.value = Math.ceil(remaining / 1000);
+  }
+
+  // Coarse background poll: decides whether we're inside the warning window yet.
+  function poll(): void {
+    const idle = idleMs();
+    if (idle >= expiryMs.value) {
+      expireLogout();
+    } else if (idle >= expiryMs.value - WARNING_LEAD_MS) {
+      if (!warningVisible.value) showWarning();
+    } else if (warningVisible.value) {
+      hideWarning();
+    }
+  }
+
+  function performLogout(reason?: string): void {
+    if (loggingOut) return;
+    loggingOut = true;
+    disarm();
+    auth.logout();
+    if (router.currentRoute.value.name !== 'login') {
+      // Fresh login on idle — no redirect query; the user stepped away.
+      void router.push({ name: 'login' });
+    }
+    if (reason) notifications.error(reason);
+  }
+
+  function expireLogout(): void {
+    const mins = idleLogoffMinutes.value;
+    performLogout(`Signed out after ${mins} minute${mins === 1 ? '' : 's'} of inactivity.`);
+  }
+
+  function stayActive(): void {
+    lastWrite = now();
+    writeActivity(lastWrite);
+    hideWarning();
+  }
+
+  function signOutNow(): void {
+    performLogout(); // no toast — the user clicked "Sign out now"
+  }
+
+  function arm(): void {
+    if (armed) return;
+    armed = true;
+    loggingOut = false;
+    lastWrite = now();
+    writeActivity(lastWrite); // seed so a just-logged-in user isn't instantly "idle"
+    attachListeners();
+    pollId = setInterval(poll, POLL_INTERVAL_MS);
+  }
+
+  function disarm(): void {
+    if (!armed) return;
+    armed = false;
+    detachListeners();
+    if (pollId !== undefined) {
+      clearInterval(pollId);
+      pollId = undefined;
+    }
+    hideWarning();
+  }
+
+  // Arm only while authenticated with a positive timeout; 0 (or logout) disarms cleanly.
+  watch(
+    [isAuthenticated, idleLogoffMinutes],
+    ([authed, mins]) => {
+      if (authed && mins > 0) arm();
+      else disarm();
+    },
+    { immediate: true }
+  );
+
+  onScopeDispose(disarm);
+
+  return { warningVisible, secondsRemaining, stayActive, signOutNow };
+}

--- a/app-ui/src/interfaces/Auth.ts
+++ b/app-ui/src/interfaces/Auth.ts
@@ -41,4 +41,10 @@ export interface CurrentUserResponse {
   roles: string[];
   claims: ClaimDto[];
   isSystemAdmin: boolean;
+  /**
+   * WP-32 (U4): idle auto-logoff in minutes; 0 = disabled. The API always sends it (sourced from
+   * the Site row, 60 fallback), but it's optional here so pre-existing test fixtures that build a
+   * user literal stay valid; consumers default to 60.
+   */
+  idleLogoffMinutes?: number;
 }

--- a/app-ui/src/interfaces/Site.ts
+++ b/app-ui/src/interfaces/Site.ts
@@ -9,6 +9,7 @@ export interface Site {
   address: string | null;
   latitude: number | null;
   longitude: number | null;
+  idleLogoffMinutes: number; // WP-32 (U4): idle auto-logoff minutes; 0 = disabled
 }
 
 // Maps to API's SiteProfileRequest (POST)
@@ -19,6 +20,7 @@ export interface SiteCreateRequest {
   address?: string;
   latitude?: number;
   longitude?: number;
+  idleLogoffMinutes?: number; // optional; API defaults to 60
 }
 
 // Maps to API's SiteProfileUpdateRequest (PUT)
@@ -29,4 +31,5 @@ export interface SiteUpdateRequest {
   address?: string;
   latitude?: number;
   longitude?: number;
+  idleLogoffMinutes?: number; // null/omitted = unchanged; API clamps 0-480
 }

--- a/app-ui/src/stores/auth.ts
+++ b/app-ui/src/stores/auth.ts
@@ -29,6 +29,8 @@ export const useAuthStore = defineStore('auth', () => {
   const mustChangePassword = computed(() => user.value?.mustChangePassword ?? false);
   const fullName = computed(() => user.value?.fullName ?? '');
   const roles = computed(() => user.value?.roles ?? []);
+  // WP-32 (U4): idle auto-logoff minutes from /auth/me; 0 = disabled, 60 default when absent.
+  const idleLogoffMinutes = computed(() => user.value?.idleLogoffMinutes ?? 60);
 
   /** True if the user holds (type, value), or is a SystemAdmin (the FullAccess wildcard). */
   function hasClaim(type: string, value: string): boolean {
@@ -118,6 +120,7 @@ export const useAuthStore = defineStore('auth', () => {
     mustChangePassword,
     fullName,
     roles,
+    idleLogoffMinutes,
     hasClaim,
     hasAnyClaim,
     hasAllClaims,

--- a/app-ui/test-scenarios/wp-32-idle-logoff.md
+++ b/app-ui/test-scenarios/wp-32-idle-logoff.md
@@ -1,0 +1,67 @@
+# WP-32C (U4) — Idle Auto-Logoff: owner walkthrough
+
+Client-side idle timer: after N minutes of no activity the app shows a 60-second warning, then
+signs the user out and returns to login. N is set per Site in Admin (default 60, `0` = disabled).
+
+> This is UX hygiene, **not** server security — the token is not invalidated server-side. Someone
+> holding a stolen token could still use it directly; the app just stops leaving an unattended
+> session open on screen.
+
+**Prereqs:** DB **V029** applied, API **WP-32B** deployed (so `/auth/me` returns
+`idleLogoffMinutes`), and this UI (WP-32C) deployed. No re-login needed for the *value* to flow —
+it's read at each login/refresh.
+
+## Setup for a fast live test (use 1 minute)
+
+Front-desk staff shouldn't wait an hour to test. Temporarily shorten the timeout:
+
+1. Sign in as an admin (a user with **Admin › Sites** access).
+2. Go to **Admin → Sites**, edit the site (usually "Main Clinic").
+3. Set **Idle auto-logoff (minutes)** to `1`. Save.
+4. **Sign out and back in** (the new value is picked up at login). ⚠️ Without re-login your current
+   session still uses the old value.
+
+Restore it to `60` (or your chosen value) when you're done — same steps.
+
+## Scenario 1 — the warning appears, "I'm still here" keeps you in
+
+1. With the timeout at 1 minute, sign in and then **stop touching the mouse/keyboard**.
+2. **Expected:** at ~0:00 remaining of the first minute (i.e. immediately, since warning lead is
+   60s and the timeout is 60s) a **"Still there?"** dialog appears with a live countdown.
+   - *(At the real 60-minute setting the dialog appears at the 59-minute mark.)*
+3. Click **"I'm still here"** before it reaches 0.
+4. **Expected:** the dialog closes and you stay signed in; the clock resets.
+
+## Scenario 2 — idle logout
+
+1. Trigger the warning again (stop interacting).
+2. Let the countdown reach **0** without clicking.
+3. **Expected:** you're returned to the **login screen** with a toast:
+   *"Signed out after 1 minute of inactivity."* (says "minutes" at higher settings).
+
+## Scenario 3 — "Sign out now"
+
+1. Trigger the warning, then click **"Sign out now"**.
+2. **Expected:** immediate return to login, **no** inactivity toast (you chose to leave).
+
+## Scenario 4 — activity resets the timer
+
+1. Sign in and keep **lightly moving the mouse / typing** every 20–30 seconds.
+2. **Expected:** the warning **never** appears — activity keeps the session alive.
+
+## Scenario 5 — multi-tab
+
+1. Open the app in **two browser tabs**, signed in.
+2. In tab A, go idle until the warning shows; in tab B, **move the mouse**.
+3. **Expected:** tab A's warning **disappears** — activity in any tab keeps them all alive.
+4. Conversely, if you let it log out in one tab, the other tab drops to login on its next action.
+
+## Scenario 6 — disabled (0)
+
+1. Set **Idle auto-logoff** to `0`, save, re-login.
+2. **Expected:** no warning and no idle logout, ever (feature off).
+
+## Cleanup
+
+Set the site's **Idle auto-logoff (minutes)** back to your intended production value (default `60`)
+and re-login so staff sessions use it.


### PR DESCRIPTION
…tting

- useIdleLogoff composable: window activity listeners (throttled, passive), 30s background poll + 1s countdown, wall-clock idle via localStorage pc_last_activity (survives tab sleep, multi-tab aware), warning at N-60s, expiry -> auth.logout + router 'login' + inactivity toast, 0 = disabled no-op, arms/disarms on auth + timeout
- IdleWarningModal.vue: countdown, "I'm still here" / "Sign out now" (idle-* testids)
- App.vue mounts the watcher at root; auth store exposes idleLogoffMinutes from /auth/me (optional on CurrentUserResponse so existing fixtures stay valid; default 60)
- SiteFormModal: minutes field (0-480, "0 = disabled"), populated on edit, sent in payload, client-side range guard; Site interfaces gain idleLogoffMinutes
- Tests +13 (vitest 167->180): composable timing (warn/expire/stay/signout/activity/cross-tab/ disabled), modal render+emit, form field; testing-guide gains an idle fake-timers section (T1)
- Owner walkthrough test-scenarios/wp-32-idle-logoff.md; vue-tsc + lint clean; no matrix change