### PR TITLE
WP-31C (U1): audit info ⓘ popover on Patients, Caretakers, and Sessio…

### DIFF
--- a/app-ui/src/__tests__/wp31-audit-popover.spec.ts
+++ b/app-ui/src/__tests__/wp31-audit-popover.spec.ts
@@ -1,0 +1,126 @@
+// WP-31 (U1) — AuditPopover: open/close behavior, content, absent-audit tolerance, and that it
+// shows for a FrontDesk user (no claim gate — anyone who sees the row sees its history).
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { setActivePinia, createPinia } from 'pinia';
+import manifest from '../generated/access-control-matrix.json';
+import { useAuthStore } from '../stores/auth';
+import type { ClaimDto } from '../interfaces/Auth';
+import type { AuditInfo } from '../interfaces/Audit';
+import type { Patient } from '../interfaces/Patient';
+import AuditPopover from '../components/shared/AuditPopover.vue';
+import PatientTable from '../components/patients/PatientTable.vue';
+
+function audit(overrides: Partial<AuditInfo> = {}): AuditInfo {
+  return {
+    createdAt: '2025-01-15T10:00:00Z',
+    updatedAt: '2025-06-01T14:30:00Z',
+    updatedBy: 'Doe, John',
+    ...overrides,
+  };
+}
+
+const stubs = { teleport: true };
+
+describe('AuditPopover', () => {
+  it('renders nothing when there is no audit block (older API)', () => {
+    const wrapper = mount(AuditPopover, { props: { audit: null }, global: { stubs } });
+    expect(wrapper.find('[data-testid="audit-info-button"]').exists()).toBe(false);
+  });
+
+  it('shows the ⓘ trigger when audit is present, popover starts closed', () => {
+    const wrapper = mount(AuditPopover, { props: { audit: audit() }, global: { stubs } });
+    expect(wrapper.find('[data-testid="audit-info-button"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="audit-info-popover"]').exists()).toBe(false);
+  });
+
+  it('opens on click and shows created / updated / updated-by', async () => {
+    const wrapper = mount(AuditPopover, { props: { audit: audit() }, global: { stubs } });
+    await wrapper.find('[data-testid="audit-info-button"]').trigger('click');
+
+    expect(wrapper.find('[data-testid="audit-info-popover"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="audit-updated-by"]').text()).toBe('Doe, John');
+    expect(wrapper.find('[data-testid="audit-created"]').text()).toContain('2025');
+    expect(wrapper.find('[data-testid="audit-updated"]').text()).toContain('2025');
+  });
+
+  it('toggles closed on a second click', async () => {
+    const wrapper = mount(AuditPopover, { props: { audit: audit() }, global: { stubs } });
+    const btn = wrapper.find('[data-testid="audit-info-button"]');
+    await btn.trigger('click');
+    expect(wrapper.find('[data-testid="audit-info-popover"]').exists()).toBe(true);
+    await btn.trigger('click');
+    expect(wrapper.find('[data-testid="audit-info-popover"]').exists()).toBe(false);
+  });
+
+  it('closes on Escape', async () => {
+    const wrapper = mount(AuditPopover, { props: { audit: audit() }, global: { stubs } });
+    await wrapper.find('[data-testid="audit-info-button"]').trigger('click');
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    await flushPromises();
+    expect(wrapper.find('[data-testid="audit-info-popover"]').exists()).toBe(false);
+  });
+
+  it('closes on an outside pointer press', async () => {
+    const wrapper = mount(AuditPopover, { props: { audit: audit() }, global: { stubs } });
+    await wrapper.find('[data-testid="audit-info-button"]').trigger('click');
+    document.dispatchEvent(new Event('pointerdown')); // target outside the root
+    await flushPromises();
+    expect(wrapper.find('[data-testid="audit-info-popover"]').exists()).toBe(false);
+  });
+
+  it('shows "System" as updated-by verbatim', async () => {
+    const wrapper = mount(AuditPopover, { props: { audit: audit({ updatedBy: 'System' }) }, global: { stubs } });
+    await wrapper.find('[data-testid="audit-info-button"]').trigger('click');
+    expect(wrapper.find('[data-testid="audit-updated-by"]').text()).toBe('System');
+  });
+});
+
+// Integration: the popover shows in the Patients table for a FrontDesk user (no claim gate).
+function claimsForRole(role: string): ClaimDto[] {
+  return (manifest.claims as Array<{ claim: string; grants: string[] }>)
+    .filter((c) => c.grants.includes(role))
+    .map((c) => ({ type: 'Permission', value: c.claim }));
+}
+
+function authAs(role: string) {
+  const pinia = createPinia();
+  setActivePinia(pinia);
+  const store = useAuthStore();
+  store.user = {
+    userId: 1, email: 't@e.com', fullName: 'Test', mustChangePassword: false,
+    roles: [role], claims: claimsForRole(role), isSystemAdmin: false,
+  };
+  return pinia;
+}
+
+function patient(overrides: Partial<Patient> = {}): Patient {
+  return {
+    patientId: 1, userId: 1, patientName: 'Roe, Jane', medicalRecordNumber: 'L26-0001',
+    cedula: null, dateOfBirth: '2000-01-01', email: null, phoneNumber: null, gender: null,
+    isActive: true, hasCompletedDiscovery: null, createdTimestamp: '2025-01-01T00:00:00Z',
+    audit: audit(), caretakers: [], ...overrides,
+  } as Patient;
+}
+
+describe('PatientTable audit popover', () => {
+  beforeEach(() => setActivePinia(createPinia()));
+
+  it('renders the ⓘ trigger on rows for a FrontDesk user', () => {
+    const wrapper = mount(PatientTable, {
+      props: { patients: [patient()] },
+      global: { plugins: [authAs('FD')], stubs },
+    });
+    // desktop + mobile both render a trigger for the row
+    expect(wrapper.findAll('[data-testid="audit-info-button"]').length).toBeGreaterThan(0);
+  });
+
+  it('omits the ⓘ trigger when a row has no audit block', () => {
+    const wrapper = mount(PatientTable, {
+      props: { patients: [patient({ audit: undefined })] },
+      global: { plugins: [authAs('FD')], stubs },
+    });
+    expect(wrapper.find('[data-testid="audit-info-button"]').exists()).toBe(false);
+  });
+});

--- a/app-ui/src/components/appointments/ActionsPanel.vue
+++ b/app-ui/src/components/appointments/ActionsPanel.vue
@@ -22,11 +22,14 @@
                 <span v-if="appointment.isDiscovery" class="inline-flex items-center px-2.5 py-0.5 rounded-full font-medium bg-amber-100 text-amber-700">Discovery</span>
               </div>
             </div>
-            <button class="p-1 text-slate-400 hover:text-slate-600 rounded-lg hover:bg-slate-100 flex-shrink-0" @click="$emit('close')">
-              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-              </svg>
-            </button>
+            <div class="flex items-center gap-1 flex-shrink-0">
+              <AuditPopover :audit="appointment.audit" align="right" />
+              <button class="p-1 text-slate-400 hover:text-slate-600 rounded-lg hover:bg-slate-100" @click="$emit('close')">
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
           </div>
         </div>
 
@@ -306,6 +309,7 @@
 import { defineComponent, ref, computed, watch, type PropType } from 'vue';
 import { useRouter } from 'vue-router';
 import StatusBadge from './StatusBadge.vue';
+import AuditPopover from '../shared/AuditPopover.vue';
 import { SessionsHttpClient } from '../../services/SessionsHttpClient';
 import type { Appointment } from '../../interfaces/Appointment';
 import { useClaims, Permissions } from '../../composables/useClaims';
@@ -314,7 +318,7 @@ const TERMINAL_STATUSES = [3, 4, 5]; // Cancelled, Completed, NoShow
 
 export default defineComponent({
   name: 'ActionsPanel',
-  components: { StatusBadge },
+  components: { StatusBadge, AuditPopover },
   props: {
     visible: { type: Boolean, required: true },
     appointment: { type: Object as PropType<Appointment | null>, default: null },

--- a/app-ui/src/components/caretakers/CaretakerTable.vue
+++ b/app-ui/src/components/caretakers/CaretakerTable.vue
@@ -45,6 +45,7 @@
           </td>
           <td class="px-4 py-3 text-right">
             <div class="flex items-center justify-end space-x-2">
+              <AuditPopover :audit="caretaker.audit" align="right" />
               <button
                 class="p-1.5 rounded-lg text-slate-400 hover:text-indigo-600 hover:bg-indigo-50 transition-colors"
                 title="View patients"
@@ -116,6 +117,7 @@
         <div><span class="font-medium"># Patients:</span> {{ caretaker.patients.length }}</div>
       </div>
       <div class="flex items-center justify-end space-x-2 border-t border-slate-100 pt-2">
+        <AuditPopover :audit="caretaker.audit" align="left" />
         <button
           class="px-3 py-1.5 rounded-lg text-xs font-medium text-indigo-600 hover:bg-indigo-50 transition-colors"
           @click="$emit('view-patients', caretaker)"
@@ -149,9 +151,11 @@
 import { defineComponent, ref, computed, type PropType } from 'vue';
 import type { Caretaker } from '../../interfaces/Caretaker';
 import { useClaims, Permissions } from '../../composables/useClaims';
+import AuditPopover from '../shared/AuditPopover.vue';
 
 export default defineComponent({
   name: 'CaretakerTable',
+  components: { AuditPopover },
   props: {
     caretakers: { type: Array as PropType<Caretaker[]>, required: true },
   },

--- a/app-ui/src/components/patients/PatientTable.vue
+++ b/app-ui/src/components/patients/PatientTable.vue
@@ -85,6 +85,7 @@
           </td>
           <td class="px-4 py-3 text-right">
             <div class="flex items-center justify-end space-x-2">
+              <AuditPopover :audit="patient.audit" align="right" />
               <button
                 class="p-1.5 rounded-lg text-slate-400 hover:text-indigo-600 hover:bg-indigo-50 transition-colors"
                 title="View caretakers"
@@ -184,6 +185,7 @@
         </div>
       </div>
       <div class="flex items-center justify-end space-x-2 border-t border-slate-100 pt-2">
+        <AuditPopover :audit="patient.audit" align="left" />
         <button
           class="px-3 py-1.5 rounded-lg text-xs font-medium text-indigo-600 hover:bg-indigo-50 transition-colors"
           @click="$emit('view-caretakers', patient)"
@@ -231,9 +233,11 @@ import type { Patient } from '../../interfaces/Patient';
 import { isTemporaryMrn } from '../../interfaces/Patient';
 import { formatAge } from '../../utils/age';
 import { useClaims, Permissions } from '../../composables/useClaims';
+import AuditPopover from '../shared/AuditPopover.vue';
 
 export default defineComponent({
   name: 'PatientTable',
+  components: { AuditPopover },
   props: {
     patients: { type: Array as PropType<Patient[]>, required: true },
   },

--- a/app-ui/src/components/shared/AuditPopover.vue
+++ b/app-ui/src/components/shared/AuditPopover.vue
@@ -1,0 +1,154 @@
+<template>
+  <!-- Renders nothing when the API didn't send an audit block (older deployment). -->
+  <span v-if="audit" ref="root" class="relative inline-flex" @mouseenter="onEnter" @mouseleave="onLeave">
+    <button
+      ref="trigger"
+      type="button"
+      data-testid="audit-info-button"
+      class="p-1.5 rounded-lg text-slate-400 hover:text-slate-600 hover:bg-slate-100 transition-colors"
+      :aria-expanded="open"
+      aria-label="Record history"
+      title="Record history"
+      @click="toggle"
+    >
+      <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+          d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+      </svg>
+    </button>
+
+    <!-- Teleported to body + fixed-positioned so the table's overflow clipping never cuts it off.
+         The content is static (no local state), so the teleport-stub remount gotcha doesn't apply. -->
+    <teleport to="body">
+      <div
+        v-if="open"
+        ref="popover"
+        data-testid="audit-info-popover"
+        class="fixed z-50 w-60 rounded-lg border border-slate-200 bg-white p-3 text-left shadow-xl"
+        :style="popoverStyle"
+        role="dialog"
+        aria-label="Record history"
+      >
+        <p class="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-400">Record history</p>
+        <dl class="space-y-1.5 text-xs">
+          <div class="flex justify-between gap-3">
+            <dt class="text-slate-500">Created</dt>
+            <dd class="text-right text-slate-700" data-testid="audit-created">{{ formatDateTime(audit.createdAt) }}</dd>
+          </div>
+          <div class="flex justify-between gap-3">
+            <dt class="text-slate-500">Last updated</dt>
+            <dd class="text-right text-slate-700" data-testid="audit-updated">{{ formatDateTime(audit.updatedAt) }}</dd>
+          </div>
+          <div class="flex justify-between gap-3">
+            <dt class="text-slate-500">Last updated by</dt>
+            <dd class="text-right font-medium text-slate-800" data-testid="audit-updated-by">{{ audit.updatedBy }}</dd>
+          </div>
+        </dl>
+      </div>
+    </teleport>
+  </span>
+</template>
+
+<script lang="ts">
+import { defineComponent, nextTick, onBeforeUnmount, reactive, ref, type PropType } from 'vue';
+import type { AuditInfo } from '../../interfaces/Audit';
+
+const HOVER_OPEN_DELAY_MS = 350;
+const GAP_PX = 6;
+const POPOVER_WIDTH_PX = 240; // matches w-60
+const EST_HEIGHT_PX = 120;
+
+// WP-31 (U1): a tappable ⓘ that reveals a record's created / last-updated / updated-by. Tap-toggle
+// (mobile-first) plus a delayed hover-open on desktop; Escape and outside-click close it. Hidden
+// entirely when no audit block is present, so it degrades cleanly against an older API.
+export default defineComponent({
+  name: 'AuditPopover',
+  props: {
+    audit: { type: Object as PropType<AuditInfo | null | undefined>, default: null },
+    align: { type: String as PropType<'left' | 'right'>, default: 'right' },
+  },
+  setup(props) {
+    const root = ref<HTMLElement | null>(null);
+    const trigger = ref<HTMLElement | null>(null);
+    const open = ref(false);
+    const pinned = ref(false); // a click pins it open so a passing mouseleave doesn't dismiss
+    const popoverStyle = reactive<Record<string, string>>({ top: '0px', left: '0px' });
+    let hoverTimer: ReturnType<typeof setTimeout> | undefined;
+
+    function position() {
+      const el = trigger.value;
+      if (!el || typeof el.getBoundingClientRect !== 'function') return;
+      const r = el.getBoundingClientRect();
+      const vw = window.innerWidth || 0;
+      const vh = window.innerHeight || 0;
+      // Right-aligned to the trigger by default; clamp into the viewport.
+      let left = props.align === 'left' ? r.left : r.right - POPOVER_WIDTH_PX;
+      left = Math.max(8, Math.min(left, vw - POPOVER_WIDTH_PX - 8));
+      // Below the trigger, or above if it would overflow the bottom.
+      const top = r.bottom + EST_HEIGHT_PX + GAP_PX > vh ? r.top - EST_HEIGHT_PX - GAP_PX : r.bottom + GAP_PX;
+      popoverStyle.left = `${Math.round(left)}px`;
+      popoverStyle.top = `${Math.round(Math.max(8, top))}px`;
+    }
+
+    function onDocPointer(e: Event) {
+      const target = e.target as Node;
+      if (root.value?.contains(target)) return;
+      close();
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') close();
+    }
+    function addGlobalListeners() {
+      document.addEventListener('pointerdown', onDocPointer, true);
+      document.addEventListener('keydown', onKey);
+    }
+    function removeGlobalListeners() {
+      document.removeEventListener('pointerdown', onDocPointer, true);
+      document.removeEventListener('keydown', onKey);
+    }
+
+    function show() {
+      if (open.value) return;
+      position();
+      open.value = true;
+      addGlobalListeners();
+      void nextTick(position); // refine once the element exists
+    }
+    function close() {
+      open.value = false;
+      pinned.value = false;
+      if (hoverTimer) clearTimeout(hoverTimer);
+      removeGlobalListeners();
+    }
+    function toggle() {
+      if (open.value) {
+        close();
+      } else {
+        pinned.value = true;
+        show();
+      }
+    }
+    function onEnter() {
+      if (hoverTimer) clearTimeout(hoverTimer);
+      hoverTimer = setTimeout(show, HOVER_OPEN_DELAY_MS);
+    }
+    function onLeave() {
+      if (hoverTimer) clearTimeout(hoverTimer);
+      if (!pinned.value) close();
+    }
+
+    function formatDateTime(value: string): string {
+      if (!value) return '—';
+      const d = new Date(value);
+      if (isNaN(d.getTime())) return value;
+      return d.toLocaleString('en-US', {
+        year: 'numeric', month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit',
+      });
+    }
+
+    onBeforeUnmount(removeGlobalListeners);
+
+    return { root, trigger, open, popoverStyle, toggle, onEnter, onLeave, formatDateTime };
+  },
+});
+</script>

--- a/app-ui/src/interfaces/Appointment.ts
+++ b/app-ui/src/interfaces/Appointment.ts
@@ -1,4 +1,6 @@
 // interfaces/Appointment.ts
+import type { AuditInfo } from './Audit';
+
 export interface Appointment {
     sessionId: number;
     sessionDate: string;
@@ -33,6 +35,8 @@ export interface Appointment {
     // WP-17: confidential (matrix grants Appointments.ProviderAmount to MGR/AM only). The API omits
     // this field from the response for callers lacking the claim (e.g. FrontDesk), so it is optional.
     providerAmount?: number;
+    // WP-31 (U1): audit block for the Session Details ⓘ popover. Optional — tolerates an older API.
+    audit?: AuditInfo;
 }
 
 export interface SessionEventRequest {

--- a/app-ui/src/interfaces/Audit.ts
+++ b/app-ui/src/interfaces/Audit.ts
@@ -1,0 +1,10 @@
+// interfaces/Audit.ts
+// WP-31 (U1): additive audit block surfaced by the row ⓘ popover. Source of truth:
+// patient-care-super/_contracts/patients-api.md (same shape on caretakers + sessions).
+
+export interface AuditInfo {
+  createdAt: string;
+  updatedAt: string;
+  /** Display string: "Lastname, Firstname" or "System" (never a raw id). */
+  updatedBy: string;
+}

--- a/app-ui/src/interfaces/Caretaker.ts
+++ b/app-ui/src/interfaces/Caretaker.ts
@@ -1,5 +1,7 @@
 // interfaces/Caretaker.ts
 
+import type { AuditInfo } from './Audit';
+
 // Maps to API's CaretakerProfile response
 export interface Caretaker {
   caretakerId: number
@@ -11,6 +13,8 @@ export interface Caretaker {
   createdTimestamp: string
   lastUpdated: string
   isActive: boolean
+  // WP-31 (U1): audit block for the row ⓘ popover. Optional — the UI tolerates an older API.
+  audit?: AuditInfo
   patients: CaretakerPatientSummary[]
 }
 

--- a/app-ui/src/interfaces/Patient.ts
+++ b/app-ui/src/interfaces/Patient.ts
@@ -1,5 +1,7 @@
 // interfaces/Patient.ts
 
+import type { AuditInfo } from './Audit';
+
 // Maps to API's PatientProfile response
 export interface Patient {
   patientId: number;
@@ -23,6 +25,8 @@ export interface Patient {
   requiresDiscovery?: boolean;
   hasCompletedDiscovery: boolean | null;
   createdTimestamp: string;
+  // WP-31 (U1): audit block for the row ⓘ popover. Optional — the UI tolerates an older API.
+  audit?: AuditInfo;
   caretakers?: PatientCaretakerSummary[];
 }
 

--- a/app-ui/test-scenarios/wp-31-audit-popover.md
+++ b/app-ui/test-scenarios/wp-31-audit-popover.md
@@ -1,0 +1,45 @@
+# WP-31C (U1) — Audit Info Popover: owner walkthrough
+
+A small ⓘ button on each Patient row, Caretaker row, and the Session Details panel reveals a
+record's history: **Created**, **Last updated**, and **Last updated by**. It's read-only and
+shows for anyone who can see the row.
+
+> "Last updated by" is best-effort: it shows the operator's name when we can attribute the change,
+> or **"System"** for legacy-imported records and background scripts (the database only stores who
+> last *updated* a row — there's no "created by").
+
+**Prereqs:** API **WP-31B** deployed (so the responses carry the `audit` block) and this UI
+deployed. Additive — an older API just means the ⓘ doesn't appear (no error).
+
+## Scenario 1 — Patients
+
+1. Go to **Patients**. Each row (desktop) and card (mobile) has a small ⓘ in the actions area.
+2. **Tap/click** the ⓘ. A little card appears: Created · Last updated · Last updated by.
+3. On desktop, **hovering** the ⓘ for a moment also opens it.
+4. Click the ⓘ again, press **Esc**, or click **anywhere outside** — it closes.
+5. Edit a patient (change the phone), save, reopen the ⓘ → **Last updated** is now, **Last updated
+   by** is your name.
+
+## Scenario 2 — a legacy patient shows "System"
+
+1. Search a legacy-imported patient (MRN like `L24-####` / `L25-####`) that hasn't been edited in-app.
+2. Open its ⓘ → **Last updated by: System** (imported by a script, not a person).
+
+## Scenario 3 — Caretakers
+
+1. Go to **Caretakers**. Same ⓘ on each row/card; open it to see the history.
+
+## Scenario 4 — Session Details
+
+1. Open **Appointments**, click a session to open the **Session Details** panel.
+2. The ⓘ sits in the panel header (next to the ✕). Open it to see the session's created/updated/by.
+
+## Scenario 5 — nothing leaks, nothing breaks
+
+1. The card never shows a raw user id — only a name or "System".
+2. The popover opens above the fold near the bottom of the screen (it flips up so it isn't clipped).
+
+## Notes
+
+- No new permission — if you can see the row, you can see its history (no re-login needed).
+- Front-desk, managers, accountants, owners all see it on the pages they already have.


### PR DESCRIPTION
…n Details

- AuditInfo interface; audit? added to Patient / Caretaker / Appointment (optional — tolerates an older API)
- shared/AuditPopover.vue: tappable ⓘ -> created / last updated / updated-by card; tap-toggle (mobile-first) + delayed hover-open (desktop); Escape + outside-click close; teleport-to-body with fixed positioning so table overflow never clips it; hidden when no audit block present
- mounted in PatientTable (desktop row + mobile card), CaretakerTable (both), ActionsPanel (Session Details header)
- Tests +9 (vitest 180->189): open/close/toggle/Escape/outside-click, content rows, "System" verbatim, absent-audit hides, shows for FrontDesk (no claim gate)
- Owner walkthrough test-scenarios/wp-31-audit-popover.md; vue-tsc + lint clean; no matrix change