### PR TITLE
WP-38 (MRG-1): merge panel — selector change after preview raises a d…

### DIFF
--- a/app-ui/src/__tests__/patient-merge.spec.ts
+++ b/app-ui/src/__tests__/patient-merge.spec.ts
@@ -61,6 +61,7 @@ function authAs(opts: { role?: Role; isSystemAdmin?: boolean }): Pinia {
 // WP-30: the pickers hold slim lookup rows, not full Patient profiles.
 const survivor: LookupOption = { id: 1, name: 'Perez, Juan', detail: 'MRN L24-0312' };
 const duplicate: LookupOption = { id: 2, name: 'Perez, Jaun', detail: 'MRN L24-0313' };
+const otherDuplicate: LookupOption = { id: 3, name: 'Perez, Josue', detail: 'MRN L24-0400' };
 
 function makePreview(overrides: Partial<PatientMergePreview> = {}): PatientMergePreview {
   return {
@@ -98,7 +99,7 @@ function makeResult(): PatientMergeResult {
 
 async function mountPanel(): Promise<ReturnType<typeof mount>> {
   const pinia = authAs({ isSystemAdmin: true });
-  const wrapper = mount(PatientMergePanel, { global: { plugins: [pinia] } });
+  const wrapper = mount(PatientMergePanel, { global: { plugins: [pinia], stubs: { teleport: true } } });
   await flushPromises();
   return wrapper;
 }
@@ -257,5 +258,86 @@ describe('PatientMergePanel — stepper behavior', () => {
 
     expect(wrapper.text()).toContain('Conflict: resolve manually');
     expect(wrapper.find('[data-testid="merge-preview"]').exists()).toBe(true);
+  });
+});
+
+// WP-38 (MRG-1): a selector change after a preview exists must never leave the stale preview
+// (and its live type-to-confirm + Execute path) describing a pair that no longer matches the
+// pickers. G1: confirm-first dialog; G2: Continue keeps the new selection, clears preview+confirm.
+describe('WP-38 — selection change after preview resets the merge session', () => {
+  interface PanelVm {
+    survivor: LookupOption | null;
+    eliminated: LookupOption | null;
+  }
+
+  it('changing the duplicate raises the discard dialog; Continue clears the preview but keeps the new pick', async () => {
+    const wrapper = await mountPreviewedPanel();
+    const vm = wrapper.vm as unknown as PanelVm;
+
+    vm.eliminated = otherDuplicate;
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.find('[data-testid="merge-discard-dialog"]').exists()).toBe(true);
+    await wrapper.find('[data-testid="merge-discard-continue"]').trigger('click');
+
+    expect(wrapper.find('[data-testid="merge-discard-dialog"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="merge-preview"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="merge-confirm-input"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="merge-execute-button"]').exists()).toBe(false);
+    expect(vm.eliminated).toEqual(otherDuplicate); // G2: the operator's new pick survives
+    expect(vm.survivor).toEqual(survivor);
+  });
+
+  it('typed confirm text does not survive the discard into the next preview', async () => {
+    const wrapper = await mountPreviewedPanel();
+    await wrapper.find('[data-testid="merge-confirm-input"]').setValue('L24-0313');
+
+    (wrapper.vm as unknown as PanelVm).eliminated = otherDuplicate;
+    await wrapper.vm.$nextTick();
+    await wrapper.find('[data-testid="merge-discard-continue"]').trigger('click');
+
+    // Re-preview the new pair: type-to-confirm must start empty, Execute disabled.
+    await wrapper.find('button.bg-violet-600').trigger('click');
+    await flushPromises();
+    expect((wrapper.find('[data-testid="merge-confirm-input"]').element as HTMLInputElement).value).toBe('');
+    expect(wrapper.find('[data-testid="merge-execute-button"]').attributes('disabled')).toBeDefined();
+  });
+
+  it('Cancel restores the previous selection and keeps the preview', async () => {
+    const wrapper = await mountPreviewedPanel();
+    const vm = wrapper.vm as unknown as PanelVm;
+
+    vm.eliminated = otherDuplicate;
+    await wrapper.vm.$nextTick();
+    await wrapper.find('[data-testid="merge-discard-cancel"]').trigger('click');
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="merge-discard-dialog"]').exists()).toBe(false); // restore must not re-raise it
+    expect(vm.eliminated).toEqual(duplicate);
+    expect(wrapper.find('[data-testid="merge-preview"]').exists()).toBe(true);
+  });
+
+  it('swap() stays silent — pair-preserving, resets the preview without a dialog', async () => {
+    const wrapper = await mountPreviewedPanel();
+    const vm = wrapper.vm as unknown as PanelVm;
+
+    await wrapper.find('[data-testid="merge-swap-button"]').trigger('click');
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="merge-discard-dialog"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="merge-preview"]').exists()).toBe(false);
+    expect(vm.survivor).toEqual(duplicate);
+    expect(vm.eliminated).toEqual(survivor);
+  });
+
+  it('no dialog when a selector changes before any preview exists', async () => {
+    const wrapper = await mountPanel();
+    const vm = wrapper.vm as unknown as PanelVm;
+
+    vm.survivor = survivor;
+    vm.eliminated = duplicate;
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.find('[data-testid="merge-discard-dialog"]').exists()).toBe(false);
   });
 });

--- a/app-ui/src/components/admin/PatientMergePanel.vue
+++ b/app-ui/src/components/admin/PatientMergePanel.vue
@@ -57,6 +57,7 @@
             class="mt-6 self-center rounded-lg border border-slate-300 p-2 text-slate-500 hover:bg-slate-50 disabled:opacity-40"
             title="Swap survivor and duplicate"
             :disabled="!survivor && !eliminated"
+            data-testid="merge-swap-button"
             @click="swap"
           >
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -184,11 +185,68 @@
         </div>
       </template>
     </div>
+
+    <!-- WP-38 (MRG-1): confirm-first discard guard — a picker change while a preview exists -->
+    <teleport to="body">
+      <div
+        v-if="discardDialogVisible"
+        class="fixed inset-0 z-[60] flex items-center justify-center p-4"
+        role="alertdialog"
+        aria-modal="true"
+        aria-labelledby="merge-discard-title"
+      >
+        <!-- Backdrop (no click-to-dismiss: the choice must be explicit) -->
+        <div class="absolute inset-0 bg-black/40"></div>
+
+        <div
+          data-testid="merge-discard-dialog"
+          class="relative w-full max-w-sm rounded-xl bg-white shadow-2xl p-6 text-center"
+        >
+          <div class="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-amber-100">
+            <svg class="h-6 w-6 text-amber-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M12 8v4m0 4h.01M12 3a9 9 0 100 18 9 9 0 000-18z"
+              />
+            </svg>
+          </div>
+
+          <h2 id="merge-discard-title" class="text-lg font-semibold text-slate-800">
+            Discard this preview?
+          </h2>
+          <p class="mt-2 text-sm text-slate-600">
+            Changing the selection discards the current preview and its confirmation.
+            You'll need to run a new preview for the new pair. Continue?
+          </p>
+
+          <div class="mt-6 flex items-center justify-center gap-3">
+            <button
+              type="button"
+              data-testid="merge-discard-cancel"
+              class="px-4 py-2 rounded-lg text-sm font-medium text-slate-700 bg-white border border-slate-300 hover:bg-slate-50"
+              @click="cancelDiscard"
+            >
+              Keep preview
+            </button>
+            <button
+              type="button"
+              data-testid="merge-discard-continue"
+              class="px-4 py-2 rounded-lg text-sm font-medium text-white bg-rose-600 hover:bg-rose-700"
+              @click="confirmDiscard"
+            >
+              Discard preview
+            </button>
+          </div>
+        </div>
+      </div>
+    </teleport>
   </div>
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, computed } from 'vue';
+import { defineComponent, ref, computed, watch } from 'vue';
 import LookupSelect, { type LookupOption } from '../shared/LookupSelect.vue';
 import { PatientsHttpClient } from '../../services/PatientsHttpClient';
 import type { PatientMergePreview, PatientMergeResult } from '../../interfaces/PatientMerge';
@@ -251,8 +309,45 @@ export default defineComponent({
       const s = survivor.value;
       survivor.value = eliminated.value;
       eliminated.value = s;
+      // Clearing the preview here also keeps the WP-38 discard guard silent: by the time the
+      // watcher runs there is no preview left to protect (swap is intentionally pair-preserving).
       preview.value = null;
       confirmText.value = '';
+    };
+
+    // WP-38 (MRG-1): a picker change while a preview exists would leave the stale preview (and
+    // its live type-to-confirm + Execute path) describing a pair the selectors no longer match —
+    // a wrong-patient-merge hazard. Confirm first (G1); Continue keeps the new selection and
+    // clears only preview + confirm text (G2); Cancel restores the previous selection.
+    const discardDialogVisible = ref(false);
+    let priorSelection: { survivor: LookupOption | null; eliminated: LookupOption | null } | null = null;
+    let restoringSelection = false;
+
+    watch([survivor, eliminated], (_now, [oldSurvivor, oldEliminated]) => {
+      if (restoringSelection) {
+        restoringSelection = false;
+        return;
+      }
+      if (!preview.value || discardDialogVisible.value) return;
+      priorSelection = { survivor: oldSurvivor, eliminated: oldEliminated };
+      discardDialogVisible.value = true;
+    });
+
+    const confirmDiscard = () => {
+      preview.value = null;
+      confirmText.value = '';
+      priorSelection = null;
+      discardDialogVisible.value = false;
+    };
+
+    const cancelDiscard = () => {
+      if (priorSelection) {
+        restoringSelection = true;
+        survivor.value = priorSelection.survivor;
+        eliminated.value = priorSelection.eliminated;
+        priorSelection = null;
+      }
+      discardDialogVisible.value = false;
     };
 
     const runPreview = async () => {
@@ -308,6 +403,7 @@ export default defineComponent({
       survivor, eliminated, preview, result, fetchPatientOptions,
       confirmText, confirmTarget, confirmMatches, previewing, merging, error,
       canPreview, identitySides, swap, runPreview, runMerge, reset, formatDate,
+      discardDialogVisible, confirmDiscard, cancelDiscard,
     };
   },
 });

--- a/app-ui/test-scenarios/wp-38-merge-reset.md
+++ b/app-ui/test-scenarios/wp-38-merge-reset.md
@@ -1,0 +1,49 @@
+# WP-38 — Merge Panel Selection-Change Reset: Owner Walkthrough
+
+Bug fix (punch-list MRG-1, SYSADMIN-only surface). Previously, changing the survivor or the
+duplicate **after** running a preview left the stale preview — including its type-to-confirm and
+Execute button — on screen describing the OLD pair, while Execute would have merged the NEW pair.
+Now any selection change while a preview is up asks first, then wipes the stale preview.
+
+UI-only: no API deploy, no reseed, no re-login.
+
+## Scenario 1 — Change the duplicate after preview → warning → clean slate
+
+1. Log in as the SYSADMIN account → Admin → Data Maintenance → Merge Duplicate Patients.
+2. Pick a survivor and a duplicate (any two test patients), click **Preview merge**.
+3. With the preview cards on screen, change the **Duplicate** picker to a different patient.
+4. **Expect:** a dialog — "Discard this preview? Changing the selection discards the current
+   preview and its confirmation…" with **Keep preview** / **Discard preview** buttons.
+   The screen behind it is dimmed; clicking the backdrop does nothing (the choice is explicit).
+5. Click **Discard preview**.
+6. **Expect:** the preview cards, the type-to-confirm box, and the Merge & Delete button are all
+   gone. Both pickers **keep their current values** (survivor unchanged + your new duplicate).
+   You must click Preview merge again to stage anything.
+
+## Scenario 2 — Keep preview (cancel path)
+
+1. Repeat steps 1–3 above (preview up, change a picker).
+2. In the dialog, click **Keep preview**.
+3. **Expect:** the picker snaps back to the patient it had before your change, the preview stays
+   exactly as it was, and no second dialog appears.
+
+## Scenario 3 — Typed confirmation never survives
+
+1. Preview a pair and type the duplicate's MRN into the confirm box (Execute button lights up).
+2. Change the **Survivor** picker → **Discard preview**.
+3. Click **Preview merge** for the new pair.
+4. **Expect:** the confirm box is empty and Execute is disabled until you type the (new)
+   duplicate's MRN.
+
+## Scenario 4 — Swap stays silent
+
+1. Preview a pair, then click the **⇄ swap** button between the pickers.
+2. **Expect:** no dialog — the two pickers trade places and the preview clears immediately
+   (swap is an intentional pair-preserving action; it was already safe).
+
+## Notes
+
+- The guard only arms while a preview is on screen — changing pickers before any preview never
+  prompts.
+- The server re-validates the pair on execute regardless; this fix removes the client-side
+  wrong-patient hazard where the operator reads cards for one pair while Execute targets another.


### PR DESCRIPTION
…iscard guard

Changing survivor or duplicate while a preview existed left the stale preview, type-to-confirm, and Execute path live for a pair the pickers no longer matched (wrong-patient-merge hazard). A watch on both pickers now raises a confirm-first dialog (G1): Discard clears preview + confirm text but keeps the new selection (G2); Keep preview restores the prior selection. swap() stays silent (it already resets the pair intentionally). Red-first regression specs; vitest 189 -> 194.