### PR TITLE
WP-37C (SEN-1/SEN-2): SENADIS expiration date — patient field + expir…

### DIFF
--- a/app-ui/docs/testing-guide.md
+++ b/app-ui/docs/testing-guide.md
@@ -157,6 +157,12 @@ function patient(overrides: Partial<Patient> = {}): Patient {
 ```
 
 - One factory per entity, defaults valid, override only what the test cares about.
+- **Date-comparison features don't need fake timers** (2026-07-19, `wp37-senadis-expiration.spec.ts`):
+  when the code compares a fixture date against "today" or a form date, use **far-past (2020) /
+  far-future (2099)** fixture dates for the static cases, and drive the form's own date field
+  explicitly (`vm.form.sessionDate = '2026-08-15'`) for boundary/flip cases — assertions then
+  never depend on the real clock. Reserve `vi.useFakeTimers()` for code that reads `Date.now()`
+  itself (debounce, idle logoff).
 - Form-fill helpers are local per spec and index positional inputs (first `input[type="email"]`,
   `findAll('input[type="text"]')[0]`, first `select` = gender, …) — if you add a field to a form,
   check the positional helpers in its specs.

--- a/app-ui/src/__tests__/wp37-senadis-expiration.spec.ts
+++ b/app-ui/src/__tests__/wp37-senadis-expiration.spec.ts
@@ -1,0 +1,475 @@
+// WP-37 (SEN-1/SEN-2) — SENADIS discount expiration date:
+//   - PatientFormModal gains an expiration date input next to the SENADIS flag — shown only
+//     while the flag is checked, disabled by the same Patients.SenadisDiscount.Edit claim gate
+//     on edit (G4: one claim governs both fields; create stays free per SEN-2), with a
+//     "SENADIS expired {date}" badge when the date is past (G3 — the flag is NEVER auto-cleared).
+//   - BookingFormModal's 20% floor/min/clamp becomes expiry-aware (G2): it applies only when
+//     the flag is on AND (no expiry OR the booking's SESSION date <= expiry). Flagged-but-
+//     expired ⇒ no floor, no clamp-on-submit, badge instead. Boundary (session date == expiry)
+//     still floors. Changing the session date across the expiry flips the behavior.
+//   - SchedulePlanWizard's per-line clamp does the same against the schedule START date.
+// Date determinism: fixtures use far-past (2020) / far-future (2099) expiries, and the
+// boundary/flip cases drive form.sessionDate/startDate explicitly — no fake clock needed.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { setActivePinia, createPinia, type Pinia } from 'pinia';
+import { mount, flushPromises } from '@vue/test-utils';
+import { nextTick } from 'vue';
+import manifest from '../generated/access-control-matrix.json';
+import { useAuthStore } from '../stores/auth';
+import { useNotificationsStore } from '../stores/notifications';
+import type { ClaimDto } from '../interfaces/Auth';
+import type { Patient } from '../interfaces/Patient';
+import type { TreatmentPlan } from '../interfaces/TreatmentPlan';
+import BookingFormModal from '../components/appointments/BookingFormModal.vue';
+import PatientFormModal from '../components/patients/PatientFormModal.vue';
+import SchedulePlanWizard from '../components/treatment-plans/SchedulePlanWizard.vue';
+import { isSenadisExpired } from '../utils/senadis';
+
+// ── fixtures ─────────────────────────────────────────────────────────────────
+
+const NULL_EXPIRY_ID = 1; // flagged, no expiry (G1: open-ended)
+const EXPIRED_ID = 2; // flagged, expired long ago
+const FUTURE_ID = 3; // flagged, expires far in the future
+const WINDOW_ID = 4; // flagged, fixed expiry for boundary/flip cases
+
+const EXPIRY_BY_ID: Record<number, string | null> = {
+  [NULL_EXPIRY_ID]: null,
+  [EXPIRED_ID]: '2020-06-30T00:00:00',
+  [FUTURE_ID]: '2099-12-31T00:00:00',
+  [WINDOW_ID]: '2026-08-15T00:00:00',
+};
+
+function patient(overrides: Partial<Patient> = {}): Patient {
+  return {
+    patientId: NULL_EXPIRY_ID,
+    userId: 10,
+    patientName: 'Doe, John',
+    medicalRecordNumber: 'MRN-001',
+    cedula: null,
+    dateOfBirth: '2015-01-15T00:00:00',
+    email: 'john@example.com',
+    phoneNumber: '555-0100',
+    gender: 'Male',
+    isActive: true,
+    hasSenadisDiscount: false,
+    senadisExpirationDate: null,
+    hasCompletedDiscovery: true,
+    createdTimestamp: '2025-01-01T00:00:00',
+    caretakers: [],
+    ...overrides,
+  };
+}
+
+// ── mocks (every client the three components new up) ─────────────────────────
+
+const { patientsClientMocks, lookupGetAllMock, createSessionMock, updatePatientMock, createPatientMock } = vi.hoisted(() => ({
+  patientsClientMocks: {
+    getPatient: vi.fn(),
+    getPatientCaretakers: vi.fn(),
+  },
+  lookupGetAllMock: vi.fn(),
+  createSessionMock: vi.fn().mockResolvedValue({}),
+  updatePatientMock: vi.fn().mockResolvedValue(undefined),
+  createPatientMock: vi.fn().mockResolvedValue({ patientId: 99, medicalRecordNumber: 'MRN-099' }),
+}));
+
+vi.mock('../services/PatientsHttpClient', () => ({
+  PatientsHttpClient: vi.fn().mockImplementation(() => ({
+    getPatient: patientsClientMocks.getPatient,
+    getPatientCaretakers: patientsClientMocks.getPatientCaretakers,
+    updatePatient: updatePatientMock,
+    createPatient: createPatientMock,
+  })),
+}));
+
+vi.mock('../services/TherapistsHttpClient', () => ({
+  TherapistsHttpClient: vi.fn().mockImplementation(() => ({
+    getTherapists: vi.fn().mockResolvedValue([
+      { therapistId: 7, id: 7, therapistName: 'Therapist, Test', specialties: [] },
+    ]),
+  })),
+}));
+
+vi.mock('../services/LookupHttpClient', () => ({
+  LookupHttpClient: vi.fn().mockImplementation(() => ({
+    getAll: lookupGetAllMock,
+  })),
+}));
+
+vi.mock('../services/SessionsHttpClient', () => ({
+  SessionsHttpClient: vi.fn().mockImplementation(() => ({
+    createSession: createSessionMock,
+  })),
+}));
+
+vi.mock('../services/SitesHttpClient', () => ({
+  SitesHttpClient: vi.fn().mockImplementation(() => ({
+    getSites: vi.fn().mockResolvedValue([{ siteId: 1, siteName: 'Main' }]),
+  })),
+}));
+
+vi.mock('../services/TreatmentPlansHttpClient', () => ({
+  TreatmentPlansHttpClient: vi.fn().mockImplementation(() => ({
+    schedule: vi.fn().mockResolvedValue({ planId: 1, sessionsCreated: 0, sessions: [], conflicts: [] }),
+  })),
+}));
+
+function claimsForRole(role: string): ClaimDto[] {
+  return (manifest.claims as Array<{ claim: string; grants: string[] }>)
+    .filter((c) => c.grants.includes(role))
+    .map((c) => ({ type: 'Permission', value: c.claim }));
+}
+
+function authAs(role: string): Pinia {
+  const pinia = createPinia();
+  setActivePinia(pinia);
+  const store = useAuthStore();
+  store.user = {
+    userId: 1,
+    email: 'test@example.com',
+    fullName: 'Test User',
+    mustChangePassword: false,
+    roles: [role],
+    claims: claimsForRole(role),
+    isSystemAdmin: false,
+  };
+  return pinia;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  createSessionMock.mockResolvedValue({});
+  updatePatientMock.mockResolvedValue(undefined);
+  createPatientMock.mockResolvedValue({ patientId: 99, medicalRecordNumber: 'MRN-099' });
+  patientsClientMocks.getPatient.mockImplementation(async (id: number) =>
+    patient({ patientId: id, hasSenadisDiscount: true, senadisExpirationDate: EXPIRY_BY_ID[id] ?? null }));
+  patientsClientMocks.getPatientCaretakers.mockResolvedValue([
+    { caretakerId: 1, caretakerName: 'Care, Cara', isPrimaryCaretaker: true, relationshipToPatient: 'Mother' },
+  ]);
+  lookupGetAllMock.mockResolvedValue([
+    { id: 6, abbreviation: 'TL', name: 'Language Therapy', description: null, sortOrder: 1, defaultAmount: 65, createdTimestamp: '', lastUpdatedTimestamp: '' },
+  ]);
+});
+
+// ── util predicate (G1/G2 truth table) ───────────────────────────────────────
+
+describe('isSenadisExpired — G1/G2 predicate', () => {
+  it('null/absent expiry never expires; boundary is NOT expired; strictly-earlier expiry is', () => {
+    expect(isSenadisExpired(null, '2026-08-01')).toBe(false);
+    expect(isSenadisExpired(undefined, '2026-08-01')).toBe(false);
+    expect(isSenadisExpired('', '2026-08-01')).toBe(false);
+    // API datetime vs date-input value — compared date-only
+    expect(isSenadisExpired('2026-08-15T00:00:00', '2026-08-15')).toBe(false); // boundary floors
+    expect(isSenadisExpired('2026-08-15T00:00:00', '2026-08-16')).toBe(true);
+    expect(isSenadisExpired('2026-08-15T00:00:00', '2026-08-14')).toBe(false);
+  });
+});
+
+// ── BookingFormModal — expiry-aware floor (G2) ───────────────────────────────
+
+type BookingVm = {
+  form: { patientId: number; sessionDate: string; amount: number; discount: number };
+  senadisPatient: boolean;
+  senadisActive: boolean;
+  senadisFloor: number;
+};
+
+async function openBookingModal(pinia: Pinia) {
+  const wrapper = mount(BookingFormModal, {
+    props: { visible: false },
+    global: { plugins: [pinia], stubs: { teleport: true } },
+  });
+  await wrapper.setProps({ visible: true });
+  await flushPromises();
+  return wrapper;
+}
+
+const badge = (wrapper: ReturnType<typeof mount>) =>
+  wrapper.find('[data-testid="senadis-expired-badge"]'); // re-find after every change (teleport-stub gotcha)
+
+describe('BookingFormModal — WP-37 expiry-aware SENADIS clamp', () => {
+  it('null expiry: floor + clamp still apply (G1 open-ended), no badge', async () => {
+    const wrapper = await openBookingModal(authAs('MGR'));
+    const vm = wrapper.vm as unknown as BookingVm;
+
+    vm.form.patientId = NULL_EXPIRY_ID;
+    await flushPromises();
+    vm.form.amount = 100;
+    await flushPromises();
+
+    expect(vm.senadisActive).toBe(true);
+    expect(vm.senadisFloor).toBe(20);
+    expect(vm.form.discount).toBe(20);
+    expect(badge(wrapper).exists()).toBe(false);
+  });
+
+  it('future expiry: floor + toast apply, no badge', async () => {
+    const pinia = authAs('MGR');
+    const wrapper = await openBookingModal(pinia);
+    const vm = wrapper.vm as unknown as BookingVm;
+    const notifications = useNotificationsStore();
+
+    vm.form.patientId = FUTURE_ID;
+    await flushPromises();
+    vm.form.amount = 100;
+    await flushPromises();
+
+    expect(vm.form.discount).toBe(20);
+    expect(notifications.items.filter((n) => n.message.includes('SENADIS'))).toHaveLength(1);
+    expect(badge(wrapper).exists()).toBe(false);
+  });
+
+  it('expired: NO floor, NO min, NO toast, NO clamp-on-submit — badge shown instead', async () => {
+    const pinia = authAs('MGR');
+    const wrapper = await openBookingModal(pinia);
+    const vm = wrapper.vm as unknown as BookingVm;
+    const notifications = useNotificationsStore();
+
+    vm.form.patientId = EXPIRED_ID;
+    await flushPromises();
+    vm.form.amount = 100;
+    vm.form.discount = 5;
+    await flushPromises();
+
+    expect(vm.senadisPatient).toBe(true); // flag stays on (G3 — never auto-cleared)
+    expect(vm.senadisActive).toBe(false);
+    expect(vm.senadisFloor).toBe(0);
+    expect(vm.form.discount).toBe(5); // not clamped
+    expect(notifications.items.filter((n) => n.message.includes('SENADIS'))).toHaveLength(0);
+    expect(badge(wrapper).exists()).toBe(true);
+    expect(badge(wrapper).text()).toContain('SENADIS expired Jun 30, 2020');
+
+    // submit does NOT clamp an expired patient's discount; the requested value goes through
+    (wrapper.vm as unknown as { handleSubmit: () => Promise<void> }).handleSubmit();
+    await vi.waitFor(() => expect(createSessionMock).toHaveBeenCalled());
+    expect(createSessionMock).toHaveBeenCalledWith(expect.objectContaining({ discount: 5 }));
+  });
+
+  it('boundary: session date == expiry still floors (G2: expired only when strictly past)', async () => {
+    const wrapper = await openBookingModal(authAs('MGR'));
+    const vm = wrapper.vm as unknown as BookingVm;
+
+    vm.form.sessionDate = '2026-08-15'; // == WINDOW expiry
+    vm.form.patientId = WINDOW_ID;
+    await flushPromises();
+    vm.form.amount = 100;
+    await flushPromises();
+
+    expect(vm.senadisActive).toBe(true);
+    expect(vm.form.discount).toBe(20);
+    expect(badge(wrapper).exists()).toBe(false);
+  });
+
+  it('changing the session date across the expiry flips floor/badge both ways', async () => {
+    const wrapper = await openBookingModal(authAs('MGR'));
+    const vm = wrapper.vm as unknown as BookingVm;
+
+    vm.form.sessionDate = '2026-08-10'; // before expiry
+    vm.form.patientId = WINDOW_ID;
+    await flushPromises();
+    vm.form.amount = 100;
+    await flushPromises();
+    expect(vm.form.discount).toBe(20); // clamped
+
+    // cross past the expiry: floor lifts, badge appears, discount can go below 20%
+    vm.form.sessionDate = '2026-08-20';
+    await nextTick();
+    expect(vm.senadisActive).toBe(false);
+    expect(vm.senadisFloor).toBe(0);
+    expect(badge(wrapper).exists()).toBe(true);
+    vm.form.discount = 3;
+    await nextTick();
+    expect(vm.form.discount).toBe(3); // no re-clamp while expired
+
+    // move back on/before the expiry: the clamp re-applies
+    vm.form.sessionDate = '2026-08-15';
+    await nextTick();
+    expect(vm.senadisActive).toBe(true);
+    expect(vm.form.discount).toBe(20);
+    expect(badge(wrapper).exists()).toBe(false);
+  });
+});
+
+// ── PatientFormModal — expiration field, gating, badge, payloads ─────────────
+
+async function openPatientModal(pinia: Pinia, p: Patient | null) {
+  const wrapper = mount(PatientFormModal, {
+    props: { visible: false, patient: p },
+    global: { plugins: [pinia], stubs: { teleport: true } },
+  });
+  await wrapper.setProps({ visible: true });
+  return wrapper;
+}
+
+// First checkbox in the form is the SENADIS flag (WP-23 precedent).
+const senadisCheckbox = (wrapper: ReturnType<typeof mount>) => wrapper.find('input[type="checkbox"]');
+const expiryInput = (wrapper: ReturnType<typeof mount>) => wrapper.find('[data-testid="senadis-expiration-input"]');
+
+describe('PatientFormModal — WP-37 expiration field', () => {
+  it('hidden while the flag is off; appears (enabled) once checked on CREATE', async () => {
+    const wrapper = await openPatientModal(authAs('FD'), null);
+
+    expect(expiryInput(wrapper).exists()).toBe(false);
+    await senadisCheckbox(wrapper).setValue(true);
+    expect(expiryInput(wrapper).exists()).toBe(true);
+    expect((expiryInput(wrapper).element as HTMLInputElement).disabled).toBe(false); // SEN-2: create stays free
+  });
+
+  it('EDIT claim gate mirrors the flag: FD disabled, MGR enabled (G4 — same claim)', async () => {
+    const fd = await openPatientModal(authAs('FD'), patient({ hasSenadisDiscount: true, senadisExpirationDate: '2099-12-31T00:00:00' }));
+    expect((expiryInput(fd).element as HTMLInputElement).disabled).toBe(true);
+
+    const mgr = await openPatientModal(authAs('MGR'), patient({ hasSenadisDiscount: true, senadisExpirationDate: '2099-12-31T00:00:00' }));
+    expect((expiryInput(mgr).element as HTMLInputElement).disabled).toBe(false);
+  });
+
+  it('badge: past expiry shows "SENADIS expired {date}"; future or null expiry does not', async () => {
+    const past = await openPatientModal(authAs('MGR'), patient({ hasSenadisDiscount: true, senadisExpirationDate: '2020-06-30T00:00:00' }));
+    expect(badge(past).exists()).toBe(true);
+    expect(badge(past).text()).toContain('SENADIS expired Jun 30, 2020');
+    // G3: the flag stays checked — expired is badge-only, never auto-cleared
+    expect((senadisCheckbox(past).element as HTMLInputElement).checked).toBe(true);
+
+    const future = await openPatientModal(authAs('MGR'), patient({ hasSenadisDiscount: true, senadisExpirationDate: '2099-12-31T00:00:00' }));
+    expect(badge(future).exists()).toBe(false);
+
+    const none = await openPatientModal(authAs('MGR'), patient({ hasSenadisDiscount: true, senadisExpirationDate: null }));
+    expect(badge(none).exists()).toBe(false);
+    expect((expiryInput(none).element as HTMLInputElement).value).toBe('');
+  });
+
+  it('MGR on EDIT: a set date is sent as T00:00:00 (echo keeps working); blank is omitted', async () => {
+    const wrapper = await openPatientModal(authAs('MGR'), patient({ hasSenadisDiscount: true, senadisExpirationDate: null }));
+
+    await expiryInput(wrapper).setValue('2027-06-30');
+    await wrapper.find('form').trigger('submit');
+    await vi.waitFor(() => expect(updatePatientMock).toHaveBeenCalled());
+    expect(updatePatientMock.mock.calls[0][1].senadisExpirationDate).toBe('2027-06-30T00:00:00');
+  });
+
+  it('MGR on EDIT with blank expiry: field omitted (omitted/null = unchanged server-side)', async () => {
+    const wrapper = await openPatientModal(authAs('MGR'), patient({ hasSenadisDiscount: true, senadisExpirationDate: null }));
+
+    await wrapper.find('form').trigger('submit');
+    await vi.waitFor(() => expect(updatePatientMock).toHaveBeenCalled());
+    expect(updatePatientMock.mock.calls[0][1].senadisExpirationDate).toBeUndefined();
+  });
+
+  it('FD on EDIT: payload omits the expiry (same omit-when-gated rule as the flag)', async () => {
+    const wrapper = await openPatientModal(authAs('FD'), patient({ hasSenadisDiscount: true, senadisExpirationDate: '2027-06-30T00:00:00' }));
+
+    await wrapper.find('form').trigger('submit');
+    await vi.waitFor(() => expect(updatePatientMock).toHaveBeenCalled());
+    expect(updatePatientMock.mock.calls[0][1].senadisExpirationDate).toBeUndefined();
+    expect(updatePatientMock.mock.calls[0][1].hasSenadisDiscount).toBeUndefined();
+  });
+
+  it('FD on CREATE: flag + expiry both sent (SEN-2 — create is free for any creating role)', async () => {
+    const wrapper = await openPatientModal(authAs('FD'), null);
+
+    await senadisCheckbox(wrapper).setValue(true);
+    // date inputs: [0] = DOB, [1] = SENADIS expiry (visible now the flag is on)
+    const dates = wrapper.findAll('input[type="date"]');
+    await dates[0].setValue('2015-01-15');
+    await dates[1].setValue('2027-06-30');
+    await wrapper.find('input[type="email"]').setValue('new@example.com');
+    await wrapper.find('input[type="tel"]').setValue('555-0101');
+    await wrapper.find('select').setValue('Male');
+    const textInputs = wrapper.findAll('input[type="text"]');
+    await textInputs[0].setValue('First');
+    await textInputs[2].setValue('Last');
+    await textInputs[3].setValue('001-0000001-1'); // cedula — required at create (WP-25)
+
+    await wrapper.find('form').trigger('submit');
+    await vi.waitFor(() => expect(createPatientMock).toHaveBeenCalled());
+    expect(createPatientMock).toHaveBeenCalledWith(
+      expect.objectContaining({ hasSenadisDiscount: true, senadisExpirationDate: '2027-06-30T00:00:00' })
+    );
+  });
+});
+
+// ── SchedulePlanWizard — expiry-aware per-line clamp (vs schedule START date) ─
+
+function makePlan(patientId: number): TreatmentPlan {
+  return {
+    id: 11,
+    patientId,
+    patientName: 'Doe, John',
+    displayTitle: 'Plan #11',
+    planStatus: 'Active',
+    weeklyFrequency: 1,
+    durationWeeks: 2,
+    lines: [
+      {
+        id: 1,
+        specialtyAbbreviation: 'TL',
+        duration: 60, // amount 65.00 ⇒ floor 13.00
+        preferredTherapistId: null,
+        dayOfWeek: 1,
+        preferredTime: '09:00',
+      },
+    ],
+  } as unknown as TreatmentPlan;
+}
+
+type WizardVm = {
+  senadisPatient: boolean;
+  senadisActive: boolean;
+  senadisExpired: boolean;
+  startDate: string;
+  lineEdits: Array<{ discountAmount: number; discountPct: number }>;
+};
+
+async function openWizard(pinia: Pinia, patientId: number) {
+  const wrapper = mount(SchedulePlanWizard, {
+    props: { visible: false, plan: makePlan(patientId) },
+    global: { plugins: [pinia], stubs: { teleport: true } },
+  });
+  await wrapper.setProps({ visible: true });
+  await flushPromises();
+  return wrapper;
+}
+
+describe('SchedulePlanWizard — WP-37 expiry-aware per-line clamp', () => {
+  it('unexpired (far-future expiry): lines still initialize to the 20% floor', async () => {
+    const wrapper = await openWizard(authAs('MGR'), FUTURE_ID);
+    const vm = wrapper.vm as unknown as WizardVm;
+
+    expect(vm.senadisActive).toBe(true);
+    expect(vm.lineEdits[0].discountAmount).toBe(13);
+    expect(vm.lineEdits[0].discountPct).toBe(20);
+  });
+
+  it('expired as of the schedule start date: no clamp, flag intact, badge state on', async () => {
+    const wrapper = await openWizard(authAs('MGR'), EXPIRED_ID);
+    const vm = wrapper.vm as unknown as WizardVm;
+
+    expect(vm.senadisPatient).toBe(true); // G3 — flag never auto-cleared
+    expect(vm.senadisActive).toBe(false);
+    expect(vm.senadisExpired).toBe(true);
+    expect(vm.lineEdits[0].discountAmount).toBe(0); // untouched
+  });
+
+  it('moving the start date across the expiry flips the clamp both ways', async () => {
+    const wrapper = await openWizard(authAs('MGR'), WINDOW_ID); // expiry 2026-08-15
+    const vm = wrapper.vm as unknown as WizardVm;
+
+    vm.startDate = '2026-08-10'; // on/before expiry ⇒ clamp applies
+    await nextTick();
+    expect(vm.senadisActive).toBe(true);
+    expect(vm.lineEdits[0].discountAmount).toBe(13);
+
+    vm.startDate = '2026-08-20'; // past expiry ⇒ min lifts; user may lower the discount
+    await nextTick();
+    expect(vm.senadisActive).toBe(false);
+    vm.lineEdits[0].discountAmount = 0;
+    await nextTick();
+    expect(vm.lineEdits[0].discountAmount).toBe(0); // no re-clamp while expired
+
+    vm.startDate = '2026-08-15'; // boundary ⇒ active again, watcher re-clamps
+    await nextTick();
+    expect(vm.senadisActive).toBe(true);
+    expect(vm.lineEdits[0].discountAmount).toBe(13);
+  });
+});

--- a/app-ui/src/components/appointments/BookingFormModal.vue
+++ b/app-ui/src/components/appointments/BookingFormModal.vue
@@ -93,9 +93,14 @@
             </div>
             <div>
               <label class="block text-sm font-medium text-slate-700 mb-1">Discount</label>
-              <!-- WP-23 (F7): min rides the SENADIS floor; the clamp re-applies on amount/patient change and at submit -->
+              <!-- WP-23 (F7): min rides the SENADIS floor; the clamp re-applies on amount/patient change and at submit.
+                   WP-37 (SEN-1/G2): floor/min/hint only while the SENADIS is active for the chosen
+                   session date — expired ⇒ no floor at all, amber badge explains why (G3). -->
               <input v-model.number="form.discount" type="number" :min="senadisFloor" step="0.01" class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:ring-2 focus:ring-violet-500 focus:border-violet-500" />
-              <p v-if="senadisPatient" class="mt-1 text-xs text-violet-600">SENADIS: min {{ senadisFloor.toFixed(2) }} (20%)</p>
+              <p v-if="senadisActive" class="mt-1 text-xs text-violet-600">SENADIS: min {{ senadisFloor.toFixed(2) }} (20%)</p>
+              <p v-else-if="senadisExpired" data-testid="senadis-expired-badge" class="mt-1 text-xs font-medium text-amber-600">
+                SENADIS expired {{ formatSenadisExpiry(senadisExpiry) }} — no discount floor for this session date.
+              </p>
             </div>
             <!-- WP-17C: cosmetic only — the API still returns ProviderAmount to anyone with Appointments.View; true field-level enforcement needs API response-shaping (deferred). -->
             <div v-if="hasClaim('Permission', Permissions.AppointmentsProviderAmount)">
@@ -153,6 +158,7 @@ import type { LookupItem } from '../../interfaces/Lookups';
 import { isDiscoverySpecialty } from '../../interfaces/TreatmentPlan';
 import { TIME_MIN, TIME_MAX, TIME_STEP } from '../../utils/timeSlots';
 import { useClaims, Permissions } from '../../composables/useClaims';
+import { isSenadisExpired, formatSenadisExpiry } from '../../utils/senadis';
 import { useNotificationsStore } from '../../stores/notifications';
 import LookupSelect, { type LookupOption } from '../shared/LookupSelect.vue';
 
@@ -181,6 +187,8 @@ export default defineComponent({
     const caretakerWarning = ref(false);
     const needsDiscovery = ref(false);
     const senadisPatient = ref(false);
+    // WP-37 (SEN-1): the flagged patient's expiry as sent by the API ("...T00:00:00" | null).
+    const senadisExpiry = ref<string | null>(null);
     const notifications = useNotificationsStore();
 
     const today = new Date().toISOString().split('T')[0];
@@ -260,13 +268,25 @@ export default defineComponent({
       }
     });
 
-    // WP-23 (F7): statutory SENADIS floor — 20% of Amount, 2dp; 0 for unflagged patients.
+    // WP-37 (SEN-1/G2): the floor applies only while the SENADIS is active for the SESSION DATE
+    // being booked — no expiry (null) = always active; boundary (session date == expiry) still
+    // floors; expired ⇒ no floor/min/clamp and the badge explains why. Re-evaluates when the
+    // user changes the booking date. The flag itself is never auto-cleared (G3).
+    const senadisActive = computed(
+      () => senadisPatient.value && !isSenadisExpired(senadisExpiry.value, form.value.sessionDate)
+    );
+    const senadisExpired = computed(
+      () => senadisPatient.value && isSenadisExpired(senadisExpiry.value, form.value.sessionDate)
+    );
+
+    // WP-23 (F7): statutory SENADIS floor — 20% of Amount, 2dp; 0 for unflagged patients
+    // (and, as of WP-37, for flagged-but-expired ones).
     const senadisFloor = computed(() =>
-      senadisPatient.value ? Math.round(0.20 * form.value.amount * 100) / 100 : 0
+      senadisActive.value ? Math.round(0.20 * form.value.amount * 100) / 100 : 0
     );
 
     const applySenadisFloor = () => {
-      if (senadisPatient.value && form.value.discount < senadisFloor.value) {
+      if (senadisActive.value && form.value.discount < senadisFloor.value) {
         form.value.discount = senadisFloor.value;
       }
     };
@@ -330,7 +350,7 @@ export default defineComponent({
     };
 
     const checkDiscovery = async (patientId: number) => {
-      if (patientId <= 0) { needsDiscovery.value = false; senadisPatient.value = false; return; }
+      if (patientId <= 0) { needsDiscovery.value = false; senadisPatient.value = false; senadisExpiry.value = null; return; }
       try {
         const patient = await patientsClient.getPatient(patientId);
         // WP-24 (F3/F4): requiresDiscovery=false waives the discovery-first rule (legacy
@@ -338,20 +358,27 @@ export default defineComponent({
         needsDiscovery.value = patient.requiresDiscovery !== false && patient.hasCompletedDiscovery === false;
         // WP-23 (F7): same fetched profile carries the SENADIS flag — one toast per
         // patient selection, then clamp the discount up to the floor.
+        // WP-37: also carries the expiry; toast + clamp only when active for the session date
+        // (a flagged-but-expired patient gets the badge instead — no floor).
         senadisPatient.value = patient.hasSenadisDiscount === true;
-        if (senadisPatient.value) {
+        senadisExpiry.value = patient.senadisExpirationDate ?? null;
+        if (senadisActive.value) {
           notifications.info('SENADIS: statutory 20% discount applied — it cannot be reduced.');
           applySenadisFloor();
         }
       } catch {
         needsDiscovery.value = false; // Fail open — don't block booking
         senadisPatient.value = false; // (the API floors server-side regardless)
+        senadisExpiry.value = null;
       }
     };
 
     watch(() => form.value.patientId, (id) => { checkCaretaker(id); checkDiscovery(id); });
     // WP-23 (F7): re-clamp when the amount moves the floor.
     watch(() => form.value.amount, applySenadisFloor);
+    // WP-37 (G2): re-clamp when the session date crosses back on/before the expiry (the floor
+    // computed lifts on its own when the date crosses past it — an existing discount is kept).
+    watch(() => form.value.sessionDate, applySenadisFloor);
     watch(form, () => { saveError.value = ''; }, { deep: true });
 
     watch(() => props.visible, (val) => {
@@ -360,6 +387,7 @@ export default defineComponent({
         saveError.value = '';
         needsDiscovery.value = false;
         senadisPatient.value = false;
+        senadisExpiry.value = null;
         selectedPatient.value = null;
         if (props.preSelectPatientId > 0) {
           loadPreselectedPatient(props.preSelectPatientId);
@@ -409,7 +437,7 @@ export default defineComponent({
       }
     };
 
-    return { form, selectedPatient, fetchPatientOptions, filteredTherapists, filteredSpecialties, saving, saveError, caretakerWarning, needsDiscovery, senadisPatient, senadisFloor, isValid, handleSubmit, timeMin: TIME_MIN, timeMax: TIME_MAX, timeStep: TIME_STEP, hasClaim, Permissions };
+    return { form, selectedPatient, fetchPatientOptions, filteredTherapists, filteredSpecialties, saving, saveError, caretakerWarning, needsDiscovery, senadisPatient, senadisExpiry, senadisActive, senadisExpired, senadisFloor, formatSenadisExpiry, isValid, handleSubmit, timeMin: TIME_MIN, timeMax: TIME_MAX, timeStep: TIME_STEP, hasClaim, Permissions };
   },
 });
 </script>

--- a/app-ui/src/components/patients/PatientFormModal.vue
+++ b/app-ui/src/components/patients/PatientFormModal.vue
@@ -114,6 +114,32 @@
             <p v-if="!canEditSenadis" class="text-xs text-slate-400">
               Only Managers / Assistant Managers can change the SENADIS flag.
             </p>
+            <!-- WP-37 (SEN-1): expiration date — shown only while the flag is checked, disabled
+                 by the same claim gate as the flag (G4: one claim governs both fields). An
+                 expired SENADIS keeps the flag checked (G3) — badge only, never auto-cleared. -->
+            <div v-if="form.hasSenadisDiscount" class="pl-6 space-y-1">
+              <label class="block text-sm font-medium text-slate-700">SENADIS expiration date</label>
+              <input
+                v-model="form.senadisExpirationDate"
+                type="date"
+                :disabled="!canEditSenadis"
+                data-testid="senadis-expiration-input"
+                class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:cursor-not-allowed disabled:bg-slate-50 disabled:text-slate-500"
+              />
+              <span
+                v-if="senadisExpired"
+                data-testid="senadis-expired-badge"
+                class="inline-flex items-center rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800"
+              >
+                SENADIS expired {{ formatSenadisExpiry(form.senadisExpirationDate) }}
+              </span>
+              <p v-if="senadisExpired" class="text-xs text-amber-600">
+                Bookings for dates after the expiry get no automatic discount; the flag stays on for history.
+              </p>
+              <p v-else class="text-xs text-slate-400">
+                Leave blank for no expiry. An expiry already on file can be extended, not cleared.
+              </p>
+            </div>
           </div>
 
           <!-- WP-24 (F3/F4): discovery-first waiver — free at create (default CHECKED); on edit
@@ -297,6 +323,7 @@ import { useModalForm } from '../../composables/useModalForm';
 import FormErrorBanner from '../shared/FormErrorBanner.vue';
 import { PatientsHttpClient } from '../../services/PatientsHttpClient';
 import { formatAge } from '../../utils/age';
+import { isSenadisExpired, formatSenadisExpiry, todayDateOnly } from '../../utils/senadis';
 import { useClaims, Permissions } from '../../composables/useClaims';
 
 function parseName(patientName: string) {
@@ -354,6 +381,8 @@ export default defineComponent({
       medicalRecordNumber: '',
       cedula: '',
       hasSenadisDiscount: false,
+      // WP-37 (SEN-1): yyyy-MM-dd date-input value; '' = no expiry (G1 null).
+      senadisExpirationDate: '',
       // WP-24 (F3): discovery required by default — a new patient must complete a discovery
       // session before treatment bookings unless explicitly waived at create.
       requiresDiscovery: true,
@@ -397,6 +426,12 @@ export default defineComponent({
       () => isEdit.value && !hadCedulaOnFile.value && !form.cedula.trim()
     );
 
+    // WP-37 (SEN-1/G3): in this modal (no session-date context) "expired" means strictly before
+    // today, date-only. Badge only — an expired SENADIS still saves fine and the flag stays on.
+    const senadisExpired = computed(
+      () => form.hasSenadisDiscount && isSenadisExpired(form.senadisExpirationDate, todayDateOnly())
+    );
+
     watch(form, () => clearError(), { deep: true });
 
     watch(
@@ -418,6 +453,10 @@ export default defineComponent({
           form.cedula = props.patient.cedula ?? '';
           hadCedulaOnFile.value = !!props.patient.cedula; // WP-25: on-file value may never be cleared
           form.hasSenadisDiscount = props.patient.hasSenadisDiscount === true;
+          // WP-37: API sends "2027-06-30T00:00:00" | null — date inputs want yyyy-MM-dd.
+          form.senadisExpirationDate = props.patient.senadisExpirationDate
+            ? formatDobForInput(props.patient.senadisExpirationDate)
+            : '';
           // WP-24: absent/undefined (older API) reads as true — only an explicit false waives.
           form.requiresDiscovery = props.patient.requiresDiscovery !== false;
           form.activeStatus = props.patient.isActive;
@@ -434,6 +473,7 @@ export default defineComponent({
           form.cedula = '';
           hadCedulaOnFile.value = false;
           form.hasSenadisDiscount = false;
+          form.senadisExpirationDate = ''; // WP-37: no expiry by default
           form.requiresDiscovery = true; // WP-24: default CHECKED at create
           form.activeStatus = true;
           linkRelationship.value = null;
@@ -482,6 +522,13 @@ export default defineComponent({
             cedula: form.cedula.trim() || undefined,
             // WP-23 (F7): only send when this user may edit it — omitted = unchanged server-side.
             hasSenadisDiscount: canEditSenadis.value ? form.hasSenadisDiscount : undefined,
+            // WP-37 (SEN-1/G4): same gate as the flag (omit when not editable). Also omitted
+            // when blank or when the flag is off — omitted/null = unchanged server-side, and a
+            // stored expiry can only be extended, never cleared, via PUT.
+            senadisExpirationDate:
+              canEditSenadis.value && form.hasSenadisDiscount && form.senadisExpirationDate
+                ? formatDobForApi(form.senadisExpirationDate)
+                : undefined,
             // WP-24 (F3/F4): same omit-when-gated rule.
             requiresDiscovery: canEditRequiresDiscovery.value ? form.requiresDiscovery : undefined,
           };
@@ -516,6 +563,11 @@ export default defineComponent({
             medicalRecordNumber: form.medicalRecordNumber || undefined,
             cedula: form.cedula.trim(), // WP-25 (F5): required at create — guard above ensures non-blank
             hasSenadisDiscount: form.hasSenadisDiscount,
+            // WP-37 (SEN-2): free at create for any patient-creating role; omitted = no expiry.
+            senadisExpirationDate:
+              form.hasSenadisDiscount && form.senadisExpirationDate
+                ? formatDobForApi(form.senadisExpirationDate)
+                : undefined,
             requiresDiscovery: form.requiresDiscovery,
           });
           // WP-27: hand the created record (plus chain link fields when applicable) to the
@@ -533,7 +585,7 @@ export default defineComponent({
       });
     };
 
-    return { form, isEdit, saving, error, hasError, hasTemporaryMrn, cannotActivate, canEditSenadis, canEditRequiresDiscovery, age, hadCedulaOnFile, showLegacyCedulaNag, linkRelationship, linkIsPrimary, handleSubmit };
+    return { form, isEdit, saving, error, hasError, hasTemporaryMrn, cannotActivate, canEditSenadis, canEditRequiresDiscovery, age, hadCedulaOnFile, showLegacyCedulaNag, senadisExpired, formatSenadisExpiry, linkRelationship, linkIsPrimary, handleSubmit };
   },
 });
 </script>

--- a/app-ui/src/components/treatment-plans/SchedulePlanWizard.vue
+++ b/app-ui/src/components/treatment-plans/SchedulePlanWizard.vue
@@ -118,11 +118,12 @@
                   <div class="flex items-center space-x-2">
                     <div class="relative flex-1">
                       <span class="absolute left-2 top-1.5 text-xs text-slate-400">$</span>
-                      <!-- WP-23 (F7): min rides the per-line SENADIS floor; submit clamps, API floors -->
+                      <!-- WP-23 (F7): min rides the per-line SENADIS floor; submit clamps, API floors.
+                           WP-37 (G2): only while active as of the schedule start date. -->
                       <input
                         type="number"
                         step="0.01"
-                        :min="senadisPatient ? lineFloor(line) : 0"
+                        :min="senadisActive ? lineFloor(line) : 0"
                         v-model.number="line.discountAmount"
                         @input="updateDiscountPct(line)"
                         class="w-full pl-5 pr-2 py-1.5 border border-slate-200 rounded-lg text-sm"
@@ -133,7 +134,7 @@
                       <input
                         type="number"
                         step="0.1"
-                        :min="senadisPatient ? 20 : 0"
+                        :min="senadisActive ? 20 : 0"
                         max="100"
                         v-model.number="line.discountPct"
                         @input="updateDiscountAmt(line)"
@@ -148,8 +149,11 @@
                       &rarr; Net: ${{ (lineAmount(line) - line.discountAmount).toFixed(2) }}
                     </template>
                   </p>
-                  <p v-if="senadisPatient" class="text-xs text-violet-600 mt-0.5">
+                  <p v-if="senadisActive" class="text-xs text-violet-600 mt-0.5">
                     SENADIS: min ${{ lineFloor(line).toFixed(2) }} (20%)
+                  </p>
+                  <p v-else-if="senadisExpired" data-testid="senadis-expired-badge" class="text-xs font-medium text-amber-600 mt-0.5">
+                    SENADIS expired {{ formatSenadisExpiry(senadisExpiry) }} — no discount floor for this schedule.
                   </p>
                 </div>
               </div>
@@ -313,6 +317,7 @@ import { PatientsHttpClient } from '../../services/PatientsHttpClient';
 import type { Site } from '../../interfaces/Site';
 import type { Therapist } from '../../interfaces/Therapist';
 import { useClaims, Permissions } from '../../composables/useClaims';
+import { isSenadisExpired, formatSenadisExpiry } from '../../utils/senadis';
 
 interface LineEdit {
   lineId: number;
@@ -354,6 +359,20 @@ export default defineComponent({
     // WP-23: F10 hard block + F7 per-line SENADIS floor.
     const caretakerBlocked = ref(false);
     const senadisPatient = ref(false);
+    // WP-37 (SEN-1): the flagged patient's expiry as sent by the API ("...T00:00:00" | null).
+    const senadisExpiry = ref<string | null>(null);
+
+    // WP-37 (SEN-1/G2): the clamp only applies while the SENADIS is active as of the schedule
+    // START date (conservative — a schedule that starts on/before the expiry keeps the per-line
+    // clamp even if later weeks run past it; the API floors per SESSION date server-side, so
+    // only the on/before-expiry sessions are actually floored). A schedule starting after the
+    // expiry gets no clamp at all + the badge. Flag never auto-cleared (G3).
+    const senadisActive = computed(
+      () => senadisPatient.value && !isSenadisExpired(senadisExpiry.value, startDate.value)
+    );
+    const senadisExpired = computed(
+      () => senadisPatient.value && isSenadisExpired(senadisExpiry.value, startDate.value)
+    );
 
     // Alternative selection for conflict resolution
     // Key: "conflictIdx-altIdx", Value: { lineId, alternative }
@@ -411,9 +430,21 @@ export default defineComponent({
 
     // WP-23: one profile + caretaker fetch per wizard open; on failure fail open — the API
     // enforces both rules server-side (caretaker 400, discount floored).
+    // WP-37: shared so the startDate watcher can re-clamp when the date moves back on/before
+    // the expiry (crossing past it just lifts the min — an already-entered discount is kept).
+    const applyLineFloors = () => {
+      for (const line of lineEdits.value) {
+        if (line.discountAmount < lineFloor(line)) {
+          line.discountAmount = lineFloor(line);
+          updateDiscountPct(line);
+        }
+      }
+    };
+
     const checkPatientFlags = async () => {
       caretakerBlocked.value = false;
       senadisPatient.value = false;
+      senadisExpiry.value = null;
       if (!props.plan) return;
       try {
         const [patient, caretakers] = await Promise.all([
@@ -422,18 +453,19 @@ export default defineComponent({
         ]);
         caretakerBlocked.value = caretakers.length === 0;
         senadisPatient.value = patient.hasSenadisDiscount === true;
-        if (senadisPatient.value) {
-          for (const line of lineEdits.value) {
-            if (line.discountAmount < lineFloor(line)) {
-              line.discountAmount = lineFloor(line);
-              updateDiscountPct(line);
-            }
-          }
+        senadisExpiry.value = patient.senadisExpirationDate ?? null;
+        if (senadisActive.value) {
+          applyLineFloors();
         }
       } catch {
         // fail open (see above)
       }
     };
+
+    // WP-37 (G2): re-evaluate the clamp when the schedule start date changes.
+    watch(startDate, () => {
+      if (senadisActive.value) applyLineFloors();
+    });
 
     const updateDiscountPct = (line: LineEdit) => {
       const amt = lineAmount(line);
@@ -526,7 +558,8 @@ export default defineComponent({
         dayOfWeek: le.dayOfWeek > 0 ? le.dayOfWeek : null,
         time: le.time || null,
         // WP-23 (F7): last-line clamp to the SENADIS floor; the API floors server-side too.
-        discountAmount: senadisPatient.value
+        // WP-37 (G2): no clamp when the SENADIS is expired as of the schedule start date.
+        discountAmount: senadisActive.value
           ? Math.max(le.discountAmount, lineFloor(le))
           : (le.discountAmount > 0 ? le.discountAmount : null),
       }));
@@ -576,6 +609,10 @@ export default defineComponent({
       lineFloor,
       caretakerBlocked,
       senadisPatient,
+      senadisExpiry,
+      senadisActive,
+      senadisExpired,
+      formatSenadisExpiry,
       updateDiscountPct,
       updateDiscountAmt,
       sessionsByWeek,

--- a/app-ui/src/interfaces/Patient.ts
+++ b/app-ui/src/interfaces/Patient.ts
@@ -18,6 +18,11 @@ export interface Patient {
   // floor; edit gated by Patients.SenadisDiscount.Edit (MGR/AM). Optional so the UI
   // tolerates an older deployed API (absent ⇒ treated as false).
   hasSenadisDiscount?: boolean;
+  // WP-37 (SEN-1): SENADIS credential expiry — "2027-06-30T00:00:00" | null. null = no expiry
+  // (open-ended, G1). Expired for a booking when expiry < the SESSION date (G2); an expired
+  // SENADIS keeps hasSenadisDiscount = true (G3 — badge, never auto-cleared). Optional so the
+  // UI tolerates an older deployed API (absent ⇒ treated as no expiry).
+  senadisExpirationDate?: string | null;
   // WP-24 (F3/F4): discovery-first waiver — false = exempt from the completed-discovery-
   // before-treatment rule (legacy imports are backfilled false). Default true; edit gated by
   // Patients.RequiresDiscovery.Edit (MGR/AM). Optional so the UI tolerates an older deployed
@@ -50,6 +55,9 @@ export interface PatientCreateRequest {
   // WP-25 (F5): "Cedula | Passport" — required at create (free text, unique; duplicate → 409).
   cedula: string;
   hasSenadisDiscount?: boolean;
+  // WP-37 (SEN-1): optional, default null = no expiry. Free at create for any patient-creating
+  // role (SEN-2) — the edit gate applies to later PUTs only.
+  senadisExpirationDate?: string | null;
   // WP-24 (F3): omitted = true server-side (discovery required by default).
   requiresDiscovery?: boolean;
 }
@@ -71,6 +79,10 @@ export interface PatientUpdateRequest {
   cedula?: string;
   // Omit when the caller may not edit it (claim-gated) — omitted/null = unchanged server-side.
   hasSenadisDiscount?: boolean;
+  // WP-37 (SEN-1/G4): rides the SAME Patients.SenadisDiscount.Edit gate as the flag — omit when
+  // the caller may not edit it (omitted/null = unchanged server-side). Consequence: an expiry,
+  // once set, cannot be cleared back to null via PUT — extend it with a later date instead.
+  senadisExpirationDate?: string | null;
   // Omit when the caller may not edit it (claim-gated) — omitted/null = unchanged server-side.
   requiresDiscovery?: boolean;
 }

--- a/app-ui/src/utils/senadis.ts
+++ b/app-ui/src/utils/senadis.ts
@@ -1,0 +1,41 @@
+// WP-37 (SEN-1): SENADIS discount-expiration helpers, shared by PatientFormModal,
+// BookingFormModal, and SchedulePlanWizard so the G2/G3 semantics can't drift between them:
+//   G2 — the discount is expired for a given booking when expiration < the SESSION date
+//        (comparison is against the session date being booked, not "today").
+//   G3 — an expired SENADIS keeps hasSenadisDiscount = true (history is never auto-cleared);
+//        the UI shows a "SENADIS expired {date}" badge instead of applying the floor.
+// The API applies the same predicate server-side (Patient.HasActiveSenadisDiscount) — these
+// helpers only keep the modal hints/clamps honest before submit.
+
+/** Date-only `yyyy-MM-dd` from an API datetime (`2027-06-30T00:00:00`) or a date-input value. */
+export function toDateOnly(value: string): string {
+  return value.slice(0, 10);
+}
+
+/** Local today as `yyyy-MM-dd` (no UTC shift — toISOString would skew evening timezones). */
+export function todayDateOnly(): string {
+  const d = new Date();
+  return `${String(d.getFullYear()).padStart(4, '0')}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+}
+
+/**
+ * G2: expired when `expiration < onDate`, date-only. The boundary (onDate == expiration) is
+ * NOT expired — a session booked for the expiry day itself still gets the floor. Null/absent
+ * expiry = open-ended (G1), never expires; a blank onDate compares as not-expired (fail open —
+ * the API floors server-side regardless).
+ */
+export function isSenadisExpired(expiration: string | null | undefined, onDate: string): boolean {
+  if (!expiration || !onDate) return false;
+  // ISO yyyy-MM-dd strings compare correctly as plain strings — no Date parsing, no timezone.
+  return toDateOnly(expiration) < toDateOnly(onDate);
+}
+
+const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+/** Badge text date — deterministic, locale-independent (e.g. `Jun 30, 2026`). */
+export function formatSenadisExpiry(expiration: string | null | undefined): string {
+  if (!expiration) return '';
+  const [y, m, d] = toDateOnly(expiration).split('-').map(Number);
+  if (!y || !m || !d) return toDateOnly(expiration);
+  return `${MONTHS[m - 1]} ${d}, ${y}`;
+}

--- a/app-ui/test-scenarios/wp-37-senadis-expiration.md
+++ b/app-ui/test-scenarios/wp-37-senadis-expiration.md
@@ -1,0 +1,93 @@
+# WP-37C — SENADIS Discount Expiration Date: owner walkthrough
+
+The SENADIS discount now carries an optional **expiration date** on the patient profile. An
+expired SENADIS stops producing the automatic 20% discount floor at booking — compared against
+the **session date being booked** (a session booked for a date on/before the expiry still gets
+the floor). An expired SENADIS **never un-checks the flag**: history is preserved and the UI
+shows an amber **"SENADIS expired {date}"** badge instead of the floor. The date rides the same
+permission as the flag itself (`Patients.SenadisDiscount.Edit`): free at create for any
+patient-creating role, **MGR/AM only** on later edits.
+
+**Prereqs:** DB **V031** applied, API **WP-37B** deployed, this UI (WP-37C) deployed. No
+RoleClaim reseed and **no re-login needed** — no permission changed. You need one test patient
+with the SENADIS flag on (any of the ~30 backfill-era SENADIS patients works, or make one).
+
+## Scenario 1 — MGR sets an expiration date
+
+1. Sign in as a **Manager**. Patients → edit a patient whose **SENADIS discount** box is checked.
+2. **Expected:** below the SENADIS checkbox there is now a **"SENADIS expiration date"** field
+   (it only appears while the flag is checked — uncheck the flag and it disappears), with the
+   hint *"Leave blank for no expiry. An expiry already on file can be extended, not cleared."*
+3. Set the expiry to a date **next month**, save, and re-open the patient.
+4. **Expected:** the date is stored and shown; **no** expired badge (the date is still ahead).
+5. Now edit again and set the expiry to a date **last month**, save, re-open.
+6. **Expected:** an amber badge **"SENADIS expired {date}"** under the date field, and the
+   flag checkbox is **still checked** — expiry never clears the flag.
+
+## Scenario 2 — FD sees the expiry read-only on existing patients
+
+1. Sign in as a **Front Desk** user and edit the same patient.
+2. **Expected:** the SENADIS checkbox AND the expiration date are both **greyed out /
+   disabled** (same *"Only Managers / Assistant Managers…"* note as before). The expired badge
+   from Scenario 1 is still visible — FD can see *why* no discount will apply, just not
+   change it.
+3. Change something harmless (e.g. phone number) and save.
+4. **Expected:** the save succeeds — FD editing an unrelated field never trips the SENADIS
+   permission (the app omits the gated fields; the API treats omitted as unchanged).
+
+## Scenario 3 — booking: session date vs expiry (the money behavior)
+
+Use the patient from Scenario 1 (expiry now in the past, flag on) after temporarily setting
+the expiry to a **known nearby date** as MGR — e.g. the 15th of this month.
+
+1. Sign in as **Front Desk** (booking is the FD workflow). Appointments → Book Appointment,
+   pick the SENADIS patient, pick any specialty so Amount pre-fills.
+2. Set the session **Date to on/before the expiry** (e.g. the 14th or the 15th itself).
+3. **Expected:** the familiar violet **"SENADIS: min {20% of amount} (20%)"** hint shows, the
+   info toast fires on patient selection, and the Discount clamps up to 20% of Amount — you
+   cannot save less (exactly the pre-WP-37 behavior; the 15th itself still counts — boundary
+   is NOT expired).
+4. Now change only the session **Date to after the expiry** (e.g. the 16th).
+5. **Expected:** the violet hint disappears and an amber line appears instead:
+   **"SENADIS expired {date} — no discount floor for this session date."** The Discount field
+   accepts any value now (try 0 — it sticks). Book it.
+6. **Expected:** the booking saves with your entered discount — the server no longer floors it
+   (verify the created session's Discount in the appointments list).
+7. Flip the date back on/before the expiry once more. **Expected:** the hint returns and the
+   discount clamps back up — the check follows the session date live.
+8. Cleanup for this scenario: as MGR, extend the patient's expiry back to its real value (or
+   far future). Remember: an expiry can be **extended, not cleared** — pick a far date rather
+   than trying to blank it.
+
+## Scenario 4 — no expiry = nothing changed
+
+1. As FD, book a session for a SENADIS patient **without** an expiration date (backfill-era
+   patients are all like this).
+2. **Expected:** exactly the pre-WP-37 behavior — toast, violet min hint, 20% clamp, no badge,
+   for any session date.
+
+## Scenario 5 — bulk scheduling (treatment-plan wizard)
+
+1. As MGR, open a treatment plan for the expired-SENADIS patient (expiry in the past) and
+   start **Schedule** with a start date after the expiry.
+2. **Expected:** the per-line discounts do **not** auto-fill to the 20% floor, the per-line
+   violet min hint is replaced by the amber **"SENADIS expired {date} — no discount floor for
+   this schedule"** note, and discounts below 20% are accepted.
+3. Note: the wizard judges expiry by the schedule **start date**. A schedule that *starts*
+   on/before the expiry keeps the 20% pre-fill for all its lines, but the server floors **per
+   session date** — sessions falling after the expiry are booked with your entered values, not
+   force-floored.
+
+## Scenario 6 — FD can set the expiry at CREATE (SEN-2)
+
+1. As **Front Desk**, add a brand-new patient; check **SENADIS discount**.
+2. **Expected:** the expiration date field appears and is **editable** (create is free for any
+   patient-creating role — the MGR/AM gate applies to later edits only).
+3. Save with a date, then re-open the patient as FD. **Expected:** flag + date stored; both now
+   read-only for FD.
+
+## Cleanup
+
+Restore the test patient's real expiration date (or a far-future one) as MGR, and delete any
+throwaway bookings/patients created above. If you created a test patient in Scenario 6, an MGR
+can deactivate it.


### PR DESCRIPTION
…y-aware booking clamp

PatientFormModal gains a "SENADIS expiration date" input below the flag — shown only while the flag is checked, disabled by the SAME canEditSenadis claim gate on edit (G4: one claim governs both fields; create stays free per SEN-2), with an amber "SENADIS expired {date}" badge when the date is past (G3: badge only, the flag is NEVER auto-cleared). Payloads mirror the flag's omit-when-gated round-trip: create sends flag+date; update sends the date only when editable and non-blank (omitted/null = unchanged server-side — an expiry can be extended, not cleared, per the contract).

BookingFormModal's 20% floor/min/hint/clamp-on-submit becomes expiry-aware (G2): applies only while the SENADIS is active for the SESSION DATE being booked (null expiry = open-ended; boundary session==expiry still floors), re-evaluated live as the date changes; flagged-but-expired shows the badge so FD understands why no discount applies. SchedulePlanWizard's per-line clamp gets the same treatment against the schedule START date (conservative — the API floors per session date server-side). Shared predicate/badge formatting in utils/senadis.ts so the three call sites can't drift.

Patient/PatientCreateRequest/PatientUpdateRequest gain senadisExpirationDate?: string | null (WP-37B wire shape "…T00:00:00"|null; tolerant of an older API). PatientsView.toggleActive already omits both SENADIS fields — unchanged. vitest 231 -> 247; testing-guide gains the deterministic-date-fixtures pattern (no fake timers for date comparisons).