### PR TITLE
WP-36C (NP-1): system-managed MRN — create form drops MRN input, mint…

### DIFF
--- a/app-ui/docs/testing-guide.md
+++ b/app-ui/docs/testing-guide.md
@@ -120,6 +120,12 @@ Rules:
 
 - Mount modals with `global: { stubs: { teleport: true } }`, start `visible: false`, then
   `await wrapper.setProps({ visible: true })`.
+- **Driving a parent view's `@event` handler without the real child (2026-07-19,
+  `wp36-system-mrn.spec.ts`):** stub the child (`PatientFormModal: true`), grab it with
+  `wrapper.findComponent({ name: 'PatientFormModal' })`, and `vm.$emit('created', payload)` —
+  the parent's listener runs exactly as if the real modal emitted. Useful when the child's own
+  behavior is covered by its component spec and mounting it for real would drag in more client
+  mocks than the test is about.
 - ⚠️ **Teleport-stub gotcha (2026-07-13, `wp27-cross-add-flows.spec.ts`):** the stub **recreates
   slot children on re-render, silently resetting their local state** (e.g. a form selection after
   a failed submit). That reset is a **stub artifact, not an app bug** — it was verified against a

--- a/app-ui/src/__tests__/patient-mrn-edit.spec.ts
+++ b/app-ui/src/__tests__/patient-mrn-edit.spec.ts
@@ -3,7 +3,9 @@
 //   L24-/L25-/L26-#### MRNs could never be corrected — and even an editable value was
 //   dropped from the PUT payload unless the "assign permanent MRN" path was taken.
 //   Fix: MRN is generally editable on edit; a changed, non-blank value is always sent
-//   (the API enforces uniqueness → 409). TEMP- activation semantics are unchanged.
+//   (the API enforces uniqueness → 409).
+// WP-36 (NP-1): the TEMP- flow is retired (system mints NC{yy}-#### at create) — the
+//   temp-MRN hint + two-step assign-then-activate specs were removed with the dead code.
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { setActivePinia, createPinia, type Pinia } from 'pinia';
@@ -132,11 +134,12 @@ describe('PatientFormModal — MRN is editable on edit (B2)', () => {
     );
   });
 
-  it('keeps the input mounted while typing a non-TEMP value char-by-char (repro: patient 917)', async () => {
-    // Pre-fix, the input sat behind v-if="hasTemporaryMrn", which reacts to the value being
-    // typed — clearing "TEMP-917" and typing the first character of a permanent MRN flipped
-    // the v-if and unmounted the input mid-keystroke ("textbox locks after one character").
-    const wrapper = await openEditModal(patient({ medicalRecordNumber: 'TEMP-917', isActive: false }));
+  it('keeps the input mounted while typing a new value char-by-char (repro: patient 917)', async () => {
+    // Pre-B2, the input sat behind a v-if that reacted to the value being typed — clearing the
+    // field and typing the first character of a new MRN flipped the v-if and unmounted the
+    // input mid-keystroke ("textbox locks after one character"). The v-if is long gone (and
+    // WP-36 removed the TEMP- styling branch entirely) — this guards against its return.
+    const wrapper = await openEditModal(patient({ medicalRecordNumber: 'L24-0917', isActive: false }));
 
     for (const partial of ['', 'N', 'NC', 'NC-', 'NC-9', 'NC-91', 'NC-917']) {
       const input = wrapper.find(mrnInput);
@@ -147,25 +150,5 @@ describe('PatientFormModal — MRN is editable on edit (B2)', () => {
     const survivor = wrapper.find(mrnInput);
     expect(survivor.exists()).toBe(true);
     expect((survivor.element as HTMLInputElement).value).toBe('NC-917');
-  });
-
-  it('still shows the temporary-MRN hint and two-step activate flow for TEMP- patients', async () => {
-    const wrapper = await openEditModal(patient({ medicalRecordNumber: 'TEMP-5', isActive: false }));
-    expect(wrapper.text()).toContain('temporary MRN');
-
-    await wrapper.find(mrnInput).setValue('NC-2026-0005');
-    // Toggle Active Status on (enabled once the pending MRN is permanent).
-    await wrapper.find('button.w-11').trigger('click');
-
-    await wrapper.find('form').trigger('submit');
-    await vi.waitFor(() => expect(updatePatientMock).toHaveBeenCalledTimes(2));
-
-    // Step 1: assign the permanent MRN while still inactive; step 2: activate.
-    expect(updatePatientMock.mock.calls[0][1]).toEqual(
-      expect.objectContaining({ medicalRecordNumber: 'NC-2026-0005', activeStatus: false })
-    );
-    expect(updatePatientMock.mock.calls[1][1]).toEqual(
-      expect.objectContaining({ activeStatus: true })
-    );
   });
 });

--- a/app-ui/src/__tests__/wp36-system-mrn.spec.ts
+++ b/app-ui/src/__tests__/wp36-system-mrn.spec.ts
@@ -1,0 +1,205 @@
+// WP-36C (NP-1) — system-managed MRN:
+//   The server ALWAYS mints NC{yy}-#### at create (client-supplied MRN would be ignored), the
+//   create response carries the minted value, and patients are ACTIVE at create. The UI:
+//   - create form has NO MRN input — a read-only "assigned automatically" note instead;
+//   - the create payload carries no medicalRecordNumber key at all;
+//   - PatientsView surfaces the minted MRN in a success banner so FD can note the chart number;
+//   - edit-modal MRN behavior is unchanged (B2: editable, duplicate → 409).
+//   The TEMP-/inactive-until-MRN flow is retired (prod had zero TEMP- rows).
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { setActivePinia, createPinia, type Pinia } from 'pinia';
+import { mount, flushPromises } from '@vue/test-utils';
+import manifest from '../generated/access-control-matrix.json';
+import { useAuthStore } from '../stores/auth';
+import type { ClaimDto } from '../interfaces/Auth';
+import type { Patient } from '../interfaces/Patient';
+import type { PagedResult } from '../interfaces/SessionHistory';
+import PatientFormModal from '../components/patients/PatientFormModal.vue';
+import PatientsView from '../views/PatientsView.vue';
+
+const { createPatientMock, updatePatientMock, getPatientsMock, getPastDuePatientsMock } = vi.hoisted(() => ({
+  createPatientMock: vi.fn(),
+  updatePatientMock: vi.fn(),
+  getPatientsMock: vi.fn(),
+  getPastDuePatientsMock: vi.fn(),
+}));
+
+vi.mock('../services/PatientsHttpClient', () => ({
+  PatientsHttpClient: vi.fn().mockImplementation(() => ({
+    createPatient: createPatientMock,
+    updatePatient: updatePatientMock,
+    getPatients: getPatientsMock,
+    getPastDuePatients: getPastDuePatientsMock,
+  })),
+}));
+
+// PatientsView uses useRoute (?tab= deep link) + useRouter (Plans navigation).
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ query: {} }),
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+function claimsForRole(role: string): ClaimDto[] {
+  return (manifest.claims as Array<{ claim: string; grants: string[] }>)
+    .filter((c) => c.grants.includes(role))
+    .map((c) => ({ type: 'Permission', value: c.claim }));
+}
+
+function authAs(role: string): Pinia {
+  const pinia = createPinia();
+  setActivePinia(pinia);
+  const store = useAuthStore();
+  store.user = {
+    userId: 1, email: 'test@example.com', fullName: 'Test User',
+    mustChangePassword: false, roles: [role], claims: claimsForRole(role),
+    isSystemAdmin: false,
+  };
+  return pinia;
+}
+
+function patient(overrides: Partial<Patient> = {}): Patient {
+  return {
+    patientId: 1, userId: 10, patientName: 'Doe, John', medicalRecordNumber: 'L26-0001',
+    cedula: null, dateOfBirth: '2015-01-15T00:00:00', email: 'john@example.com',
+    phoneNumber: '555-0100', gender: 'Male', isActive: true, requiresDiscovery: true,
+    hasCompletedDiscovery: true, createdTimestamp: '2025-01-01T00:00:00',
+    caretakers: [], ...overrides,
+  };
+}
+
+function paged<T>(items: T[]): PagedResult<T> {
+  return { items, page: 1, pageSize: 30, totalCount: items.length };
+}
+
+async function openModal(p: Patient | null) {
+  const pinia = authAs('MGR');
+  const wrapper = mount(PatientFormModal, {
+    props: { visible: false, patient: p },
+    global: { plugins: [pinia], stubs: { teleport: true } },
+  });
+  await wrapper.setProps({ visible: true });
+  return wrapper;
+}
+
+async function fillCreateFields(wrapper: Awaited<ReturnType<typeof openModal>>) {
+  await wrapper.find('input[type="email"]').setValue('new@example.com');
+  await wrapper.find('input[type="tel"]').setValue('555-0101');
+  await wrapper.find('input[type="date"]').setValue('2015-01-15');
+  await wrapper.find('select').setValue('Female'); // first select = gender
+  const textInputs = wrapper.findAll('input[type="text"]');
+  await textInputs[0].setValue('First'); // firstName
+  await textInputs[2].setValue('Last');  // lastName
+  await textInputs[3].setValue('8-999-1234'); // cedula — required at create (WP-25)
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  createPatientMock.mockResolvedValue(
+    patient({ patientId: 99, patientName: 'Last, First', medicalRecordNumber: 'NC26-0001' })
+  );
+  updatePatientMock.mockResolvedValue(undefined);
+  getPatientsMock.mockResolvedValue(paged([patient()]));
+  getPastDuePatientsMock.mockResolvedValue([]);
+});
+
+describe('PatientFormModal — create mode has no MRN input (WP-36)', () => {
+  it('renders the auto-assign note instead of an MRN input', async () => {
+    const wrapper = await openModal(null);
+
+    const note = wrapper.find('[data-testid="mrn-auto-note"]');
+    expect(note.exists()).toBe(true);
+    expect(note.text()).toContain('MRN assigned automatically on save');
+
+    // No MRN input in create mode: text inputs are exactly first/middle/last/cedula.
+    expect(wrapper.find('input[placeholder="Enter MRN"]').exists()).toBe(false);
+    expect(wrapper.findAll('input[type="text"]')).toHaveLength(4);
+    expect(wrapper.text()).not.toContain('temporary MRN');
+  });
+
+  it('submits a create payload with NO medicalRecordNumber key at all', async () => {
+    const wrapper = await openModal(null);
+    await fillCreateFields(wrapper);
+
+    await wrapper.find('form').trigger('submit');
+    await vi.waitFor(() => expect(createPatientMock).toHaveBeenCalled());
+
+    const payload = createPatientMock.mock.calls[0][0] as Record<string, unknown>;
+    // Not even `medicalRecordNumber: undefined` — the key must simply not exist.
+    expect(Object.prototype.hasOwnProperty.call(payload, 'medicalRecordNumber')).toBe(false);
+    expect(payload).toMatchObject({ firstName: 'First', lastName: 'Last', cedula: '8-999-1234' });
+  });
+
+  it('hands the create response (with the minted MRN) to the parent via `created`', async () => {
+    const wrapper = await openModal(null);
+    await fillCreateFields(wrapper);
+
+    await wrapper.find('form').trigger('submit');
+    await vi.waitFor(() => expect(createPatientMock).toHaveBeenCalled());
+
+    const created = wrapper.emitted('created');
+    expect(created).toHaveLength(1);
+    expect(created![0][0]).toMatchObject({
+      record: { patientId: 99, medicalRecordNumber: 'NC26-0001' },
+    });
+  });
+});
+
+describe('PatientsView — minted MRN surfaced after create (WP-36)', () => {
+  function mountView() {
+    return mount(PatientsView, {
+      global: {
+        plugins: [authAs('FD')],
+        stubs: {
+          O2MobileNav: true, O2Sidebar: true, O2Header: true, O2Footer: true,
+          PatientFormModal: true, PaymentFormModal: true, CrossAddChainModal: true,
+          PatientCaretakerPanel: true, teleport: true,
+        },
+      },
+    });
+  }
+
+  it('shows the success banner with the minted NC{yy}-#### from the create response', async () => {
+    const w = mountView();
+    await flushPromises();
+
+    const modal = w.findComponent({ name: 'PatientFormModal' });
+    modal.vm.$emit('created', {
+      record: patient({ patientId: 99, patientName: 'Last, First', medicalRecordNumber: 'NC26-0001' }),
+      link: null,
+    });
+    await flushPromises();
+
+    const banner = w.find('[data-testid="minted-mrn-banner"]');
+    expect(banner.exists()).toBe(true);
+    expect(w.find('[data-testid="minted-mrn-value"]').text()).toBe('NC26-0001');
+  });
+});
+
+describe('PatientFormModal — edit mode unchanged (B2 + 409, WP-36 G4)', () => {
+  it('still renders an editable MRN input hydrated with the current value', async () => {
+    const wrapper = await openModal(patient({ medicalRecordNumber: 'L24-0123' }));
+    const input = wrapper.find('input[placeholder="Enter MRN"]');
+    expect(input.exists()).toBe(true);
+    expect((input.element as HTMLInputElement).value).toBe('L24-0123');
+  });
+
+  it('surfaces the duplicate-MRN 409 message in the error banner', async () => {
+    // HttpClientBase surfaces ProblemDetails detail as Error.message — the 409 arrives as this.
+    updatePatientMock.mockRejectedValueOnce(
+      new Error('A patient with this Medical Record Number already exists.')
+    );
+    const wrapper = await openModal(patient({ medicalRecordNumber: 'L24-0123' }));
+    await wrapper.find('input[placeholder="Enter MRN"]').setValue('NC26-0001');
+
+    await wrapper.find('form').trigger('submit');
+    await vi.waitFor(() => expect(updatePatientMock).toHaveBeenCalled());
+    await flushPromises();
+
+    expect(updatePatientMock).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ medicalRecordNumber: 'NC26-0001' })
+    );
+    expect(wrapper.text()).toContain('A patient with this Medical Record Number already exists.');
+  });
+});

--- a/app-ui/src/components/patients/PatientFormModal.vue
+++ b/app-ui/src/components/patients/PatientFormModal.vue
@@ -197,16 +197,12 @@
             </select>
           </div>
 
+          <!-- WP-36 (NP-1): MRN is system-managed — the server mints NC{yy}-#### at create and
+               the response carries the value (surfaced in the success banner). No input here. -->
           <div v-if="!isEdit">
             <label class="block text-sm font-medium text-slate-700 mb-1">MRN</label>
-            <input
-              v-model="form.medicalRecordNumber"
-              type="text"
-              class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-              placeholder="Auto-generated if blank"
-            />
-            <p class="mt-1 text-xs text-slate-400">
-              Leave blank to assign a temporary MRN. Patient will be inactive until a permanent MRN is provided.
+            <p class="text-xs text-slate-400" data-testid="mrn-auto-note">
+              MRN assigned automatically on save.
             </p>
           </div>
 
@@ -215,18 +211,10 @@
             <input
               v-model="form.medicalRecordNumber"
               type="text"
-              :class="[
-                'w-full rounded-lg border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:border-transparent',
-                hasTemporaryMrn
-                  ? 'border-amber-300 bg-amber-50 focus:ring-amber-500'
-                  : 'border-slate-300 focus:ring-blue-500',
-              ]"
+              class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
               placeholder="Enter MRN"
             />
-            <p v-if="hasTemporaryMrn" class="mt-1 text-xs text-amber-600">
-              This patient has a temporary MRN. Assign a permanent MRN to enable activation.
-            </p>
-            <p v-else class="mt-1 text-xs text-slate-400">
+            <p class="mt-1 text-xs text-slate-400">
               Changing the MRN must keep it unique; leave blank to keep the current one.
             </p>
           </div>
@@ -268,11 +256,9 @@
                 type="button"
                 :class="[
                   'relative inline-flex h-6 w-11 items-center rounded-full transition-colors',
-                  cannotActivate ? 'bg-slate-200 cursor-not-allowed' :
                   form.activeStatus ? 'bg-blue-600' : 'bg-slate-300',
                 ]"
-                :disabled="cannotActivate"
-                @click="cannotActivate || (form.activeStatus = !form.activeStatus)"
+                @click="form.activeStatus = !form.activeStatus"
               >
                 <span
                   :class="[
@@ -282,9 +268,6 @@
                 />
               </button>
             </div>
-            <p v-if="cannotActivate" class="text-xs text-amber-600">
-              Cannot activate with a temporary MRN. Enter a permanent MRN above first.
-            </p>
           </div>
 
         </form>
@@ -318,7 +301,6 @@
 <script lang="ts">
 import { defineComponent, reactive, ref, computed, watch, type PropType } from 'vue';
 import type { Patient } from '../../interfaces/Patient';
-import { isTemporaryMrn } from '../../interfaces/Patient';
 import { useModalForm } from '../../composables/useModalForm';
 import FormErrorBanner from '../shared/FormErrorBanner.vue';
 import { PatientsHttpClient } from '../../services/PatientsHttpClient';
@@ -365,7 +347,7 @@ export default defineComponent({
     // context banner + relationship/primary fields and enriches the `created` emit.
     linkTo: { type: Object as PropType<{ name: string } | null>, default: null },
   },
-  emits: ['close', 'saved', 'created', 'created-temp-mrn'],
+  emits: ['close', 'saved', 'created'],
   setup(props, { emit }) {
     const { error, hasError, saving, setError, clearError, submit } = useModalForm();
     const { hasClaim } = useClaims();
@@ -412,12 +394,6 @@ export default defineComponent({
       () => !isEdit.value || hasClaim('Permission', Permissions.PatientsRequiresDiscoveryEdit)
     );
 
-    // Blank on edit means "keep the current MRN", so temp-ness is judged on the effective value.
-    const effectiveMrn = computed(
-      () => form.medicalRecordNumber.trim() || props.patient?.medicalRecordNumber || ''
-    );
-    const hasTemporaryMrn = computed(() => isEdit.value && isTemporaryMrn(effectiveMrn.value));
-    const cannotActivate = computed(() => hasTemporaryMrn.value && !form.activeStatus);
     const age = computed(() => formatAge(form.dateOfBirth));
 
     // WP-25 (F5): amber nag while a legacy (no stored cedula) patient's field is still blank —
@@ -494,11 +470,6 @@ export default defineComponent({
         setError('Cedula | Passport cannot be cleared.');
         return;
       }
-      // Cannot activate a patient while a temporary MRN is still in place.
-      if (isEdit.value && props.patient && form.activeStatus && isTemporaryMrn(effectiveMrn.value)) {
-        setError('Cannot activate a patient with a temporary MRN. Assign a permanent MRN first.');
-        return;
-      }
       return submit(async () => {
         const client = new PatientsHttpClient();
         if (isEdit.value && props.patient) {
@@ -507,7 +478,6 @@ export default defineComponent({
           // current MRN (the API treats an omitted/empty MRN as "leave as-is"; uniqueness → 409).
           const newMrn = form.medicalRecordNumber.trim();
           const mrnChanged = newMrn !== '' && newMrn !== originalMrn;
-          const assigningPermanentMrn = isTemporaryMrn(originalMrn) && mrnChanged && !isTemporaryMrn(newMrn);
           const baseFields = {
             firstName: form.firstName,
             middleName: form.middleName || undefined,
@@ -533,25 +503,14 @@ export default defineComponent({
             requiresDiscovery: canEditRequiresDiscovery.value ? form.requiresDiscovery : undefined,
           };
 
-          if (assigningPermanentMrn && form.activeStatus) {
-            // Two-step: first assign permanent MRN (keep inactive), then activate
-            await client.updatePatient(props.patient.patientId, {
-              ...baseFields,
-              activeStatus: false,
-              medicalRecordNumber: newMrn,
-            });
-            await client.updatePatient(props.patient.patientId, {
-              ...baseFields,
-              activeStatus: true,
-            });
-          } else {
-            await client.updatePatient(props.patient.patientId, {
-              ...baseFields,
-              activeStatus: form.activeStatus,
-              medicalRecordNumber: mrnChanged ? newMrn : undefined,
-            });
-          }
+          await client.updatePatient(props.patient.patientId, {
+            ...baseFields,
+            activeStatus: form.activeStatus,
+            medicalRecordNumber: mrnChanged ? newMrn : undefined,
+          });
         } else {
+          // WP-36 (NP-1): the payload carries NO medicalRecordNumber — the server mints
+          // NC{yy}-#### and the create response carries the value (patient active at create).
           const created = await client.createPatient({
             firstName: form.firstName,
             middleName: form.middleName || undefined,
@@ -560,7 +519,6 @@ export default defineComponent({
             email: form.email,
             phoneNumber: form.phoneNumber,
             gender: form.gender,
-            medicalRecordNumber: form.medicalRecordNumber || undefined,
             cedula: form.cedula.trim(), // WP-25 (F5): required at create — guard above ensures non-blank
             hasSenadisDiscount: form.hasSenadisDiscount,
             // WP-37 (SEN-2): free at create for any patient-creating role; omitted = no expiry.
@@ -576,16 +534,13 @@ export default defineComponent({
             record: created,
             link: props.linkTo ? { relationship: linkRelationship.value, isPrimary: linkIsPrimary.value } : null,
           });
-          if (isTemporaryMrn(created.medicalRecordNumber ?? '')) {
-            emit('created-temp-mrn', created);
-          }
         }
         emit('saved');
         emit('close');
       });
     };
 
-    return { form, isEdit, saving, error, hasError, hasTemporaryMrn, cannotActivate, canEditSenadis, canEditRequiresDiscovery, age, hadCedulaOnFile, showLegacyCedulaNag, senadisExpired, formatSenadisExpiry, linkRelationship, linkIsPrimary, handleSubmit };
+    return { form, isEdit, saving, error, hasError, canEditSenadis, canEditRequiresDiscovery, age, hadCedulaOnFile, showLegacyCedulaNag, senadisExpired, formatSenadisExpiry, linkRelationship, linkIsPrimary, handleSubmit };
   },
 });
 </script>

--- a/app-ui/src/components/patients/PatientTable.vue
+++ b/app-ui/src/components/patients/PatientTable.vue
@@ -29,17 +29,8 @@
           class="hover:bg-slate-50 transition-colors"
         >
           <td class="px-4 py-3 text-sm font-medium text-slate-800">{{ patient.patientName }}</td>
-          <td class="px-4 py-3 text-sm">
-            <span v-if="isTemporaryMrn(patient.medicalRecordNumber)" class="inline-flex items-center space-x-1">
-              <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-700">
-                {{ patient.medicalRecordNumber }}
-              </span>
-              <svg class="w-3.5 h-3.5 text-amber-500" fill="currentColor" viewBox="0 0 20 20">
-                <path fill-rule="evenodd" d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.168 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 5zm0 9a1 1 0 100-2 1 1 0 000 2z" clip-rule="evenodd" />
-              </svg>
-            </span>
-            <span v-else class="text-slate-600">{{ patient.medicalRecordNumber }}</span>
-          </td>
+          <!-- WP-36 (NP-1): TEMP- MRNs are retired (system mints NC{yy}-#### at create) — plain cell. -->
+          <td class="px-4 py-3 text-sm text-slate-600">{{ patient.medicalRecordNumber }}</td>
           <!-- Cedula is PII: the grid only acknowledges a value exists; the raw ID stays in the
                edit modal + search (intake 2026-06-29-001 item 1). The narrow badge also relieves
                the column-width pressure that clipped Actions (item 2). -->
@@ -116,14 +107,8 @@
               </button>
               <button
                 v-if="hasClaim('Permission', Permissions.PatientsEdit)"
-                class="p-1.5 rounded-lg transition-colors"
-                :class="!patient.isActive && isTemporaryMrn(patient.medicalRecordNumber)
-                  ? 'text-slate-300 cursor-not-allowed'
-                  : 'text-slate-400 hover:text-amber-600 hover:bg-amber-50'"
-                :title="!patient.isActive && isTemporaryMrn(patient.medicalRecordNumber)
-                  ? 'Cannot activate — assign a permanent MRN first'
-                  : patient.isActive ? 'Deactivate patient' : 'Activate patient'"
-                :disabled="!patient.isActive && isTemporaryMrn(patient.medicalRecordNumber)"
+                class="p-1.5 rounded-lg transition-colors text-slate-400 hover:text-amber-600 hover:bg-amber-50"
+                :title="patient.isActive ? 'Deactivate patient' : 'Activate patient'"
                 @click="$emit('toggle-active', patient)"
               >
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -153,10 +138,7 @@
       <div class="flex items-start justify-between mb-2">
         <div>
           <p class="text-sm font-semibold text-slate-800">{{ patient.patientName }}</p>
-          <p class="text-xs" :class="isTemporaryMrn(patient.medicalRecordNumber) ? 'text-amber-600 font-medium' : 'text-slate-400'">
-            MRN: {{ patient.medicalRecordNumber }}
-            <span v-if="isTemporaryMrn(patient.medicalRecordNumber)" class="ml-1 text-amber-500">(temporary)</span>
-          </p>
+          <p class="text-xs text-slate-400">MRN: {{ patient.medicalRecordNumber }}</p>
         </div>
         <span
           :class="[
@@ -208,13 +190,7 @@
         <button
           v-if="hasClaim('Permission', Permissions.PatientsEdit)"
           class="px-3 py-1.5 rounded-lg text-xs font-medium transition-colors"
-          :class="!patient.isActive && isTemporaryMrn(patient.medicalRecordNumber)
-            ? 'text-slate-300 cursor-not-allowed'
-            : patient.isActive ? 'text-amber-600 hover:bg-amber-50' : 'text-green-600 hover:bg-green-50'"
-          :disabled="!patient.isActive && isTemporaryMrn(patient.medicalRecordNumber)"
-          :title="!patient.isActive && isTemporaryMrn(patient.medicalRecordNumber)
-            ? 'Assign a permanent MRN before activating'
-            : ''"
+          :class="patient.isActive ? 'text-amber-600 hover:bg-amber-50' : 'text-green-600 hover:bg-green-50'"
           @click="$emit('toggle-active', patient)"
         >
           {{ patient.isActive ? 'Deactivate' : 'Activate' }}
@@ -230,7 +206,6 @@
 <script lang="ts">
 import { defineComponent, ref, computed, type PropType } from 'vue';
 import type { Patient } from '../../interfaces/Patient';
-import { isTemporaryMrn } from '../../interfaces/Patient';
 import { formatAge } from '../../utils/age';
 import { useClaims, Permissions } from '../../composables/useClaims';
 import AuditPopover from '../shared/AuditPopover.vue';
@@ -311,7 +286,7 @@ export default defineComponent({
       return primary ? primary.caretakerName : '';
     };
 
-    return { columns, sortKey, sortAsc, sortedPatients, toggleSort, formatDate, formatAge, isTemporaryMrn, primaryCaretakerName, hasClaim, Permissions };
+    return { columns, sortKey, sortAsc, sortedPatients, toggleSort, formatDate, formatAge, primaryCaretakerName, hasClaim, Permissions };
   },
 });
 </script>

--- a/app-ui/src/interfaces/Patient.ts
+++ b/app-ui/src/interfaces/Patient.ts
@@ -43,6 +43,8 @@ export interface PatientCaretakerSummary {
 }
 
 // Maps to API's PatientProfileRequest (POST)
+// WP-36 (NP-1): NO medicalRecordNumber — the server always mints NC{yy}-#### at create (a
+// client-supplied value would be ignored server-side); the response carries the minted MRN.
 export interface PatientCreateRequest {
   firstName: string;
   middleName?: string;
@@ -51,7 +53,6 @@ export interface PatientCreateRequest {
   email: string;
   phoneNumber: string;
   gender: string;
-  medicalRecordNumber?: string;
   // WP-25 (F5): "Cedula | Passport" — required at create (free text, unique; duplicate → 409).
   cedula: string;
   hasSenadisDiscount?: boolean;
@@ -95,7 +96,5 @@ export interface PatientLookupItem {
   medicalRecordNumber: string | null;
 }
 
-// Temporary MRN helper
-export function isTemporaryMrn(mrn: string | null | undefined): boolean {
-  return !mrn || mrn.toUpperCase().startsWith('TEMP-');
-}
+// WP-36 (NP-1): isTemporaryMrn() removed — the TEMP- flow is retired (prod has zero TEMP- rows;
+// the server mints NC{yy}-#### at create and patients are active immediately).

--- a/app-ui/src/views/PatientsView.vue
+++ b/app-ui/src/views/PatientsView.vue
@@ -50,7 +50,6 @@
       @close="modalVisible = false"
       @saved="onSaved"
       @created="onPatientCreated"
-      @created-temp-mrn="onCreatedTempMrn"
     />
 
     <!-- WP-27 (F8): a just-created patient has no caretaker — offer to link/create one now -->
@@ -69,25 +68,27 @@
       @saved="onPaymentSaved"
     />
 
-    <!-- Temp MRN creation banner -->
+    <!-- WP-36 (NP-1): minted-MRN banner — the create response carries the system-minted
+         NC{yy}-#### so front desk can read the new chart number off the screen. -->
     <teleport to="body">
       <div
-        v-if="tempMrnBanner"
-        class="fixed top-4 right-4 z-50 max-w-sm bg-amber-50 border border-amber-300 rounded-xl shadow-lg p-4"
+        v-if="mintedMrnBanner"
+        data-testid="minted-mrn-banner"
+        class="fixed top-4 right-4 z-50 max-w-sm bg-green-50 border border-green-300 rounded-xl shadow-lg p-4"
       >
         <div class="flex items-start space-x-3">
-          <svg class="w-5 h-5 text-amber-500 mt-0.5 shrink-0" fill="currentColor" viewBox="0 0 20 20">
-            <path fill-rule="evenodd" d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.168 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 5zm0 9a1 1 0 100-2 1 1 0 000 2z" clip-rule="evenodd" />
+          <svg class="w-5 h-5 text-green-500 mt-0.5 shrink-0" fill="currentColor" viewBox="0 0 20 20">
+            <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
           </svg>
           <div class="flex-1">
-            <p class="text-sm font-medium text-amber-800">Temporary MRN Assigned</p>
-            <p class="text-xs text-amber-700 mt-1">
-              <span class="font-mono font-semibold">{{ tempMrnBanner }}</span> was assigned as a temporary MRN. The patient is inactive until a permanent MRN is provided.
+            <p class="text-sm font-medium text-green-800">Patient Created</p>
+            <p class="text-xs text-green-700 mt-1">
+              MRN <span class="font-mono font-semibold" data-testid="minted-mrn-value">{{ mintedMrnBanner }}</span> was assigned — this is the patient's chart number.
             </p>
           </div>
           <button
-            class="p-1 rounded text-amber-400 hover:text-amber-600"
-            @click="tempMrnBanner = ''"
+            class="p-1 rounded text-green-400 hover:text-green-600"
+            @click="mintedMrnBanner = ''"
           >
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
@@ -113,7 +114,6 @@ import PaymentFormModal from '../components/payments/PaymentFormModal.vue';
 import CrossAddChainModal, { type ChainTarget } from '../components/shared/CrossAddChainModal.vue';
 import { PatientsHttpClient } from '../services/PatientsHttpClient';
 import type { Patient } from '../interfaces/Patient';
-import { isTemporaryMrn } from '../interfaces/Patient';
 import type { CreatedForChain } from '../interfaces/CrossAdd';
 import type { DelinquentPatient } from '../interfaces/Delinquency';
 import { useFormError } from '../composables/useFormError';
@@ -146,10 +146,11 @@ export default defineComponent({
       page: 1,
     });
     const loading = ref(false);
-    const { message: error, setError, setFromException, clear: clearError } = useFormError();
+    const { message: error, setFromException, clear: clearError } = useFormError();
     const modalVisible = ref(false);
     const editingPatient = ref<Patient | null>(null);
-    const tempMrnBanner = ref('');
+    // WP-36 (NP-1): system-minted MRN from the create response, shown in the success banner.
+    const mintedMrnBanner = ref('');
     const pastDuePatients = ref<DelinquentPatient[]>([]);
     const pastDueLoaded = ref(false);
     const selectedPatient = ref<Patient | null>(null);
@@ -188,11 +189,6 @@ export default defineComponent({
     };
 
     const toggleActive = async (patient: Patient) => {
-      // Guard: cannot activate a patient with a temporary MRN
-      if (!patient.isActive && isTemporaryMrn(patient.medicalRecordNumber)) {
-        setError('Cannot activate a patient with a temporary MRN. Edit the patient to assign a permanent MRN first.');
-        return;
-      }
       try {
         const parsed = parseName(patient.patientName);
         await client.updatePatient(patient.patientId, {
@@ -269,6 +265,9 @@ export default defineComponent({
     // WP-27 (F8): every create lands caretaker-less — open the chain when this user holds the
     // claim the link endpoint enforces (Caretakers.LinkPatient; linking is caretaker-side only).
     const onPatientCreated = (payload: CreatedForChain<Patient>) => {
+      // WP-36 (NP-1): surface the system-minted NC{yy}-#### so FD can note the chart number.
+      mintedMrnBanner.value = payload.record.medicalRecordNumber ?? '';
+      setTimeout(() => { mintedMrnBanner.value = ''; }, 8000);
       if (!hasClaim('Permission', Permissions.CaretakersLinkPatient)) return;
       chainTarget.value = { id: payload.record.patientId, name: payload.record.patientName };
       chainVisible.value = true;
@@ -277,11 +276,6 @@ export default defineComponent({
     const onChainClose = () => {
       chainVisible.value = false;
       loadPatients(); // a caretaker may have been created/linked — refresh booking-readiness
-    };
-
-    const onCreatedTempMrn = (patient: Patient) => {
-      tempMrnBanner.value = patient.medicalRecordNumber ?? '';
-      setTimeout(() => { tempMrnBanner.value = ''; }, 8000);
     };
 
     const viewPlans = (patient: Patient) => {
@@ -301,7 +295,7 @@ export default defineComponent({
       modalVisible,
       editingPatient,
       selectedPatient,
-      tempMrnBanner,
+      mintedMrnBanner,
       pastDuePatients,
       initialTab,
       loadPatients,
@@ -311,7 +305,6 @@ export default defineComponent({
       viewCaretakers,
       onCaretakersUpdated,
       onSaved,
-      onCreatedTempMrn,
       chainVisible,
       chainTarget,
       onPatientCreated,

--- a/app-ui/test-scenarios/wp-36-system-mrn.md
+++ b/app-ui/test-scenarios/wp-36-system-mrn.md
@@ -1,0 +1,61 @@
+# WP-36C — System-Managed MRN (`NC{yy}-####`): owner walkthrough
+
+MRNs are now **minted by the system**, never typed by staff. Creating a patient always assigns
+the next `NC{yy}-####` for the current (Panama) year — e.g. the first app-created patient is
+**`NC26-0001`**, the next `NC26-0002`, and the sequence **resets each calendar year** (first
+patient of Jan-2027 → `NC27-0001`). The old "leave MRN blank ⇒ TEMP- ⇒ patient inactive until a
+permanent MRN" dance is fully retired: **patients are active the moment they're created**. The
+edit-modal MRN stays editable exactly as before (B2 — for correcting legacy `L2x-####` values;
+a duplicate still gets the 409 message).
+
+**Prereqs:** API **WP-36B** deployed, this UI (WP-36C) deployed. No DB migration, no RoleClaim
+reseed, **no re-login needed**. Any patient-creating role works (FD is the natural one).
+
+## Scenario 1 — create two patients back-to-back: sequential MRNs, no MRN field
+
+1. Sign in as **Front Desk**. Patients → **Add Patient**.
+2. **Expected:** the form has **no MRN input** anymore. Where it used to be there is only a
+   read-only note: *"MRN assigned automatically on save."* (The old "leave blank for a
+   temporary MRN…" hint is gone.)
+3. Fill the required fields (name, DOB, Cedula | Passport, email, phone, gender) and save.
+4. **Expected:** a **green "Patient Created" banner** appears top-right showing the minted MRN
+   (e.g. **`NC26-0001`** on a fresh year) — read the chart number straight off the screen.
+   The WP-27 "link a caretaker now?" chain offer still appears as before.
+5. Immediately create a **second** patient (different cedula/email).
+6. **Expected:** the banner shows the **next sequential** MRN (e.g. `NC26-0002`). Both patients
+   appear in the list with their `NC26-####` MRNs.
+
+## Scenario 2 — both patients are ACTIVE immediately
+
+1. Stay on the Patients list; find the two patients from Scenario 1 (Active tab or search).
+2. **Expected:** both show the green **Active** badge right away — no "inactive until a
+   permanent MRN" state, no amber temporary-MRN badge anywhere in the table.
+3. **Expected:** the Activate/Deactivate action is enabled normally for both (no
+   "assign a permanent MRN first" lockout — that rule is gone with the TEMP flow).
+
+## Scenario 3 — edit-modal MRN correction still works (B2), duplicate → 409
+
+1. As **MGR** (or FD), edit any legacy patient with an `L2x-####` MRN.
+2. **Expected:** the MRN field is still there and **editable**, with the familiar hint
+   *"Changing the MRN must keep it unique; leave blank to keep the current one."*
+3. Change the MRN to a value **already used by another patient** (e.g. the `NC26-0001` minted
+   in Scenario 1) and save.
+4. **Expected:** red banner — *"A patient with this Medical Record Number already exists."*
+   (the 409). Nothing is saved.
+5. Change it instead to a **unique** corrected value and save. **Expected:** saves fine and the
+   list shows the corrected MRN.
+
+## Scenario 4 — typed MRNs are ignored (deploy-gap tolerance, API-side)
+
+Nothing to do in this UI — the field no longer exists. For completeness: if an old cached UI
+(or any API client) still sends a `medicalRecordNumber` on create, the server **ignores it**
+and mints anyway; the response carries the minted value.
+
+## Ops note for staff (tell the front desk)
+
+**Stop hand-minting `L2x-####` MRNs for new patients.** The system now mints every new
+patient's MRN (`NC{yy}-####`) automatically at save — the `L{yy}-####` series belongs to the
+legacy Excel imports only (`promote.py` keeps using it, unchanged). A hand-typed L-number can
+no longer be entered at create at all, and hand-minting them anywhere else just risks
+colliding with a future import. Corrections to *existing* legacy MRNs still go through the
+edit modal as before.


### PR DESCRIPTION
…ed NC{yy}-#### surfaced, TEMP- flow retired

- PatientFormModal create mode: MRN input + 'leave blank for temporary' hint replaced by a read-only 'MRN assigned automatically on save' note; create payload carries NO medicalRecordNumber key (server always mints NC{yy}-####, response carries the value).
- PatientsView: amber temp-MRN banner repurposed as a green 'Patient Created' success banner showing the minted MRN off the create response; temp-activation guard removed.
- TEMP- debris removed (prod has 0 TEMP- rows; API retires the flow): edit-modal temp warning
  + two-step assign-then-activate, table temp badges + activate lockout, created-temp-mrn emit, isTemporaryMrn() helper, PatientCreateRequest.medicalRecordNumber.
- Edit-modal MRN unchanged (B2): editable, changed non-blank value sent, duplicate -> 409.
- Vitest 247 -> 252 (new wp36-system-mrn.spec.ts: no-MRN-input, payload-key-absent, minted banner, edit 409 path; dead TEMP two-step spec removed); vue-tsc + lint clean.
- Walkthrough: test-scenarios/wp-36-system-mrn.md (incl. FD stop-hand-minting L2x ops note); testing-guide: stub-child-emit pattern documented per DoD.