### PR TITLE
WP-34C: dashboard Cancelled/No-Show tile + wrap-friendly stat grid

### DIFF
--- a/app-ui/src/__tests__/wp34-cancelled-tile.spec.ts
+++ b/app-ui/src/__tests__/wp34-cancelled-tile.spec.ts
@@ -1,0 +1,308 @@
+// WP-34C — Dashboard tile: Cancelled / No-Show (punch-list DSH-1).
+//
+// One combined always-on tile on the O2 stat bar: headline = today's Cancelled (status id 3)
+// + No-Show (status id 5), subtitle shows the split. Counted client-side from the already
+// loaded day feed, keyed on appointmentStatusId (the FK id is the robust representation —
+// statusName strings are admin-editable lookup values). Also covers the G4 grid rework
+// (wrap-friendly auto-fit grid replaces the stats.length lg:grid-cols ladder) and the tile's
+// deep-link into the EXISTING AppointmentsView Cancelled/No-Show filter tab.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount, flushPromises, RouterLinkStub } from '@vue/test-utils';
+import { createPinia, setActivePinia, type Pinia } from 'pinia';
+import manifest from '../generated/access-control-matrix.json';
+import { useAuthStore } from '../stores/auth';
+import type { ClaimDto } from '../interfaces/Auth';
+import type { Appointment } from '../interfaces/Appointment';
+import type { DelinquentPatient } from '../interfaces/Delinquency';
+import O2StatsBar from '../components/option02/O2StatsBar.vue';
+import AppointmentsView from '../views/AppointmentsView.vue';
+
+// ---- mocked route (AppointmentsView reads route.query.filter on mount) ----
+const mockRoute = vi.hoisted(() => ({
+  query: {} as Record<string, unknown>,
+  path: '/appointments',
+}));
+vi.mock('vue-router', () => ({
+  useRoute: () => mockRoute,
+}));
+
+// ---- HTTP client mocks (every client the mounted trees new up) ----
+const { getPendingSummaryMock, getPastDuePatientsMock, getSessionsMock, getUpcomingMock } =
+  vi.hoisted(() => ({
+    getPendingSummaryMock: vi.fn(),
+    getPastDuePatientsMock: vi.fn(),
+    getSessionsMock: vi.fn(),
+    getUpcomingMock: vi.fn(),
+  }));
+
+vi.mock('../services/ServicePaymentsHttpClient', () => ({
+  ServicePaymentsHttpClient: vi.fn().mockImplementation(() => ({
+    getPendingSummary: getPendingSummaryMock,
+  })),
+}));
+
+vi.mock('../services/PatientsHttpClient', () => ({
+  PatientsHttpClient: vi.fn().mockImplementation(() => ({
+    getPastDuePatients: getPastDuePatientsMock,
+  })),
+}));
+
+vi.mock('../services/SessionsHttpClient', () => ({
+  SessionsHttpClient: vi.fn().mockImplementation(() => ({
+    getSessions: getSessionsMock,
+    getUpcoming: getUpcomingMock,
+  })),
+}));
+
+// ---- auth helpers (manifest-driven, per testing guide) ----
+function claimsForRole(role: string): ClaimDto[] {
+  return (manifest.claims as Array<{ claim: string; grants: string[] }>)
+    .filter((c) => c.grants.includes(role))
+    .map((c) => ({ type: 'Permission', value: c.claim }));
+}
+
+function authAs(role: string): Pinia {
+  const pinia = createPinia();
+  setActivePinia(pinia);
+  const store = useAuthStore();
+  store.user = {
+    userId: 1,
+    email: 'test@example.com',
+    fullName: 'Test User',
+    mustChangePassword: false,
+    roles: [role],
+    claims: claimsForRole(role),
+    isSystemAdmin: false,
+  };
+  return pinia;
+}
+
+// ---- factories ----
+function appt(overrides: Partial<Appointment> = {}): Appointment {
+  return {
+    sessionId: 1,
+    sessionDate: '2026-07-27',
+    sessionTime: '09:00',
+    patient: 'Test Patient',
+    therapist: 'Test Therapist',
+    therapyTypes: 'ABA',
+    amount: 50,
+    discount: 0,
+    amountPaid: 0,
+    amountDue: 50,
+    isPastDue: false,
+    isPaidOff: false,
+    notes: '',
+    patientId: 1,
+    therapistId: 1,
+    time: '09:00',
+    appointmentStatusId: 4,
+    statusName: 'Completed',
+    isConfirmed: true,
+    siteId: 1,
+    siteName: 'Main',
+    specialtyTypeId: null,
+    specialtyAbbreviation: null,
+    specialtyName: null,
+    isDiscovery: false,
+    caretakerName: null,
+    caretakerPhone: null,
+    caretakerEmail: null,
+    ...overrides,
+  } as Appointment;
+}
+
+function delinquent(overrides: Partial<DelinquentPatient> = {}): DelinquentPatient {
+  return { pastDueTotalAmount: 200, amountPaidSoFar: 50, ...overrides } as DelinquentPatient;
+}
+
+const WRAP_GRID_CLASS = 'lg:grid-cols-[repeat(auto-fit,minmax(11rem,1fr))]';
+
+function mountBar(role: string, appointments: Appointment[]) {
+  return mount(O2StatsBar, {
+    props: { appointments },
+    global: {
+      plugins: [authAs(role)],
+      stubs: { 'router-link': RouterLinkStub },
+    },
+  });
+}
+
+// unique sessionIds per row so :key stays stable
+let nextId = 100;
+function withStatus(appointmentStatusId: number, statusName = ''): Appointment {
+  return appt({ sessionId: nextId++, appointmentStatusId, statusName });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRoute.query = {};
+  // re-seed defaults AFTER clearing (clearAllMocks wipes the seeds; re-seeding also
+  // overwrites any per-test mockRejectedValue implementations so they can't leak)
+  getPendingSummaryMock.mockResolvedValue({ totalPending: 100, therapistCount: 2, sessionCount: 5 });
+  getPastDuePatientsMock.mockResolvedValue([delinquent()]);
+  getSessionsMock.mockResolvedValue([]);
+  getUpcomingMock.mockResolvedValue([]);
+});
+
+describe('O2StatsBar — WP-34C Cancelled / No-Show tile', () => {
+  it('shows the combined headline count with the split detail', async () => {
+    const wrapper = mountBar('FD', [
+      withStatus(3, 'Cancelled'),
+      withStatus(3, 'Cancelled'),
+      withStatus(3, 'Cancelled'),
+      withStatus(5, 'NoShow'),
+      withStatus(4, 'Completed'),
+      withStatus(2, 'Confirmed'),
+    ]);
+    await flushPromises();
+
+    const tile = wrapper.find('[data-testid="stat-cancelled-noshow"]');
+    expect(tile.exists()).toBe(true);
+    expect(tile.text()).toContain('Cancelled / No-Show');
+    expect(wrapper.find('[data-testid="stat-cancelled-noshow-value"]').text()).toBe('4');
+    expect(wrapper.find('[data-testid="stat-cancelled-noshow-subtitle"]').text())
+      .toBe('3 cancelled · 1 no-show');
+  });
+
+  it('stays visible with 0 on a clean day (matches the other always-on tiles)', async () => {
+    const wrapper = mountBar('FD', [withStatus(4, 'Completed'), withStatus(2, 'Confirmed')]);
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="stat-cancelled-noshow"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="stat-cancelled-noshow-value"]').text()).toBe('0');
+    expect(wrapper.find('[data-testid="stat-cancelled-noshow-subtitle"]').text())
+      .toBe('0 cancelled · 0 no-show');
+  });
+
+  it('keys on appointmentStatusId (3 and 5 only) — not on statusName', async () => {
+    const wrapper = mountBar('FD', [
+      withStatus(1, 'Proposed'),
+      withStatus(2, 'Confirmed'),
+      withStatus(4, 'Cancelled'), // lying statusName, id says Completed → NOT counted
+      withStatus(6, 'CheckedIn'),
+      withStatus(7, 'InTherapy'),
+      withStatus(3, ''), // missing statusName, id says Cancelled → counted
+      withStatus(5, ''), // missing statusName, id says NoShow → counted
+    ]);
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="stat-cancelled-noshow-value"]').text()).toBe('2');
+    expect(wrapper.find('[data-testid="stat-cancelled-noshow-subtitle"]').text())
+      .toBe('1 cancelled · 1 no-show');
+  });
+
+  it('FD sees 5 tiles: the money tiles are claim-gated off, the new tile is not', async () => {
+    const wrapper = mountBar('FD', [withStatus(3, 'Cancelled')]);
+    await flushPromises();
+
+    // one -value node per tile → tile count
+    expect(wrapper.findAll('[data-testid$="-value"]').length).toBe(5);
+    expect(wrapper.find('[data-testid="stat-cancelled-noshow"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="stat-pending-therapist-pay"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="stat-pending-caretaker-pay"]').exists()).toBe(false);
+    // FD claims never trigger the gated fetches
+    expect(getPendingSummaryMock).not.toHaveBeenCalled();
+    expect(getPastDuePatientsMock).not.toHaveBeenCalled();
+  });
+
+  it('MGR sees all 7 tiles (both gated summaries load)', async () => {
+    const wrapper = mountBar('MGR', [withStatus(3, 'Cancelled')]);
+    await flushPromises();
+
+    expect(wrapper.findAll('[data-testid$="-value"]').length).toBe(7);
+    expect(wrapper.find('[data-testid="stat-cancelled-noshow"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="stat-pending-therapist-pay"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="stat-pending-caretaker-pay"]').exists()).toBe(true);
+  });
+
+  it('a failed gated summary just omits its tile (6-tile variant)', async () => {
+    getPastDuePatientsMock.mockRejectedValue(new Error('boom'));
+    const wrapper = mountBar('MGR', []);
+    await flushPromises();
+
+    expect(wrapper.findAll('[data-testid$="-value"]').length).toBe(6);
+    expect(wrapper.find('[data-testid="stat-pending-therapist-pay"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="stat-pending-caretaker-pay"]').exists()).toBe(false);
+  });
+
+  it('G4: the grid is a static wrap-friendly auto-fit layout at every tile count — no ladder', async () => {
+    // The old ladder keyed off stats.length (lg:grid-cols-6/-5/-4). With the always-on
+    // 5th tile the reachable lengths are 5 (FD), 6 (one gated summary down), 7 (MGR/AM);
+    // 4 is no longer reachable. The class must be identical — length-independent — in all
+    // variants so any future tile count wraps cleanly too (mobile stays grid-cols-2).
+    const variants: Array<[string, () => void]> = [
+      ['FD-5', () => undefined],
+      ['MGR-6', () => getPendingSummaryMock.mockRejectedValue(new Error('down'))],
+      ['MGR-7', () => undefined],
+    ];
+    for (const [variant, seed] of variants) {
+      seed();
+      const wrapper = mountBar(variant.startsWith('FD') ? 'FD' : 'MGR', []);
+      await flushPromises();
+      const grid = wrapper.find('[data-testid="stats-grid"]');
+      expect(grid.classes(), variant).toContain(WRAP_GRID_CLASS);
+      expect(grid.classes(), variant).toContain('grid-cols-2');
+      expect(grid.classes().join(' '), variant).not.toMatch(/lg:grid-cols-[4567]/);
+      // re-seed for the next variant (per-test overrides must not leak forward)
+      getPendingSummaryMock.mockResolvedValue({ totalPending: 100, therapistCount: 2, sessionCount: 5 });
+    }
+  });
+
+  it('links to the existing Cancelled/No-Show filter tab on the Appointments view', async () => {
+    const wrapper = mountBar('FD', [withStatus(3, 'Cancelled')]);
+    await flushPromises();
+
+    // FD has no money tiles, so the only router-link tile is the cancelled one
+    const links = wrapper.findAllComponents(RouterLinkStub);
+    expect(links.length).toBe(1);
+    expect(links[0].props('to')).toEqual({ path: '/appointments', query: { filter: 'cancelled' } });
+    expect(links[0].attributes('data-testid')).toBe('stat-cancelled-noshow');
+  });
+});
+
+describe('AppointmentsView — ?filter=cancelled deep-link (WP-34C)', () => {
+  const viewStubs = {
+    O2MobileNav: true,
+    O2Sidebar: true,
+    O2Header: true,
+    O2Footer: true,
+    BookingFormModal: true,
+    ActionsPanel: true,
+    AppointmentsTable: true,
+  };
+
+  function seedDay() {
+    getSessionsMock.mockResolvedValue([
+      withStatus(4, 'Completed'),
+      withStatus(3, 'Cancelled'),
+      withStatus(5, 'NoShow'),
+    ]);
+    getUpcomingMock.mockResolvedValue([]);
+  }
+
+  it('pre-selects the existing Cancelled tab so the table shows only statuses 3 and 5', async () => {
+    seedDay();
+    mockRoute.query = { filter: 'cancelled' };
+    const wrapper = mount(AppointmentsView, {
+      global: { plugins: [authAs('FD')], stubs: viewStubs },
+    });
+    await flushPromises();
+
+    const table = wrapper.findComponent({ name: 'AppointmentsTable' });
+    const rows = table.props('appointments') as Appointment[];
+    expect(rows.length).toBe(2);
+    expect(rows.every((a) => a.appointmentStatusId === 3 || a.appointmentStatusId === 5)).toBe(true);
+  });
+
+  it('without the param the view still defaults to All', async () => {
+    seedDay();
+    const wrapper = mount(AppointmentsView, {
+      global: { plugins: [authAs('FD')], stubs: viewStubs },
+    });
+    await flushPromises();
+
+    const table = wrapper.findComponent({ name: 'AppointmentsTable' });
+    expect((table.props('appointments') as Appointment[]).length).toBe(3);
+  });
+});

--- a/app-ui/src/components/option02/O2StatsBar.vue
+++ b/app-ui/src/components/option02/O2StatsBar.vue
@@ -1,13 +1,19 @@
 <template>
   <div>
     <!-- Stat Tiles -->
-    <div :class="['grid grid-cols-2 gap-4',
-                  stats.length >= 6 ? 'lg:grid-cols-6' : stats.length >= 5 ? 'lg:grid-cols-5' : 'lg:grid-cols-4']">
+    <!-- WP-34C (G4): wrap-friendly auto-fit grid replaces the old stats.length ladder
+         (lg:grid-cols-6/-5/-4) — any tile count (4..7+) wraps cleanly at every role
+         perspective without adding ladder rungs. Mobile stays 2-up. -->
+    <div
+      data-testid="stats-grid"
+      class="grid grid-cols-2 gap-4 lg:grid-cols-[repeat(auto-fit,minmax(11rem,1fr))]"
+    >
       <component
         :is="stat.to ? 'router-link' : 'div'"
         v-for="stat in stats"
         :key="stat.label"
         :to="stat.to"
+        :data-testid="stat.testId"
         :class="[
           'bg-white rounded-xl border px-5 py-4 flex items-center gap-4',
           stat.borderClass,
@@ -18,9 +24,9 @@
           <font-awesome-icon :icon="['fas', stat.icon]" :class="stat.iconColor" />
         </div>
         <div class="min-w-0">
-          <p class="text-2xl font-bold text-gray-800 truncate">{{ stat.value }}</p>
+          <p class="text-2xl font-bold text-gray-800 truncate" :data-testid="`${stat.testId}-value`">{{ stat.value }}</p>
           <p class="text-xs text-gray-400">{{ stat.label }}</p>
-          <p v-if="stat.subtitle" class="text-[11px] text-gray-400 mt-0.5">{{ stat.subtitle }}</p>
+          <p v-if="stat.subtitle" class="text-[11px] text-gray-400 mt-0.5" :data-testid="`${stat.testId}-subtitle`">{{ stat.subtitle }}</p>
         </div>
       </component>
     </div>
@@ -155,10 +161,11 @@ import {
   faDollarSign,
   faMoneyBillWave,
   faHandHoldingDollar,
+  faBan,
 } from '@fortawesome/free-solid-svg-icons';
 
 library.add(faCalendarDay, faHourglassHalf, faExclamationTriangle, faCheckCircle, faDollarSign,
-  faMoneyBillWave, faHandHoldingDollar);
+  faMoneyBillWave, faHandHoldingDollar, faBan);
 
 interface StatTile {
   label: string;
@@ -169,6 +176,7 @@ interface StatTile {
   iconColor: string;
   borderClass: string;
   to?: RouteLocationRaw;   // when set, the tile renders as a router-link
+  testId: string;          // stat-* data-testid for specs
 }
 
 export default defineComponent({
@@ -211,6 +219,12 @@ export default defineComponent({
       const paid = props.appointments.filter((a) => a.isPaidOff).length;
       const pastDue = props.appointments.filter((a) => a.isPastDue).length;
       const pending = total - paid - pastDue;
+      // WP-34C (G3 ruling): combined Cancelled + No-Show tile, keyed on appointmentStatusId
+      // (3 = Cancelled, 5 = NoShow — FK ids from the AppointmentStatus lookup seed; ids are
+      // the robust representation, statusName strings are admin-editable lookup values).
+      // Same id predicate as the AppointmentsList "Cancelled" filter tab.
+      const cancelled = props.appointments.filter((a) => a.appointmentStatusId === 3).length;
+      const noShow = props.appointments.filter((a) => a.appointmentStatusId === 5).length;
 
       const tiles: StatTile[] = [
         {
@@ -220,6 +234,7 @@ export default defineComponent({
           iconBg: 'bg-violet-100',
           iconColor: 'text-violet-600',
           borderClass: 'border-gray-200',
+          testId: 'stat-todays-appointments',
         },
         {
           label: 'Paid Off',
@@ -228,6 +243,7 @@ export default defineComponent({
           iconBg: 'bg-green-100',
           iconColor: 'text-green-600',
           borderClass: 'border-gray-200',
+          testId: 'stat-paid-off',
         },
         {
           label: 'Pending Payment',
@@ -236,6 +252,7 @@ export default defineComponent({
           iconBg: 'bg-amber-100',
           iconColor: 'text-amber-600',
           borderClass: 'border-gray-200',
+          testId: 'stat-pending-payment',
         },
         {
           label: 'Past Due',
@@ -244,6 +261,21 @@ export default defineComponent({
           iconBg: 'bg-red-100',
           iconColor: 'text-red-600',
           borderClass: pastDue > 0 ? 'border-red-200' : 'border-gray-200',
+          testId: 'stat-past-due',
+        },
+        {
+          // WP-34C: always-on (rides Dashboard.View like the 4 tiles above — shows 0 on a
+          // clean day, matching their behavior). Links to the EXISTING Cancelled/No-Show
+          // filter tab on the Appointments view (no new view or filter built).
+          label: 'Cancelled / No-Show',
+          value: cancelled + noShow,
+          subtitle: `${cancelled} cancelled · ${noShow} no-show`,
+          icon: 'ban',
+          iconBg: 'bg-slate-100',
+          iconColor: 'text-slate-500',
+          borderClass: 'border-gray-200',
+          to: { path: '/appointments', query: { filter: 'cancelled' } },
+          testId: 'stat-cancelled-noshow',
         },
       ];
 
@@ -258,6 +290,7 @@ export default defineComponent({
           iconColor: 'text-sky-600',
           borderClass: summary.totalPending > 0 ? 'border-sky-200' : 'border-gray-200',
           to: { path: '/therapists', query: { tab: 'pending-pay' } },
+          testId: 'stat-pending-therapist-pay',
         });
       }
 
@@ -273,6 +306,7 @@ export default defineComponent({
           iconColor: 'text-rose-600',
           borderClass: receivable > 0 ? 'border-rose-200' : 'border-gray-200',
           to: { path: '/patients', query: { tab: 'delinquent' } },
+          testId: 'stat-pending-caretaker-pay',
         });
       }
 

--- a/app-ui/src/views/AppointmentsView.vue
+++ b/app-ui/src/views/AppointmentsView.vue
@@ -158,6 +158,12 @@ export default defineComponent({
     const onStatusUpdated = () => loadAppointments();
 
     onMounted(async () => {
+      // WP-34C: the dashboard Cancelled/No-Show tile deep-links to the EXISTING filter tab
+      // (?filter=cancelled). Pre-selects any known tab value; no new filter logic added.
+      const filterParam = route.query.filter;
+      if (typeof filterParam === 'string' && filterParam) {
+        activeFilter.value = filterParam;
+      }
       await loadAppointments();
       // Auto-open booking modal if deep-linked with bookFor param
       const bookFor = Number(route.query.bookFor);

--- a/app-ui/test-scenarios/wp-34-cancelled-tile.md
+++ b/app-ui/test-scenarios/wp-34-cancelled-tile.md
@@ -1,0 +1,76 @@
+# WP-34C — Dashboard Tile: Cancelled / No-Show — Owner Walkthrough
+
+**What changed:**
+1. A new always-on dashboard stat tile, **"Cancelled / No-Show"**: headline number = today's
+   Cancelled + No-Show appointments combined; small subtitle shows the split
+   ("3 cancelled · 1 no-show"). Visible to **everyone** with dashboard access (it is a count,
+   not money — no claim gating).
+2. The stat-bar grid was reworked to a wrap-friendly layout: any number of tiles (FD's 5,
+   MGR/AM's 7, or more in the future) wraps cleanly instead of relying on a fixed
+   6/5/4-column ladder.
+3. Clicking the tile jumps to **Appointments** with the existing **Cancelled** filter tab
+   pre-selected (shows today's Cancelled + No-Show rows).
+
+No API or DB change; no permission/matrix change; no re-login needed.
+
+---
+
+## Scenario 1 — Day with several cancelled/no-show (any role)
+
+Pick (or set up) a day that has a mix: e.g. 3 sessions Cancelled, 1 marked No-Show, plus some
+Completed/Confirmed ones. (To stage one: Appointments → row actions → Cancel on a few,
+No-Show on one.)
+
+1. Open the dashboard (Home) for that day.
+2. **Expect:** a "Cancelled / No-Show" tile with a gray "ban" icon.
+   - Headline number = **4** (3 cancelled + 1 no-show).
+   - Subtitle underneath reads **"3 cancelled · 1 no-show"**.
+3. Cross-check: the headline must equal the count of rows on the Appointments view's
+   Cancelled tab for the same day.
+4. The other tiles are unchanged: Today's Appointments still counts ALL sessions (including
+   cancelled ones), Paid Off / Pending Payment / Past Due behave as before.
+
+## Scenario 2 — Clean day (0 cancelled)
+
+1. Navigate the dashboard calendar to a day with no cancelled/no-show sessions.
+2. **Expect:** the tile stays visible and shows **0**, subtitle "0 cancelled · 0 no-show" —
+   same behavior as the other always-on tiles (they show 0 rather than hide).
+
+## Scenario 3 — Tile click-through
+
+1. On a day with cancellations, click the "Cancelled / No-Show" tile.
+2. **Expect:** you land on **Appointments** with the **Cancelled** filter tab already
+   selected, listing today's Cancelled and No-Show rows (both statuses share that tab —
+   this is the pre-existing tab, unchanged).
+3. Click the "All" tab — the full list appears as usual.
+
+## Scenario 4 — Role perspectives (grid spacing)
+
+**As Front Desk (FD):**
+1. Open the dashboard. **Expect 5 tiles:** Today's Appointments, Paid Off, Pending Payment,
+   Past Due, Cancelled / No-Show. The two money tiles (Pending Therapist Pay, Pending
+   Caretaker Pay) are absent as before.
+2. Tiles are evenly sized with no oversized gaps or a lonely stretched tile.
+
+**As Manager or Admin (MGR/AM):**
+1. Open the dashboard. **Expect 7 tiles:** the 5 above plus Pending Therapist Pay and
+   Pending Caretaker Pay (still linked to their tabs).
+2. On a typical desktop width the 7 tiles wrap onto a second row cleanly (e.g. 4+3 or 5+2
+   depending on window width) — no squashed tiles, no horizontal scrollbar.
+
+## Scenario 5 — Desktop and mobile widths
+
+1. Desktop (roughly 1280px+): tiles lay out in a single row or wrap once; resize the browser
+   narrower and watch tiles re-wrap smoothly with equal widths.
+2. Mobile / narrow window (under ~1024px): tiles show **2 per row** as before, for both FD
+   (5 tiles → 2+2+1) and MGR/AM (7 tiles → 2+2+2+1).
+3. The "Cancelled / No-Show" label may wrap to two lines in a tight tile — that is expected;
+   nothing should be cut off.
+
+## Scenario 6 — Count keys on status, not money
+
+1. Cancel a session that already has money recorded (or one past due).
+2. **Expect:** it counts in the Cancelled / No-Show tile regardless of its payment state,
+   and it still ALSO appears wherever its money state puts it (e.g. Past Due) — the tile is
+   status-only and deliberately money-agnostic (the cancelled-money cleanup is a separate,
+   pending work package).


### PR DESCRIPTION
- New always-on 5th stat tile on O2StatsBar: headline = today's Cancelled (status 3) + No-Show (status 5) combined, subtitle shows the split ("3 cancelled . 1 no-show"). Counted client-side from the already-loaded day feed, keyed on appointmentStatusId (ids are the robust wire representation; statusName is an admin-editable lookup string). Visible to everyone with dashboard access - no claim gating, no new fetches.
- G4 grid rework: the stats.length lg:grid-cols-6/-5/-4 ladder is replaced with a static wrap-friendly auto-fit grid (lg:grid-cols-[repeat(auto-fit,minmax(11rem,1fr))]) so 4..7+ tiles all wrap cleanly at every role perspective; mobile stays 2-up.
- Tile deep-links to the EXISTING Cancelled/No-Show filter tab on the Appointments view via ?filter=cancelled (AppointmentsView now pre-selects activeFilter from the query param on mount - no new view or filter built).
- data-testids added to all stat tiles (stat-*, plus -value/-subtitle) and the grid container for spec targeting.
- Specs: wp34-cancelled-tile.spec.ts (10 tests) - combined count + split, zero-day shows 0, id-keying (3/5 counted, lying statusName ignored), FD 5-tile / MGR 7-tile / degraded 6-tile variants, ladder-free grid class at every reachable stats length, router-link target, and the ?filter=cancelled deep-link. Suite: 284 -> 294 green.
- Test artifact: test-scenarios/wp-34-cancelled-tile.md (role-by-role owner walkthrough incl. 0-cancelled day, mobile + desktop widths).