### PR TITLE
WP-40C (BK-1/2/3): booking auto-money UI — duration select {30,40,45,…

### DIFF
--- a/app-ui/src/__tests__/wp23-booking-money.spec.ts
+++ b/app-ui/src/__tests__/wp23-booking-money.spec.ts
@@ -146,11 +146,15 @@ beforeEach(() => {
 // ── BookingFormModal ─────────────────────────────────────────────────────────
 
 type BookingVm = {
-  form: { patientId: number; specialtyTypeId: number; amount: number; discount: number };
+  form: { patientId: number; specialtyTypeId: number; duration: number };
   senadisPatient: boolean;
-  senadisFloor: number;
   caretakerWarning: boolean;
   isValid: boolean;
+  // WP-40: money is derived + read-only in the booking form.
+  derivedAmount: number | null;
+  derivedDiscount: number;
+  amountSource: string;
+  missingPrice: boolean;
 };
 
 async function openBookingModal(pinia: Pinia) {
@@ -163,61 +167,61 @@ async function openBookingModal(pinia: Pinia) {
   return wrapper;
 }
 
-describe('BookingFormModal — F6 default-price pre-fill', () => {
-  it('pre-fills Amount from the specialty defaultAmount and refills on change', async () => {
+describe('BookingFormModal — F6 default-price fallback (WP-40: derived, read-only)', () => {
+  it('derives Amount from the specialty defaultAmount when no duration row exists — and blocks when neither exists', async () => {
     const wrapper = await openBookingModal(authAs('MGR'));
     const vm = wrapper.vm as unknown as BookingVm;
 
-    vm.form.specialtyTypeId = 6; // TL, defaultAmount 65
+    vm.form.specialtyTypeId = 6; // TL, defaultAmount 65, no duration rows
     await flushPromises();
-    expect(vm.form.amount).toBe(65);
+    expect(vm.derivedAmount).toBe(65);
+    expect(vm.amountSource).toBe('defaultAmount'); // G2 badge path
+    expect(wrapper.find('[data-testid="default-amount-badge"]').exists()).toBe(true);
 
-    // NULL default leaves the amount alone (user may have typed one already)
-    vm.form.amount = 42;
+    // No duration row AND null default ⇒ G4 missing-price block
     vm.form.specialtyTypeId = 2; // FS, defaultAmount null
     await flushPromises();
-    expect(vm.form.amount).toBe(42);
+    expect(vm.derivedAmount).toBeNull();
+    expect(vm.missingPrice).toBe(true);
+    expect(vm.isValid).toBe(false);
+    expect(wrapper.find('[data-testid="missing-price-block"]').exists()).toBe(true);
   });
 });
 
-describe('BookingFormModal — F7 SENADIS floor + toast', () => {
-  it('flags the patient, toasts once, and clamps the discount to 20% of amount', async () => {
+describe('BookingFormModal — F7 SENADIS (WP-40: derived exact-20%, no toast/clamp)', () => {
+  it('derives the discount to exactly 20% of the derived amount and submits the derived money', async () => {
     const pinia = authAs('MGR');
     const wrapper = await openBookingModal(pinia);
     const vm = wrapper.vm as unknown as BookingVm;
     const notifications = useNotificationsStore();
 
     vm.form.patientId = FLAGGED_ID;
+    vm.form.specialtyTypeId = 6; // defaultAmount 65
     await flushPromises();
 
     expect(vm.senadisPatient).toBe(true);
-    const senadisToasts = notifications.items.filter((n) => n.message.includes('SENADIS'));
-    expect(senadisToasts).toHaveLength(1);
+    // WP-40: the toast is gone — the in-place "SENADIS 20% applied" badge explains it.
+    expect(notifications.items.filter((n) => n.message.includes('SENADIS'))).toHaveLength(0);
+    expect(wrapper.find('[data-testid="senadis-applied-badge"]').exists()).toBe(true);
+    expect(vm.derivedDiscount).toBe(13); // round(0.20 × 65, 2)
 
-    vm.form.amount = 100;
-    await flushPromises();
-    expect(vm.senadisFloor).toBe(20);
-    expect(vm.form.discount).toBe(20); // re-clamped when the amount moved the floor
-
-    // submit clamps a below-floor discount before sending; server floors too
-    vm.form.discount = 5;
     (wrapper.vm as unknown as { handleSubmit: () => Promise<void> }).handleSubmit();
     await flushPromises();
-    expect(createSessionMock).toHaveBeenCalledWith(expect.objectContaining({ discount: 20 }));
+    expect(createSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ amount: 65, discount: 13 }));
   });
 
-  it('leaves unflagged patients untouched', async () => {
+  it('derives 0 for unflagged patients regardless of the amount', async () => {
     const wrapper = await openBookingModal(authAs('MGR'));
     const vm = wrapper.vm as unknown as BookingVm;
 
     vm.form.patientId = UNFLAGGED_ID;
-    await flushPromises();
-    vm.form.amount = 100;
-    vm.form.discount = 5;
+    vm.form.specialtyTypeId = 6;
     await flushPromises();
 
     expect(vm.senadisPatient).toBe(false);
-    expect(vm.form.discount).toBe(5);
+    expect(vm.derivedDiscount).toBe(0);
+    expect(wrapper.find('[data-testid="senadis-applied-badge"]').exists()).toBe(false);
   });
 });
 

--- a/app-ui/src/__tests__/wp37-senadis-expiration.spec.ts
+++ b/app-ui/src/__tests__/wp37-senadis-expiration.spec.ts
@@ -169,10 +169,11 @@ describe('isSenadisExpired — G1/G2 predicate', () => {
 // ── BookingFormModal — expiry-aware floor (G2) ───────────────────────────────
 
 type BookingVm = {
-  form: { patientId: number; sessionDate: string; amount: number; discount: number };
+  form: { patientId: number; sessionDate: string; specialtyTypeId: number };
   senadisPatient: boolean;
   senadisActive: boolean;
-  senadisFloor: number;
+  // WP-40: money derives read-only — 20% of the derived amount while active, else 0.
+  derivedDiscount: number;
 };
 
 async function openBookingModal(pinia: Pinia) {
@@ -188,105 +189,93 @@ async function openBookingModal(pinia: Pinia) {
 const badge = (wrapper: ReturnType<typeof mount>) =>
   wrapper.find('[data-testid="senadis-expired-badge"]'); // re-find after every change (teleport-stub gotcha)
 
-describe('BookingFormModal — WP-37 expiry-aware SENADIS clamp', () => {
-  it('null expiry: floor + clamp still apply (G1 open-ended), no badge', async () => {
+describe('BookingFormModal — WP-37 expiry-aware SENADIS derivation (WP-40: read-only exact-20%)', () => {
+  it('null expiry: discount derives to 20% (G1 open-ended), no badge', async () => {
     const wrapper = await openBookingModal(authAs('MGR'));
     const vm = wrapper.vm as unknown as BookingVm;
 
     vm.form.patientId = NULL_EXPIRY_ID;
-    await flushPromises();
-    vm.form.amount = 100;
+    vm.form.specialtyTypeId = 6; // defaultAmount 65
     await flushPromises();
 
     expect(vm.senadisActive).toBe(true);
-    expect(vm.senadisFloor).toBe(20);
-    expect(vm.form.discount).toBe(20);
+    expect(vm.derivedDiscount).toBe(13); // round(0.20 × 65, 2)
     expect(badge(wrapper).exists()).toBe(false);
   });
 
-  it('future expiry: floor + toast apply, no badge', async () => {
+  it('future expiry: discount derives to 20% — badge in place of the retired toast', async () => {
     const pinia = authAs('MGR');
     const wrapper = await openBookingModal(pinia);
     const vm = wrapper.vm as unknown as BookingVm;
     const notifications = useNotificationsStore();
 
     vm.form.patientId = FUTURE_ID;
-    await flushPromises();
-    vm.form.amount = 100;
+    vm.form.specialtyTypeId = 6;
     await flushPromises();
 
-    expect(vm.form.discount).toBe(20);
-    expect(notifications.items.filter((n) => n.message.includes('SENADIS'))).toHaveLength(1);
+    expect(vm.derivedDiscount).toBe(13);
+    // WP-40: no toast — the "SENADIS 20% applied" badge explains the derived value in place.
+    expect(notifications.items.filter((n) => n.message.includes('SENADIS'))).toHaveLength(0);
+    expect(wrapper.find('[data-testid="senadis-applied-badge"]').exists()).toBe(true);
     expect(badge(wrapper).exists()).toBe(false);
   });
 
-  it('expired: NO floor, NO min, NO toast, NO clamp-on-submit — badge shown instead', async () => {
+  it('expired: discount derives to 0 — badge shown, derived 0 goes to the API', async () => {
     const pinia = authAs('MGR');
     const wrapper = await openBookingModal(pinia);
     const vm = wrapper.vm as unknown as BookingVm;
-    const notifications = useNotificationsStore();
 
     vm.form.patientId = EXPIRED_ID;
-    await flushPromises();
-    vm.form.amount = 100;
-    vm.form.discount = 5;
+    vm.form.specialtyTypeId = 6;
     await flushPromises();
 
     expect(vm.senadisPatient).toBe(true); // flag stays on (G3 — never auto-cleared)
     expect(vm.senadisActive).toBe(false);
-    expect(vm.senadisFloor).toBe(0);
-    expect(vm.form.discount).toBe(5); // not clamped
-    expect(notifications.items.filter((n) => n.message.includes('SENADIS'))).toHaveLength(0);
+    expect(vm.derivedDiscount).toBe(0);
     expect(badge(wrapper).exists()).toBe(true);
     expect(badge(wrapper).text()).toContain('SENADIS expired Jun 30, 2020');
 
-    // submit does NOT clamp an expired patient's discount; the requested value goes through
     (wrapper.vm as unknown as { handleSubmit: () => Promise<void> }).handleSubmit();
     await vi.waitFor(() => expect(createSessionMock).toHaveBeenCalled());
-    expect(createSessionMock).toHaveBeenCalledWith(expect.objectContaining({ discount: 5 }));
+    expect(createSessionMock).toHaveBeenCalledWith(expect.objectContaining({ discount: 0 }));
   });
 
-  it('boundary: session date == expiry still floors (G2: expired only when strictly past)', async () => {
+  it('boundary: session date == expiry still derives 20% (G2: expired only when strictly past)', async () => {
     const wrapper = await openBookingModal(authAs('MGR'));
     const vm = wrapper.vm as unknown as BookingVm;
 
     vm.form.sessionDate = '2026-08-15'; // == WINDOW expiry
     vm.form.patientId = WINDOW_ID;
-    await flushPromises();
-    vm.form.amount = 100;
+    vm.form.specialtyTypeId = 6;
     await flushPromises();
 
     expect(vm.senadisActive).toBe(true);
-    expect(vm.form.discount).toBe(20);
+    expect(vm.derivedDiscount).toBe(13);
     expect(badge(wrapper).exists()).toBe(false);
   });
 
-  it('changing the session date across the expiry flips floor/badge both ways', async () => {
+  it('changing the session date across the expiry flips derived discount/badge both ways', async () => {
     const wrapper = await openBookingModal(authAs('MGR'));
     const vm = wrapper.vm as unknown as BookingVm;
 
     vm.form.sessionDate = '2026-08-10'; // before expiry
     vm.form.patientId = WINDOW_ID;
+    vm.form.specialtyTypeId = 6;
     await flushPromises();
-    vm.form.amount = 100;
-    await flushPromises();
-    expect(vm.form.discount).toBe(20); // clamped
+    expect(vm.derivedDiscount).toBe(13);
 
-    // cross past the expiry: floor lifts, badge appears, discount can go below 20%
+    // cross past the expiry: the derived discount drops to 0, badge appears
     vm.form.sessionDate = '2026-08-20';
     await nextTick();
     expect(vm.senadisActive).toBe(false);
-    expect(vm.senadisFloor).toBe(0);
+    expect(vm.derivedDiscount).toBe(0);
     expect(badge(wrapper).exists()).toBe(true);
-    vm.form.discount = 3;
-    await nextTick();
-    expect(vm.form.discount).toBe(3); // no re-clamp while expired
 
-    // move back on/before the expiry: the clamp re-applies
+    // move back on/before the expiry: the 20% derivation re-applies
     vm.form.sessionDate = '2026-08-15';
     await nextTick();
     expect(vm.senadisActive).toBe(true);
-    expect(vm.form.discount).toBe(20);
+    expect(vm.derivedDiscount).toBe(13);
     expect(badge(wrapper).exists()).toBe(false);
   });
 });

--- a/app-ui/src/__tests__/wp40-booking-auto-money.spec.ts
+++ b/app-ui/src/__tests__/wp40-booking-auto-money.spec.ts
@@ -1,0 +1,426 @@
+// WP-40 (BK-1/BK-2/BK-3) — booking auto-money:
+//   BK-1 — duration is a fixed select {30,40,45,60,90,120} (40 per the 2026-07-27 addendum).
+//   BK-2 — Amount/Discount/ProviderAmt are DERIVED read-only displays: amount from the WP-39
+//          price sheet (duration row → defaultAmount → G4 block), discount = exact-20% while
+//          SENADIS is active at the session date else 0, provider from the therapist fee model.
+//   On-site leg: checkbox only for offeredOnSite specialties; trip charge shown as its own line.
+//   BK-3 — the ActionsPanel discount edit is gated on Sessions.Discount.Edit (AM/MGR);
+//          the PUT omits duration (stored value kept) and providerAmount (server-derived).
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { setActivePinia, createPinia, type Pinia } from 'pinia';
+import { mount, flushPromises } from '@vue/test-utils';
+import manifest from '../generated/access-control-matrix.json';
+import { useAuthStore } from '../stores/auth';
+import type { ClaimDto } from '../interfaces/Auth';
+import type { Patient } from '../interfaces/Patient';
+import type { Appointment } from '../interfaces/Appointment';
+import BookingFormModal from '../components/appointments/BookingFormModal.vue';
+import ActionsPanel from '../components/appointments/ActionsPanel.vue';
+
+// ── ids / fixtures ───────────────────────────────────────────────────────────
+
+const FLAGGED_ID = 1;
+const UNFLAGGED_ID = 2;
+
+function patient(overrides: Partial<Patient> = {}): Patient {
+  return {
+    patientId: UNFLAGGED_ID,
+    userId: 10,
+    patientName: 'Doe, John',
+    medicalRecordNumber: 'NC26-0001',
+    cedula: null,
+    dateOfBirth: '2015-01-15T00:00:00',
+    email: 'john@example.com',
+    phoneNumber: '555-0100',
+    gender: 'Male',
+    isActive: true,
+    hasSenadisDiscount: false,
+    hasCompletedDiscovery: true,
+    createdTimestamp: '2025-01-01T00:00:00',
+    caretakers: [],
+    ...overrides,
+  };
+}
+
+// Specialty 5: priced rows for 30/60, defaultAmount fallback for other durations.
+// Specialty 9: offeredOnSite (the dormant on-site leg, exercised here ahead of the flag flip).
+// Specialty 2: NO price at all → the G4 missing-price block.
+const SPECIALTIES = [
+  {
+    id: 5, abbreviation: 'TC', name: 'Conduct Therapy', description: null, sortOrder: 1,
+    defaultAmount: 40, offeredOnSite: false, createdTimestamp: '', lastUpdatedTimestamp: '',
+    durationPrices: [
+      { durationMinutes: 30, amount: 25, effectiveFrom: '2026-01-01' },
+      { durationMinutes: 60, amount: 45, effectiveFrom: '2026-01-01' },
+    ],
+  },
+  {
+    id: 9, abbreviation: 'DOM', name: 'Domiciliar Therapy', description: null, sortOrder: 2,
+    defaultAmount: 30, offeredOnSite: true, createdTimestamp: '', lastUpdatedTimestamp: '',
+    durationPrices: [{ durationMinutes: 60, amount: 50, effectiveFrom: '2026-01-01' }],
+  },
+  {
+    id: 2, abbreviation: 'FS', name: 'Physiotherapy', description: null, sortOrder: 3,
+    defaultAmount: null, offeredOnSite: false, createdTimestamp: '', lastUpdatedTimestamp: '',
+    durationPrices: [],
+  },
+];
+
+const { patientsClientMocks, lookupGetAllMock, createSessionMock, updateSessionMock, getSitesMock } = vi.hoisted(() => ({
+  patientsClientMocks: {
+    getPatient: vi.fn(),
+    getPatientCaretakers: vi.fn(),
+  },
+  lookupGetAllMock: vi.fn(),
+  createSessionMock: vi.fn().mockResolvedValue({}),
+  updateSessionMock: vi.fn().mockResolvedValue(undefined),
+  getSitesMock: vi.fn(),
+}));
+
+vi.mock('../services/PatientsHttpClient', () => ({
+  PatientsHttpClient: vi.fn().mockImplementation(() => ({
+    getPatient: patientsClientMocks.getPatient,
+    getPatientCaretakers: patientsClientMocks.getPatientCaretakers,
+    lookupPatients: vi.fn().mockResolvedValue([]),
+  })),
+}));
+
+vi.mock('../services/TherapistsHttpClient', () => ({
+  TherapistsHttpClient: vi.fn().mockImplementation(() => ({
+    getTherapists: vi.fn().mockResolvedValue([
+      // Flat-fee therapist (pct 0 ⇒ flat 25) and %-of-net therapist (0.50). Both qualified
+      // for the fixture specialties so the specialty↔therapist filter keeps them selectable.
+      { therapistId: 7, id: 7, therapistName: 'Flat, Fiona', feePerSession: 25, feePctPerSession: 0,
+        specialties: [{ specialtyId: 5 }, { specialtyId: 9 }, { specialtyId: 2 }] },
+      { therapistId: 8, id: 8, therapistName: 'Pct, Paula', feePerSession: 0, feePctPerSession: 0.5,
+        specialties: [{ specialtyId: 5 }, { specialtyId: 9 }, { specialtyId: 2 }] },
+    ]),
+  })),
+}));
+
+vi.mock('../services/LookupHttpClient', () => ({
+  LookupHttpClient: vi.fn().mockImplementation(() => ({
+    getAll: lookupGetAllMock,
+  })),
+}));
+
+vi.mock('../services/SessionsHttpClient', () => ({
+  SessionsHttpClient: vi.fn().mockImplementation(() => ({
+    createSession: createSessionMock,
+    updateSession: updateSessionMock,
+  })),
+}));
+
+vi.mock('../services/SitesHttpClient', () => ({
+  SitesHttpClient: vi.fn().mockImplementation(() => ({
+    getSites: getSitesMock,
+  })),
+}));
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+function claimsForRole(role: string): ClaimDto[] {
+  return (manifest.claims as Array<{ claim: string; grants: string[] }>)
+    .filter((c) => c.grants.includes(role))
+    .map((c) => ({ type: 'Permission', value: c.claim }));
+}
+
+function authAs(role: string): Pinia {
+  const pinia = createPinia();
+  setActivePinia(pinia);
+  const store = useAuthStore();
+  store.user = {
+    userId: 1,
+    email: 'test@example.com',
+    fullName: 'Test User',
+    mustChangePassword: false,
+    roles: [role],
+    claims: claimsForRole(role),
+    isSystemAdmin: false,
+  };
+  return pinia;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  createSessionMock.mockResolvedValue({});
+  updateSessionMock.mockResolvedValue(undefined);
+  lookupGetAllMock.mockResolvedValue(SPECIALTIES);
+  getSitesMock.mockResolvedValue([
+    { siteId: 1, siteName: 'Main Clinic', onSiteTripChargeAmount: 25 },
+  ]);
+  patientsClientMocks.getPatient.mockImplementation(async (id: number) =>
+    patient({ patientId: id, hasSenadisDiscount: id === FLAGGED_ID }));
+  patientsClientMocks.getPatientCaretakers.mockResolvedValue([
+    { caretakerId: 1, caretakerName: 'Care, Cara', isPrimaryCaretaker: true, relationshipToPatient: 'Mother' },
+  ]);
+});
+
+// ── BookingFormModal ─────────────────────────────────────────────────────────
+
+type BookingVm = {
+  form: { patientId: number; therapistId: number; specialtyTypeId: number; duration: number; sessionDate: string };
+  derivedAmount: number | null;
+  derivedDiscount: number;
+  derivedProviderAmount: number;
+  amountSource: string;
+  missingPrice: boolean;
+  isValid: boolean;
+  onSiteVisit: boolean;
+  onSiteSiteId: number;
+  handleSubmit: () => Promise<void>;
+};
+
+async function openBookingModal(pinia: Pinia) {
+  const wrapper = mount(BookingFormModal, {
+    props: { visible: false },
+    global: { plugins: [pinia], stubs: { teleport: true } },
+  });
+  await wrapper.setProps({ visible: true });
+  await flushPromises();
+  return wrapper;
+}
+
+describe('BookingFormModal — BK-1 fixed duration select', () => {
+  it('offers exactly 30/40/45/60/90/120 and defaults to 60', async () => {
+    const wrapper = await openBookingModal(authAs('MGR'));
+
+    const options = wrapper.find('[data-testid="duration-select"]').findAll('option');
+    expect(options.map(o => Number(o.attributes('value')))).toEqual([30, 40, 45, 60, 90, 120]);
+    expect((wrapper.vm as unknown as BookingVm).form.duration).toBe(60);
+  });
+});
+
+describe('BookingFormModal — BK-2 derived read-only money', () => {
+  it('derives Amount from the duration price row and re-derives when the duration changes', async () => {
+    const wrapper = await openBookingModal(authAs('MGR'));
+    const vm = wrapper.vm as unknown as BookingVm;
+
+    vm.form.specialtyTypeId = 5;
+    await flushPromises();
+    expect(vm.derivedAmount).toBe(45);         // 60-min row
+    expect(vm.amountSource).toBe('durationPrice');
+    expect(wrapper.find('[data-testid="derived-amount"]').text()).toContain('45.00');
+
+    vm.form.duration = 30;
+    await flushPromises();
+    expect(vm.derivedAmount).toBe(25);         // 30-min row
+
+    vm.form.duration = 40;                     // no 40-min row → defaultAmount fallback + badge
+    await flushPromises();
+    expect(vm.derivedAmount).toBe(40);
+    expect(vm.amountSource).toBe('defaultAmount');
+    expect(wrapper.find('[data-testid="default-amount-badge"]').exists()).toBe(true);
+  });
+
+  it('renders money as read-only displays — no amount/discount/provider inputs for anyone', async () => {
+    const wrapper = await openBookingModal(authAs('MGR'));
+
+    expect(wrapper.find('[data-testid="derived-amount"]').element.tagName).toBe('P');
+    expect(wrapper.find('[data-testid="derived-discount"]').element.tagName).toBe('P');
+    expect(wrapper.find('[data-testid="derived-provider-amount"]').element.tagName).toBe('P');
+    // The only number-ish inputs left are date/time/checkbox/select — no money inputs.
+    expect(wrapper.findAll('input[type="number"]')).toHaveLength(0);
+  });
+
+  it('G4: a specialty with no price row and no default blocks submit with the message', async () => {
+    const wrapper = await openBookingModal(authAs('MGR'));
+    const vm = wrapper.vm as unknown as BookingVm;
+
+    vm.form.specialtyTypeId = 2; // Physiotherapy — unpriced
+    await flushPromises();
+
+    expect(vm.missingPrice).toBe(true);
+    expect(vm.isValid).toBe(false);
+    const block = wrapper.find('[data-testid="missing-price-block"]');
+    expect(block.exists()).toBe(true);
+    expect(block.text()).toContain('No price configured for Physiotherapy at 60 min');
+  });
+
+  it('derives the provider fee from the therapist model — flat vs % of net', async () => {
+    const wrapper = await openBookingModal(authAs('MGR'));
+    const vm = wrapper.vm as unknown as BookingVm;
+
+    vm.form.specialtyTypeId = 5; // 60-min row = 45
+    vm.form.therapistId = 7;     // flat 25
+    await flushPromises();
+    expect(vm.derivedProviderAmount).toBe(25);
+
+    vm.form.therapistId = 8;     // 50% of net (45 − 0)
+    await flushPromises();
+    expect(vm.derivedProviderAmount).toBe(22.5);
+  });
+
+  it('claim-gates the provider display: MGR sees it, FD does not', async () => {
+    const mgr = await openBookingModal(authAs('MGR'));
+    expect(mgr.find('[data-testid="derived-provider-amount"]').exists()).toBe(true);
+
+    const fd = await openBookingModal(authAs('FD'));
+    expect(fd.find('[data-testid="derived-provider-amount"]').exists()).toBe(false);
+  });
+
+  it('SENADIS patient: derived exact-20% discount rides into the submit payload', async () => {
+    const wrapper = await openBookingModal(authAs('MGR'));
+    const vm = wrapper.vm as unknown as BookingVm;
+
+    vm.form.patientId = FLAGGED_ID;
+    vm.form.specialtyTypeId = 5;   // 45.00
+    vm.form.therapistId = 7;
+    await flushPromises();
+
+    expect(vm.derivedDiscount).toBe(9); // round(0.20 × 45, 2)
+    expect(wrapper.find('[data-testid="senadis-applied-badge"]').exists()).toBe(true);
+
+    vm.handleSubmit();
+    await vi.waitFor(() => expect(createSessionMock).toHaveBeenCalled());
+    expect(createSessionMock).toHaveBeenCalledWith(expect.objectContaining({
+      amount: 45, discount: 9, duration: 60, specialtyTypeId: 5, isOnSiteVisit: false,
+    }));
+  });
+});
+
+describe('BookingFormModal — on-site leg (dormant until OfferedOnSite flips)', () => {
+  it('shows the checkbox only for offeredOnSite specialties', async () => {
+    const wrapper = await openBookingModal(authAs('MGR'));
+    const vm = wrapper.vm as unknown as BookingVm;
+
+    vm.form.specialtyTypeId = 5; // not offered on-site
+    await flushPromises();
+    expect(wrapper.find('[data-testid="onsite-checkbox"]').exists()).toBe(false);
+
+    vm.form.specialtyTypeId = 9; // offeredOnSite
+    await flushPromises();
+    expect(wrapper.find('[data-testid="onsite-checkbox"]').exists()).toBe(true);
+  });
+
+  it('checked: loads sites, shows the trip charge as its own line, and submits isOnSiteVisit + siteId', async () => {
+    const wrapper = await openBookingModal(authAs('MGR'));
+    const vm = wrapper.vm as unknown as BookingVm;
+
+    vm.form.patientId = UNFLAGGED_ID;
+    vm.form.specialtyTypeId = 9; // 60-min row = 50
+    vm.form.therapistId = 7;
+    await flushPromises();
+
+    vm.onSiteVisit = true;
+    await flushPromises();
+    expect(getSitesMock).toHaveBeenCalled();
+    expect(vm.isValid).toBe(false); // no site chosen yet
+
+    vm.onSiteSiteId = 1;
+    await flushPromises();
+    const chargeLine = wrapper.find('[data-testid="onsite-charge-line"]');
+    expect(chargeLine.exists()).toBe(true);
+    expect(chargeLine.text()).toContain('On-site visit charge: $25.00');
+    expect(vm.isValid).toBe(true);
+
+    vm.handleSubmit();
+    await vi.waitFor(() => expect(createSessionMock).toHaveBeenCalled());
+    expect(createSessionMock).toHaveBeenCalledWith(expect.objectContaining({
+      amount: 50, isOnSiteVisit: true, siteId: 1,
+    }));
+  });
+});
+
+// ── ActionsPanel — BK-3 gated discount edit ──────────────────────────────────
+
+function appointmentFixture(overrides: Partial<Appointment> = {}): Appointment {
+  return {
+    sessionId: 77,
+    sessionDate: '2026-07-27',
+    sessionTime: '09:00:00',
+    patient: 'Doe, John',
+    therapist: 'Flat, Fiona',
+    therapyTypes: 'TC',
+    amount: 45,
+    discount: 9,
+    amountPaid: 0,
+    amountDue: 36,
+    isPastDue: false,
+    isPaidOff: false,
+    notes: '',
+    patientId: FLAGGED_ID,
+    therapistId: 7,
+    time: '09:00',
+    appointmentStatusId: 1,
+    statusName: 'Proposed',
+    isConfirmed: false,
+    siteId: 1,
+    siteName: 'Main Clinic',
+    specialtyTypeId: 5,
+    specialtyAbbreviation: 'TC',
+    specialtyName: 'Conduct Therapy',
+    isDiscovery: false,
+    caretakerName: 'Care, Cara',
+    caretakerPhone: '555-0001',
+    caretakerEmail: 'cara@example.com',
+    providerAmount: 25,
+    ...overrides,
+  };
+}
+
+async function openFinancialEdit(role: string, appt: Appointment = appointmentFixture()) {
+  const pinia = authAs(role);
+  const wrapper = mount(ActionsPanel, {
+    props: { visible: true, appointment: appt },
+    global: { plugins: [pinia], stubs: { teleport: true } },
+  });
+  await flushPromises();
+  await (wrapper.vm as unknown as { startEditFinancials: () => Promise<void> }).startEditFinancials();
+  await flushPromises();
+  return wrapper;
+}
+
+describe('ActionsPanel — BK-3 discount edit gating', () => {
+  it('FD: discount is read-only with the manager hint; no provider input anywhere', async () => {
+    const wrapper = await openFinancialEdit('FD');
+
+    expect(wrapper.find('[data-testid="edit-discount-input"]').exists()).toBe(false);
+    const readonly = wrapper.find('[data-testid="edit-discount-readonly"]');
+    expect(readonly.exists()).toBe(true);
+    expect(readonly.text()).toContain('9.00');
+    expect(wrapper.text()).toContain('Discount edits need a Manager / Assistant Manager.');
+    // FD lacks Appointments.ProviderAmount → no provider display either.
+    expect(wrapper.find('[data-testid="edit-provider-display"]').exists()).toBe(false);
+  });
+
+  it('MGR: discount editable with the SENADIS floor hint; provider is display-only ("recomputed on save")', async () => {
+    const wrapper = await openFinancialEdit('MGR');
+
+    expect(wrapper.find('[data-testid="edit-discount-input"]').exists()).toBe(true);
+    const hint = wrapper.find('[data-testid="edit-senadis-floor-hint"]');
+    expect(hint.exists()).toBe(true);
+    expect(hint.text()).toContain('$9.00'); // 20% of 45
+    // The provider figure is shown (claim held) but not editable.
+    expect(wrapper.find('[data-testid="edit-provider-display"]').exists()).toBe(true);
+    expect(wrapper.find('input[data-testid="edit-provider-input"]').exists()).toBe(false);
+  });
+
+  it('MGR save: PUT omits duration (stored value kept) and providerAmount (server-derived)', async () => {
+    const wrapper = await openFinancialEdit('MGR');
+    const vm = wrapper.vm as unknown as {
+      financialForm: { amount: number; discount: number };
+      saveFinancials: () => Promise<void>;
+    };
+
+    vm.financialForm.discount = 15;
+    await vm.saveFinancials();
+
+    expect(updateSessionMock).toHaveBeenCalledTimes(1);
+    const [id, payload] = updateSessionMock.mock.calls[0] as [number, Record<string, unknown>];
+    expect(id).toBe(77);
+    expect(payload.discount).toBe(15);
+    expect(payload).not.toHaveProperty('duration');
+    expect(payload).not.toHaveProperty('providerAmount');
+  });
+
+  it('no active SENADIS (unflagged patient): no floor hint for the editable discount', async () => {
+    const wrapper = await openFinancialEdit('MGR', appointmentFixture({ patientId: UNFLAGGED_ID, discount: 0 }));
+
+    expect(wrapper.find('[data-testid="edit-discount-input"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="edit-senadis-floor-hint"]').exists()).toBe(false);
+  });
+});

--- a/app-ui/src/components/appointments/ActionsPanel.vue
+++ b/app-ui/src/components/appointments/ActionsPanel.vue
@@ -116,16 +116,37 @@
               <div class="grid grid-cols-3 gap-2">
                 <div>
                   <label class="block text-xs font-medium text-slate-600 mb-1">Amount</label>
-                  <input v-model.number="financialForm.amount" type="number" min="0" step="0.01" class="w-full rounded-lg border border-slate-300 px-2 py-1.5 text-sm" />
+                  <input v-model.number="financialForm.amount" type="number" min="0" step="0.01" data-testid="edit-amount-input" class="w-full rounded-lg border border-slate-300 px-2 py-1.5 text-sm" />
                 </div>
                 <div>
                   <label class="block text-xs font-medium text-slate-600 mb-1">Discount</label>
-                  <input v-model.number="financialForm.discount" type="number" min="0" step="0.01" class="w-full rounded-lg border border-slate-300 px-2 py-1.5 text-sm" />
+                  <!-- WP-40 (BK-3): editing the discount is gated on Sessions.Discount.Edit
+                       (AM/MGR) — the API 403s a changed discount without it. -->
+                  <input
+                    v-if="canEditDiscount"
+                    v-model.number="financialForm.discount"
+                    type="number" :min="editSenadisFloor" step="0.01"
+                    data-testid="edit-discount-input"
+                    class="w-full rounded-lg border border-slate-300 px-2 py-1.5 text-sm"
+                  />
+                  <p v-else data-testid="edit-discount-readonly" class="w-full rounded-lg border border-slate-200 bg-slate-100 px-2 py-1.5 text-sm text-slate-500">
+                    ${{ financialForm.discount.toFixed(2) }}
+                  </p>
+                  <p v-if="canEditDiscount && editSenadisActive" data-testid="edit-senadis-floor-hint" class="mt-1 text-[11px] text-violet-600">
+                    SENADIS floor: min ${{ editSenadisFloor.toFixed(2) }} (20%) — may go up, never below.
+                  </p>
+                  <p v-else-if="!canEditDiscount" class="mt-1 text-[11px] text-slate-400">
+                    Discount edits need a Manager / Assistant Manager.
+                  </p>
                 </div>
-                <!-- WP-17C: cosmetic only — the API still returns ProviderAmount to anyone with Appointments.View; true field-level enforcement needs API response-shaping (deferred). -->
+                <!-- WP-40: the manual Provider input is gone — the API derives the fee from the
+                     therapist's model and recomputes whenever amount/discount change. -->
                 <div v-if="hasClaim('Permission', Permissions.AppointmentsProviderAmount)">
                   <label class="block text-xs font-medium text-slate-600 mb-1">Provider</label>
-                  <input v-model.number="financialForm.providerAmount" type="number" min="0" step="0.01" class="w-full rounded-lg border border-slate-300 px-2 py-1.5 text-sm" />
+                  <p data-testid="edit-provider-display" class="w-full rounded-lg border border-slate-200 bg-slate-100 px-2 py-1.5 text-sm text-slate-500">
+                    ${{ (appointment.providerAmount ?? 0).toFixed(2) }}
+                  </p>
+                  <p class="mt-1 text-[11px] text-slate-400">Recomputed on save.</p>
                 </div>
               </div>
               <div class="flex items-center space-x-2">
@@ -311,8 +332,10 @@ import { useRouter } from 'vue-router';
 import StatusBadge from './StatusBadge.vue';
 import AuditPopover from '../shared/AuditPopover.vue';
 import { SessionsHttpClient } from '../../services/SessionsHttpClient';
+import { PatientsHttpClient } from '../../services/PatientsHttpClient';
 import type { Appointment } from '../../interfaces/Appointment';
 import { useClaims, Permissions } from '../../composables/useClaims';
+import { isSenadisExpired } from '../../utils/senadis';
 
 const TERMINAL_STATUSES = [3, 4, 5]; // Cancelled, Completed, NoShow
 
@@ -334,7 +357,16 @@ export default defineComponent({
     const confirmForm = ref({ method: 'Phone', result: '', notes: '' });
     const correctionConfirmed = ref(false);
     const editingFinancials = ref(false);
-    const financialForm = ref({ amount: 0, discount: 0, providerAmount: 0 });
+    // WP-40: no providerAmount here — the fee is server-derived, never hand-entered.
+    const financialForm = ref({ amount: 0, discount: 0 });
+    const patientsClient = new PatientsHttpClient();
+    // WP-40 (BK-3): whether the session's patient has SENADIS active AT THE SESSION DATE —
+    // drives the floor hint (the API enforces the floor regardless).
+    const editSenadisActive = ref(false);
+    const canEditDiscount = computed(() => hasClaim('Permission', Permissions.SessionsDiscountEdit));
+    const editSenadisFloor = computed(() =>
+      editSenadisActive.value ? Math.round(0.20 * financialForm.value.amount * 100) / 100 : 0
+    );
 
     const isTerminalStatus = computed(() => {
       const id = props.appointment?.appointmentStatusId;
@@ -386,14 +418,22 @@ export default defineComponent({
       return actions.filter(a => a.statusId !== currentId);
     });
 
-    const startEditFinancials = () => {
+    const startEditFinancials = async () => {
       if (!props.appointment) return;
       financialForm.value = {
         amount: props.appointment.amount,
         discount: props.appointment.discount,
-        providerAmount: 0, // Not in the Appointment response — user can set
       };
       editingFinancials.value = true;
+      // WP-40 (BK-3): floor hint — active SENADIS (expiry-aware, at the SESSION date).
+      editSenadisActive.value = false;
+      try {
+        const patient = await patientsClient.getPatient(props.appointment.patientId);
+        editSenadisActive.value = patient.hasSenadisDiscount === true
+          && !isSenadisExpired(patient.senadisExpirationDate ?? null, props.appointment.sessionDate);
+      } catch {
+        // Hint only — the API enforces the floor server-side regardless
+      }
     };
 
     const saveFinancials = async () => {
@@ -401,14 +441,15 @@ export default defineComponent({
       actionInProgress.value = true;
       actionError.value = '';
       try {
+        // WP-40: duration is OMITTED (the read model doesn't carry it — the API keeps the
+        // stored value; the old hardcoded 60 silently overwrote legacy durations) and
+        // providerAmount is no longer sent (server-derived, recomputed on money change).
         await client.updateSession(props.appointment.sessionId, {
           sessionTime: props.appointment.sessionTime + (props.appointment.sessionTime.length === 5 ? ':00' : ''),
           therapyType: props.appointment.therapyTypes || 'N/A',
-          duration: 60,
           amount: financialForm.value.amount,
           amountPaid: props.appointment.amountPaid,
           discount: financialForm.value.discount,
-          providerAmount: financialForm.value.providerAmount,
           isPaidOff: props.appointment.isPaidOff,
           notes: props.appointment.notes,
           appointmentStatusId: props.appointment.appointmentStatusId,
@@ -492,6 +533,7 @@ export default defineComponent({
     return {
       confirmForm, cancelReason, actionInProgress, actionError,
       correctionConfirmed, editingFinancials, financialForm, isTerminalStatus,
+      canEditDiscount, editSenadisActive, editSenadisFloor,
       showConfirmSection, showCancelSection, availableActions,
       isCompletedDiscovery, createPlanFromDiscovery, viewPatientPlans,
       startEditFinancials, saveFinancials,

--- a/app-ui/src/components/appointments/BookingFormModal.vue
+++ b/app-ui/src/components/appointments/BookingFormModal.vue
@@ -81,31 +81,68 @@
             </div>
             <div>
               <label class="block text-sm font-medium text-slate-700 mb-1">Duration (min)</label>
-              <input v-model.number="form.duration" type="number" min="15" step="15" class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:ring-2 focus:ring-violet-500 focus:border-violet-500" />
+              <!-- WP-40 (BK-1): fixed bookable durations — the API 400s anything else. -->
+              <select v-model.number="form.duration" data-testid="duration-select" class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:ring-2 focus:ring-violet-500 focus:border-violet-500">
+                <option v-for="d in bookableDurations" :key="d" :value="d">{{ d }}</option>
+              </select>
             </div>
           </div>
 
-          <!-- Amount & Discount -->
+          <!-- WP-40 (BK-2): money is DERIVED, read-only — Amount from the WP-39 price sheet
+               (duration row → default), Discount from SENADIS applicability, ProviderAmt from
+               the therapist's fee model. The API re-derives authoritatively at booking. -->
           <div class="grid grid-cols-3 gap-3">
             <div>
               <label class="block text-sm font-medium text-slate-700 mb-1">Amount</label>
-              <input v-model.number="form.amount" type="number" min="0" step="0.01" class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:ring-2 focus:ring-violet-500 focus:border-violet-500" />
+              <p data-testid="derived-amount" class="w-full rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-800">
+                {{ derivedAmount != null ? '$' + derivedAmount.toFixed(2) : '—' }}
+              </p>
             </div>
             <div>
               <label class="block text-sm font-medium text-slate-700 mb-1">Discount</label>
-              <!-- WP-23 (F7): min rides the SENADIS floor; the clamp re-applies on amount/patient change and at submit.
-                   WP-37 (SEN-1/G2): floor/min/hint only while the SENADIS is active for the chosen
-                   session date — expired ⇒ no floor at all, amber badge explains why (G3). -->
-              <input v-model.number="form.discount" type="number" :min="senadisFloor" step="0.01" class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:ring-2 focus:ring-violet-500 focus:border-violet-500" />
-              <p v-if="senadisActive" class="mt-1 text-xs text-violet-600">SENADIS: min {{ senadisFloor.toFixed(2) }} (20%)</p>
-              <p v-else-if="senadisExpired" data-testid="senadis-expired-badge" class="mt-1 text-xs font-medium text-amber-600">
-                SENADIS expired {{ formatSenadisExpiry(senadisExpiry) }} — no discount floor for this session date.
+              <p data-testid="derived-discount" class="w-full rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-800">
+                ${{ derivedDiscount.toFixed(2) }}
               </p>
             </div>
-            <!-- WP-17C: cosmetic only — the API still returns ProviderAmount to anyone with Appointments.View; true field-level enforcement needs API response-shaping (deferred). -->
+            <!-- WP-17C: cosmetic only — true field-level enforcement is the API's ProviderAmount response-shaping. -->
             <div v-if="hasClaim('Permission', Permissions.AppointmentsProviderAmount)">
               <label class="block text-sm font-medium text-slate-700 mb-1">Provider Amt</label>
-              <input v-model.number="form.providerAmount" type="number" min="0" step="0.01" class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:ring-2 focus:ring-violet-500 focus:border-violet-500" />
+              <p data-testid="derived-provider-amount" class="w-full rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-800">
+                ${{ derivedProviderAmount.toFixed(2) }}
+              </p>
+            </div>
+          </div>
+
+          <!-- WP-40 money signals -->
+          <div class="space-y-1">
+            <p v-if="missingPrice" data-testid="missing-price-block" class="text-xs font-medium text-red-600">
+              No price configured for {{ selectedSpecialty?.name }} at {{ form.duration }} min — ask a manager to set it in Admin.
+            </p>
+            <p v-else-if="amountSource === 'defaultAmount'" data-testid="default-amount-badge" class="text-xs font-medium text-amber-600">
+              No pricing configured for this specialty/duration — using the default amount.
+            </p>
+            <p v-if="senadisActive" data-testid="senadis-applied-badge" class="text-xs text-violet-600">
+              SENADIS 20% applied ({{ derivedDiscount.toFixed(2) }})
+            </p>
+            <p v-else-if="senadisExpired" data-testid="senadis-expired-badge" class="text-xs font-medium text-amber-600">
+              SENADIS expired {{ formatSenadisExpiry(senadisExpiry) }} — no discount for this session date.
+            </p>
+          </div>
+
+          <!-- WP-40 on-site leg (dormant until OfferedOnSite flags flip) -->
+          <div v-if="selectedSpecialty?.offeredOnSite" class="rounded-lg border border-slate-200 p-3 space-y-2">
+            <label class="flex items-center gap-2 text-sm text-slate-700">
+              <input v-model="onSiteVisit" type="checkbox" data-testid="onsite-checkbox" class="rounded border-slate-300 text-violet-600 focus:ring-violet-500" />
+              On-site visit (domiciliar)
+            </label>
+            <div v-if="onSiteVisit" class="space-y-1">
+              <select v-model.number="onSiteSiteId" data-testid="onsite-site-select" class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm">
+                <option :value="0" disabled>Select site...</option>
+                <option v-for="s in sites" :key="s.siteId" :value="s.siteId">{{ s.siteName }}</option>
+              </select>
+              <p v-if="onSiteSiteId > 0" data-testid="onsite-charge-line" class="text-xs text-slate-600">
+                On-site visit charge: ${{ onSiteTripCharge.toFixed(2) }}
+              </p>
             </div>
           </div>
 
@@ -152,15 +189,20 @@ import { SessionsHttpClient } from '../../services/SessionsHttpClient';
 import { PatientsHttpClient } from '../../services/PatientsHttpClient';
 import { TherapistsHttpClient } from '../../services/TherapistsHttpClient';
 import { LookupHttpClient } from '../../services/LookupHttpClient';
+import { SitesHttpClient } from '../../services/SitesHttpClient';
 import type { SessionEventRequest } from '../../interfaces/Appointment';
 import type { Therapist } from '../../interfaces/Therapist';
 import type { LookupItem } from '../../interfaces/Lookups';
+import type { Site } from '../../interfaces/Site';
 import { isDiscoverySpecialty } from '../../interfaces/TreatmentPlan';
 import { TIME_MIN, TIME_MAX, TIME_STEP } from '../../utils/timeSlots';
 import { useClaims, Permissions } from '../../composables/useClaims';
 import { isSenadisExpired, formatSenadisExpiry } from '../../utils/senadis';
-import { useNotificationsStore } from '../../stores/notifications';
 import LookupSelect, { type LookupOption } from '../shared/LookupSelect.vue';
+
+// WP-40 (BK-1): the fixed bookable duration set — mirrors the API's validation
+// ({30,40,45,60,90,120}; 40 added by the 2026-07-27 addendum for interview services).
+export const BOOKABLE_DURATIONS = [30, 40, 45, 60, 90, 120];
 
 export default defineComponent({
   name: 'BookingFormModal',
@@ -177,6 +219,7 @@ export default defineComponent({
     const patientsClient = new PatientsHttpClient();
     const therapistsClient = new TherapistsHttpClient();
     const lookupClient = new LookupHttpClient();
+    const sitesClient = new SitesHttpClient();
 
     // WP-30: the patient picker is a lookup typeahead; the selection drives form.patientId.
     const selectedPatient = ref<LookupOption | null>(null);
@@ -189,11 +232,15 @@ export default defineComponent({
     const senadisPatient = ref(false);
     // WP-37 (SEN-1): the flagged patient's expiry as sent by the API ("...T00:00:00" | null).
     const senadisExpiry = ref<string | null>(null);
-    const notifications = useNotificationsStore();
+    // WP-40 on-site leg (dormant while all OfferedOnSite flags are 0).
+    const onSiteVisit = ref(false);
+    const onSiteSiteId = ref(0);
+    const sites = ref<Site[]>([]);
 
     const today = new Date().toISOString().split('T')[0];
     const nowTime = new Date().toTimeString().slice(0, 5);
 
+    // WP-40 (BK-2): no money fields in the form — Amount/Discount/ProviderAmt are derived.
     const form = ref({
       patientId: 0,
       therapistId: 0,
@@ -201,9 +248,6 @@ export default defineComponent({
       sessionTime: nowTime,
       specialtyTypeId: 0,
       duration: 60,
-      amount: 0,
-      discount: 0,
-      providerAmount: 0,
       notes: '',
     });
 
@@ -254,24 +298,24 @@ export default defineComponent({
       }
     });
 
-    watch(() => form.value.specialtyTypeId, (id) => {
+    const selectedSpecialty = computed<LookupItem | null>(() =>
+      specialtyTypes.value.find(s => s.id === form.value.specialtyTypeId) ?? null
+    );
+
+    watch(() => form.value.specialtyTypeId, () => {
       if (form.value.therapistId > 0 && !filteredTherapists.value.some(t => t.therapistId === form.value.therapistId)) {
         form.value.therapistId = 0;
       }
-      // WP-23 (F6): pre-fill Amount from the specialty's default price — refills on every
-      // specialty change (user-editable after; NULL default = leave the amount alone).
-      if (id > 0) {
-        const specialty = specialtyTypes.value.find(s => s.id === id);
-        if (specialty?.defaultAmount != null) {
-          form.value.amount = specialty.defaultAmount;
-        }
+      // WP-40: the on-site choice only survives while the specialty offers it.
+      if (!selectedSpecialty.value?.offeredOnSite) {
+        onSiteVisit.value = false;
+        onSiteSiteId.value = 0;
       }
     });
 
-    // WP-37 (SEN-1/G2): the floor applies only while the SENADIS is active for the SESSION DATE
-    // being booked — no expiry (null) = always active; boundary (session date == expiry) still
-    // floors; expired ⇒ no floor/min/clamp and the badge explains why. Re-evaluates when the
-    // user changes the booking date. The flag itself is never auto-cleared (G3).
+    // WP-37 (SEN-1/G2): SENADIS applies only while active for the SESSION DATE being booked —
+    // no expiry (null) = always active; boundary (session date == expiry) still applies;
+    // expired ⇒ no discount and the badge explains why. The flag is never auto-cleared (G3).
     const senadisActive = computed(
       () => senadisPatient.value && !isSenadisExpired(senadisExpiry.value, form.value.sessionDate)
     );
@@ -279,23 +323,66 @@ export default defineComponent({
       () => senadisPatient.value && isSenadisExpired(senadisExpiry.value, form.value.sessionDate)
     );
 
-    // WP-23 (F7): statutory SENADIS floor — 20% of Amount, 2dp; 0 for unflagged patients
-    // (and, as of WP-37, for flagged-but-expired ones).
-    const senadisFloor = computed(() =>
-      senadisActive.value ? Math.round(0.20 * form.value.amount * 100) / 100 : 0
+    // WP-40 (BK-2): client-side mirror of the WP-39 price resolution — duration row →
+    // defaultAmount → none. UX preview only; the API re-derives authoritatively at the
+    // session date (the lookup projection is current-effective as of today).
+    const priceRow = computed(() =>
+      (selectedSpecialty.value?.durationPrices ?? []).find(p => p.durationMinutes === form.value.duration) ?? null
+    );
+    const amountSource = computed<'durationPrice' | 'defaultAmount' | 'none'>(() => {
+      if (!selectedSpecialty.value) return 'none';
+      if (priceRow.value) return 'durationPrice';
+      if (selectedSpecialty.value.defaultAmount != null) return 'defaultAmount';
+      return 'none';
+    });
+    const derivedAmount = computed<number | null>(() =>
+      priceRow.value?.amount ?? selectedSpecialty.value?.defaultAmount ?? null
+    );
+    // G4: a selected specialty with no resolvable price blocks the booking.
+    const missingPrice = computed(() =>
+      form.value.specialtyTypeId > 0 && amountSource.value === 'none'
     );
 
-    const applySenadisFloor = () => {
-      if (senadisActive.value && form.value.discount < senadisFloor.value) {
-        form.value.discount = senadisFloor.value;
+    // G2 ruling: derived discount — exactly 20% when SENADIS is active, else exactly 0.
+    const derivedDiscount = computed(() =>
+      senadisActive.value && derivedAmount.value != null
+        ? Math.round(0.20 * derivedAmount.value * 100) / 100
+        : 0
+    );
+
+    // Fee preview from the selected therapist's model (flat when pct = 0, else % of net).
+    // Display-gated behind Appointments.ProviderAmount; the API recomputes regardless.
+    const derivedProviderAmount = computed(() => {
+      const t = therapists.value.find(x => x.therapistId === form.value.therapistId);
+      if (!t || derivedAmount.value == null) return 0;
+      const net = derivedAmount.value - derivedDiscount.value;
+      const fee = t.feePctPerSession === 0 ? t.feePerSession : net * t.feePctPerSession;
+      return Math.round(fee * 100) / 100;
+    });
+
+    const onSiteTripCharge = computed(() =>
+      sites.value.find(s => s.siteId === onSiteSiteId.value)?.onSiteTripChargeAmount ?? 0
+    );
+
+    // Lazy: sites are only needed once the (dormant) on-site checkbox is first used.
+    watch(onSiteVisit, async (checked) => {
+      if (checked && sites.value.length === 0) {
+        try {
+          sites.value = await sitesClient.getSites();
+        } catch {
+          // Non-fatal — the select stays empty and submit stays blocked
+        }
       }
-    };
+    });
 
     // WP-23 (F10): the caretaker check is now a hard block (was a soft warning) — the API
     // enforces the same rule with a 400, this keeps the modal honest before submit.
+    // WP-40: missing price (G4) also blocks; an on-site visit needs a site.
     const isValid = computed(() => {
       return form.value.patientId > 0 && form.value.therapistId > 0 && form.value.specialtyTypeId > 0
-        && !caretakerWarning.value;
+        && !caretakerWarning.value
+        && !missingPrice.value
+        && (!onSiteVisit.value || onSiteSiteId.value > 0);
     });
 
     const loadDropdowns = async () => {
@@ -362,23 +449,16 @@ export default defineComponent({
         // (a flagged-but-expired patient gets the badge instead — no floor).
         senadisPatient.value = patient.hasSenadisDiscount === true;
         senadisExpiry.value = patient.senadisExpirationDate ?? null;
-        if (senadisActive.value) {
-          notifications.info('SENADIS: statutory 20% discount applied — it cannot be reduced.');
-          applySenadisFloor();
-        }
+        // WP-40: no toast/clamp — the discount is a derived read-only display and the
+        // "SENADIS 20% applied" badge explains it in place.
       } catch {
         needsDiscovery.value = false; // Fail open — don't block booking
-        senadisPatient.value = false; // (the API floors server-side regardless)
+        senadisPatient.value = false; // (the API derives server-side regardless)
         senadisExpiry.value = null;
       }
     };
 
     watch(() => form.value.patientId, (id) => { checkCaretaker(id); checkDiscovery(id); });
-    // WP-23 (F7): re-clamp when the amount moves the floor.
-    watch(() => form.value.amount, applySenadisFloor);
-    // WP-37 (G2): re-clamp when the session date crosses back on/before the expiry (the floor
-    // computed lifts on its own when the date crosses past it — an existing discount is kept).
-    watch(() => form.value.sessionDate, applySenadisFloor);
     watch(form, () => { saveError.value = ''; }, { deep: true });
 
     watch(() => props.visible, (val) => {
@@ -392,6 +472,8 @@ export default defineComponent({
         if (props.preSelectPatientId > 0) {
           loadPreselectedPatient(props.preSelectPatientId);
         }
+        onSiteVisit.value = false;
+        onSiteSiteId.value = 0;
         form.value = {
           patientId: props.preSelectPatientId || 0,
           therapistId: 0,
@@ -399,9 +481,6 @@ export default defineComponent({
           sessionTime: props.isWalkIn ? nowTime : '09:00',
           specialtyTypeId: 0,
           duration: 60,
-          amount: 0,
-          discount: 0,
-          providerAmount: 0,
           notes: props.isWalkIn ? 'Walk-in patient' : '',
         };
       }
@@ -410,8 +489,9 @@ export default defineComponent({
     const handleSubmit = async () => {
       saving.value = true;
       saveError.value = '';
-      applySenadisFloor(); // WP-23 (F7): last-line clamp; the API floors server-side too
       try {
+        // WP-40: the money values sent are the derived preview — the API ignores them and
+        // re-derives from the price sheet + SENADIS rule + fee model (contract note).
         const request: SessionEventRequest = {
           sessionDate: form.value.sessionDate,
           sessionTime: form.value.sessionTime + ':00',
@@ -419,13 +499,15 @@ export default defineComponent({
           therapistId: form.value.therapistId,
           therapyType: 'N/A', // backward compat — API resolves from specialtyTypeId
           duration: form.value.duration,
-          amount: form.value.amount,
-          discount: form.value.discount,
-          providerAmount: form.value.providerAmount,
+          amount: derivedAmount.value ?? 0,
+          discount: derivedDiscount.value,
+          providerAmount: derivedProviderAmount.value,
           isPaidOff: false,
           notes: form.value.notes,
           appointmentStatusId: props.isWalkIn ? 6 : 1, // CheckedIn for walk-in, Proposed for booking
           specialtyTypeId: form.value.specialtyTypeId,
+          isOnSiteVisit: onSiteVisit.value,
+          siteId: onSiteVisit.value ? onSiteSiteId.value : undefined,
         };
         await sessionsClient.createSession(request);
         emit('saved');
@@ -437,7 +519,7 @@ export default defineComponent({
       }
     };
 
-    return { form, selectedPatient, fetchPatientOptions, filteredTherapists, filteredSpecialties, saving, saveError, caretakerWarning, needsDiscovery, senadisPatient, senadisExpiry, senadisActive, senadisExpired, senadisFloor, formatSenadisExpiry, isValid, handleSubmit, timeMin: TIME_MIN, timeMax: TIME_MAX, timeStep: TIME_STEP, hasClaim, Permissions };
+    return { form, selectedPatient, fetchPatientOptions, filteredTherapists, filteredSpecialties, saving, saveError, caretakerWarning, needsDiscovery, senadisPatient, senadisExpiry, senadisActive, senadisExpired, formatSenadisExpiry, isValid, handleSubmit, timeMin: TIME_MIN, timeMax: TIME_MAX, timeStep: TIME_STEP, hasClaim, Permissions, bookableDurations: BOOKABLE_DURATIONS, selectedSpecialty, derivedAmount, derivedDiscount, derivedProviderAmount, amountSource, missingPrice, onSiteVisit, onSiteSiteId, sites, onSiteTripCharge };
   },
 });
 </script>

--- a/app-ui/src/components/appointments/TherapistReassignModal.vue
+++ b/app-ui/src/components/appointments/TherapistReassignModal.vue
@@ -123,15 +123,15 @@ export default defineComponent({
       saving.value = true;
       errorMsg.value = '';
       try {
+        // WP-40: duration OMITTED (keeps the stored value — the old hardcoded 60 silently
+        // overwrote legacy durations); providerAmount no longer sent (server-derived).
         await sessionsClient.updateSession(props.session.sessionId, {
           therapistId: selectedTherapistId.value,
           sessionTime: props.session.sessionTime,
           therapyType: props.session.therapyTypes || 'N/A',
-          duration: 60,
           amount: props.session.amount,
           amountPaid: props.session.amountPaid,
           discount: props.session.discount,
-          providerAmount: props.session.providerAmount,
           isPaidOff: props.session.isPaidOff,
           notes: props.session.notes || '',
           appointmentStatusId: props.session.appointmentStatusId,

--- a/app-ui/src/generated/access-control-matrix.json
+++ b/app-ui/src/generated/access-control-matrix.json
@@ -1,9 +1,9 @@
 {
   "_meta": {
-    "generatedAt": "2026-07-19T12:14:28-05:00",
+    "generatedAt": "2026-07-27T14:46:20-05:00",
     "generator": "tools/generate-access-manifest.sh",
     "hashScope": "sha256 (first 12 hex) of canonical JSON {claims:[{claim,grants}]}, claims+grants sorted; wildcard/restricted cells and all metadata excluded",
-    "semanticHash": "57b6150a350c",
+    "semanticHash": "f82cab8c9efd",
     "source": "access-control-matrix.md"
   },
   "claims": [
@@ -314,6 +314,13 @@
         "AM",
         "MGR",
         "OWN"
+      ]
+    },
+    {
+      "claim": "Sessions.Discount.Edit",
+      "grants": [
+        "AM",
+        "MGR"
       ]
     },
     {

--- a/app-ui/src/generated/permissions.ts
+++ b/app-ui/src/generated/permissions.ts
@@ -8,7 +8,7 @@
 //   app-ui/src/generated/access-control-matrix.json, then re-run
 //   tools/generate-ui-permissions.sh.
 //
-//   Access-control manifest semantic hash: 57b6150a350c
+//   Access-control manifest semantic hash: f82cab8c9efd
 // </auto-generated>
 
 /**
@@ -62,6 +62,7 @@ export const Permissions = {
   ServicePaymentsAdjust: 'ServicePayments.Adjust',
   ServicePaymentsRecord: 'ServicePayments.Record',
   ServicePaymentsView: 'ServicePayments.View',
+  SessionsDiscountEdit: 'Sessions.Discount.Edit',
   SpecialtiesPricesEdit: 'Specialties.Prices.Edit',
   StatementsCaretakerView: 'Statements.Caretaker.View',
   StatementsTherapistView: 'Statements.Therapist.View',
@@ -80,4 +81,4 @@ export const Permissions = {
 export type Permission = (typeof Permissions)[keyof typeof Permissions];
 
 /** Access-control manifest semantic hash this module was generated from (WP-17 anchor). */
-export const ACCESS_CONTROL_MANIFEST_HASH = '57b6150a350c';
+export const ACCESS_CONTROL_MANIFEST_HASH = 'f82cab8c9efd';

--- a/app-ui/src/interfaces/Appointment.ts
+++ b/app-ui/src/interfaces/Appointment.ts
@@ -35,6 +35,11 @@ export interface Appointment {
     // WP-17: confidential (matrix grants Appointments.ProviderAmount to MGR/AM only). The API omits
     // this field from the response for callers lacking the claim (e.g. FrontDesk), so it is optional.
     providerAmount?: number;
+    // WP-40: the Site's trip charge snapshotted at booking; null/absent = in-clinic session.
+    onSiteChargeAmount?: number | null;
+    // WP-40: where the server derived the amount from — "durationPrice" | "defaultAmount";
+    // set on the create response only (null on list/read paths).
+    amountSource?: string | null;
     // WP-31 (U1): audit block for the Session Details ⓘ popover. Optional — tolerates an older API.
     audit?: AuditInfo;
 }
@@ -46,6 +51,8 @@ export interface SessionEventRequest {
     therapistId: number;
     therapyType: string;
     duration: number;
+    // WP-40: amount/discount/providerAmount are SERVER-DERIVED — the values sent here are
+    // advisory previews the API ignores (price sheet + SENADIS rule + fee model rule).
     amount: number;
     discount: number;
     providerAmount: number;
@@ -54,6 +61,28 @@ export interface SessionEventRequest {
     appointmentStatusId: number;
     siteId?: number;
     specialtyTypeId?: number;
+    // WP-40 on-site leg: valid only for offeredOnSite specialties; requires siteId.
+    isOnSiteVisit?: boolean;
+}
+
+// WP-40: typed PUT /api/sessions/{id} body (previously Record<string, unknown>).
+export interface SessionEventUpdateRequest {
+    sessionTime: string;
+    therapyType: string;
+    // WP-40: OMIT to keep the stored duration — the session read model doesn't carry it, and
+    // the old hardcoded 60 silently overwrote legacy durations. Only send a value when the
+    // user deliberately changes it (validated server-side against {30,40,45,60,90,120}).
+    duration?: number;
+    amount: number;
+    amountPaid: number;
+    // Changing discount requires the Sessions.Discount.Edit claim (403 otherwise, BK-3).
+    discount: number;
+    isPaidOff: boolean;
+    notes: string;
+    appointmentStatusId?: number;
+    therapistId?: number;
+    siteId?: number | null;
+    specialtyTypeId?: number | null;
 }
 
 export interface ConfirmationRequest {

--- a/app-ui/src/services/SessionsHttpClient.ts
+++ b/app-ui/src/services/SessionsHttpClient.ts
@@ -1,6 +1,6 @@
 // services/SessionsHttpClient.ts
 import { HttpClientBase } from './HttpClientBase';
-import type { Appointment, SessionEventRequest, ConfirmationRequest, ConfirmationRecord } from '../interfaces/Appointment';
+import type { Appointment, SessionEventRequest, SessionEventUpdateRequest, ConfirmationRequest, ConfirmationRecord } from '../interfaces/Appointment';
 import type { LookupItem } from '../interfaces/Lookups';
 import type { DiscoverySessionSummary } from '../interfaces/TreatmentPlan';
 import type { ScheduleMatrixResponse } from '../interfaces/ScheduleMatrix';
@@ -20,7 +20,7 @@ export class SessionsHttpClient extends HttpClientBase {
     return this.post<Appointment>('/api/Sessions', data);
   }
 
-  async updateSession(id: number, data: Record<string, unknown>): Promise<void> {
+  async updateSession(id: number, data: SessionEventUpdateRequest): Promise<void> {
     return this.put(`/api/Sessions/${id}`, data);
   }
 

--- a/app-ui/test-scenarios/wp-40-booking-auto-money.md
+++ b/app-ui/test-scenarios/wp-40-booking-auto-money.md
@@ -1,0 +1,80 @@
+# WP-40C Test Scenarios — Booking Auto-Money (BK-1/BK-2/BK-3)
+
+User-facing walkthrough for the auto-money booking flow. Run against the deployed stack
+**after** the WP-40 deploy (API first, then UI; RoleClaim reseed + re-login done — matrix
+hash `f82cab8c9efd`).
+
+## 1. FD books touching ZERO money fields (BK-1 + BK-2)
+
+1. Log in as **Front Desk** → Appointments → Book Appointment.
+2. **Duration is now a dropdown**: exactly 30 / 40 / 45 / 60 / 90 / 120 (default 60) — no
+   free typing.
+3. Pick a non-SENADIS patient, a specialty with a price row (e.g. TC), a therapist, 60 min.
+   - **Amount** shows as a read-only derived figure (the price-sheet row for TC @ 60) —
+     there is no amount input anywhere.
+   - **Discount** shows **$0.00**, read-only.
+   - FD sees **no Provider Amt** at all (claim-gated).
+4. Change duration 60 → 30: the Amount display re-derives to the 30-min price instantly.
+5. Book. Open the session — Amount/Discount match what the form previewed (the server
+   derived them authoritatively).
+
+## 2. SENADIS + non-SENADIS patient (exact-20% rule)
+
+1. Book for a patient with **active SENADIS** (unexpired): Discount shows exactly
+   **20% of the derived Amount** with the badge **"SENADIS 20% applied"**. No toast anymore.
+2. Same patient, session date **after** their SENADIS expiry: badge flips to
+   "SENADIS expired {date}…" and Discount derives to $0.00.
+3. Non-SENADIS patient: Discount is always $0.00 at booking. (Ad-hoc discounts now happen
+   post-booking — scenario 5.)
+
+## 3. Fallback + missing-price paths (G4 / badge)
+
+1. Pick **NM, EEG, EEG/REP, or PSICOT** (provisional default-priced): the amber badge
+   "No pricing configured for this specialty/duration — using the default amount." shows and
+   the booking proceeds at the DefaultAmount.
+2. Pick **Eval-Neuro** (deliberately unpriced): red message
+   **"No price configured for Eval-Neuro at {duration} min — ask a manager to set it in
+   Admin."** and the Book button stays disabled. This is correct behavior, not a bug.
+3. Pick **Ent-TC @ 40 min**: books at the real 40-minute price ($35) — no badge.
+
+## 4. Provider amount preview (MGR/AM only)
+
+1. As **Manager**: the Provider Amt read-only display shows the therapist's fee — flat-fee
+   therapist → the flat figure regardless of discount; %-therapist → % of (Amount − Discount).
+   Switching therapist updates it. There is **no provider input** anymore (the server always
+   derives it).
+
+## 5. BK-3 — post-booking discount edit (gated)
+
+1. As **Front Desk**: open a booked session → Session Details → Financial → Edit.
+   - Discount shows **read-only** with the note "Discount edits need a Manager / Assistant
+     Manager." Amount stays editable; Provider is display-only ("Recomputed on save").
+   - Saving with other changes works (the unchanged discount passes the API gate).
+2. As **Manager (or AM)** after re-login: same edit surface — Discount **is editable**.
+   - For an active-SENADIS session the hint shows "SENADIS floor: min $X (20%) — may go up,
+     never below." Try saving below the floor → the API rejects (400).
+   - Raise the discount above the floor → saves; re-open: **Provider/Due recomputed** (a
+     %-fee therapist's provider drops when the discount rises).
+3. Verify a MGR editing a **legacy odd-duration session** (e.g. 50 min) and saving a
+   discount change does NOT alter its duration (the PUT omits duration now).
+
+## 6. On-site visit (DORMANT — will only appear once a specialty's OfferedOnSite is flipped)
+
+1. Today: no specialty shows the "On-site visit (domiciliar)" checkbox (all flags off) —
+   confirm it's absent.
+2. (Post-flip smoke) With an offeredOnSite specialty: checkbox appears → checking it requires
+   choosing a site and shows **"On-site visit charge: $X"** as its own line (never folded into
+   Amount). The booked session's Due includes the charge; a %-therapist's provider amount is
+   unchanged by it.
+
+## 7. Regression sweep
+
+- Walk-in booking still works (same modal) — money derived the same way.
+- Discovery-first filtering, caretaker hard-block, double-booking 409: unchanged.
+- Therapist reassignment on a legacy session no longer resets its duration to 60.
+- Bulk scheduling from a treatment plan books at price-sheet amounts (not $65/h) and derives
+  SENADIS discounts per session date; a plan line with an unpriced specialty reports a
+  conflict and nothing books.
+
+**Suite:** `npx vue-tsc --noEmit && npm run lint && npx vitest run` → **307 passed**
+(baseline 294; wp40 spec added, wp23/wp37 booking specs rewritten to derived semantics).


### PR DESCRIPTION
…60,90,120}, derived read-only money, gated discount edit

- BookingFormModal: duration dropdown; Amount/Discount/ProviderAmt become derived read-only displays (price-sheet row → defaultAmount badge → G4 missing-price block; exact-20% SENADIS badge replaces the toast/clamp; fee preview from the therapist model, claim-gated); on-site checkbox + site select + trip-charge line (dormant — appears when OfferedOnSite flips); submit sends the derived preview (API re-derives authoritatively).
- ActionsPanel: Discount editable only with Sessions.Discount.Edit (AM/MGR, hash f82cab8c9efd re-vendored + permissions.ts regen), SENADIS floor hint; manual Provider input deleted (display-only, recomputed on save); PUT now OMITS duration + providerAmount — kills the hardcoded-60 overwrite (also in TherapistReassignModal).
- Typed SessionEventUpdateRequest replaces the untyped PUT body; Appointment gains onSiteChargeAmount/amountSource.
- vitest 294 → 307 green (wp40 spec; wp23/wp37 booking specs rewritten to the derived semantics); vue-tsc + lint + permissions --check clean.
- Test artifact: app-ui/test-scenarios/wp-40-booking-auto-money.md.