### PR TITLE
fix: dashboard payment classification is appointment-status-aware (WP…

### DIFF
--- a/app-ui/src/__tests__/wp42-dashboard-cancelled-classification.spec.ts
+++ b/app-ui/src/__tests__/wp42-dashboard-cancelled-classification.spec.ts
@@ -1,0 +1,204 @@
+// WP-42C cherry-pick (quick fix, owner 2026-07-28) — dashboard payment classification is
+// appointment-status-AWARE:
+//   - O2StatsBar: "Pending Payment" / "Paid Off" / "Past Due" buckets exclude Cancelled (3)
+//     and No-Show (5) rows — those have their own WP-34 tile. "Today's Appointments" total
+//     deliberately still includes them (known quirk, ruled out of scope in WP-34).
+//   - O2Appointments rows: a cancelled/no-show row shows its APPOINTMENT state chip
+//     ("Cancelled"/"No Show", statusHelpers palette) — never a "Pending" chip and never a
+//     Pay button, even when a pre-WP-42 legacy row still carries an amount due.
+// Same id predicate as WP-34 (appointmentStatusId — statusName is admin-editable).
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount, flushPromises, RouterLinkStub } from '@vue/test-utils';
+import { createPinia, setActivePinia, type Pinia } from 'pinia';
+import manifest from '../generated/access-control-matrix.json';
+import { useAuthStore } from '../stores/auth';
+import type { ClaimDto } from '../interfaces/Auth';
+import type { Appointment } from '../interfaces/Appointment';
+import O2StatsBar from '../components/option02/O2StatsBar.vue';
+import O2Appointments from '../components/option02/O2Appointments.vue';
+
+// ---- HTTP client mocks (every client the mounted trees new up) ----
+const { getPendingSummaryMock, getPastDuePatientsMock, getSessionsMock, getUpcomingMock } =
+  vi.hoisted(() => ({
+    getPendingSummaryMock: vi.fn(),
+    getPastDuePatientsMock: vi.fn(),
+    getSessionsMock: vi.fn(),
+    getUpcomingMock: vi.fn(),
+  }));
+
+vi.mock('../services/ServicePaymentsHttpClient', () => ({
+  ServicePaymentsHttpClient: vi.fn().mockImplementation(() => ({
+    getPendingSummary: getPendingSummaryMock,
+  })),
+}));
+
+vi.mock('../services/PatientsHttpClient', () => ({
+  PatientsHttpClient: vi.fn().mockImplementation(() => ({
+    getPastDuePatients: getPastDuePatientsMock,
+  })),
+}));
+
+vi.mock('../services/SessionsHttpClient', () => ({
+  SessionsHttpClient: vi.fn().mockImplementation(() => ({
+    getSessions: getSessionsMock,
+    getUpcoming: getUpcomingMock,
+  })),
+}));
+
+// ---- auth helpers (manifest-driven, per testing guide) ----
+function claimsForRole(role: string): ClaimDto[] {
+  return (manifest.claims as Array<{ claim: string; grants: string[] }>)
+    .filter((c) => c.grants.includes(role))
+    .map((c) => ({ type: 'Permission', value: c.claim }));
+}
+
+function authAs(role: string): Pinia {
+  const pinia = createPinia();
+  setActivePinia(pinia);
+  const store = useAuthStore();
+  store.user = {
+    userId: 1,
+    email: 'test@example.com',
+    fullName: 'Test User',
+    mustChangePassword: false,
+    roles: [role],
+    claims: claimsForRole(role),
+    isSystemAdmin: false,
+  };
+  return pinia;
+}
+
+// ---- factories ----
+let nextId = 500;
+function appt(overrides: Partial<Appointment> = {}): Appointment {
+  return {
+    sessionId: nextId++,
+    sessionDate: '2026-07-28',
+    sessionTime: '09:00:00',
+    patient: 'Doe, John',
+    therapist: 'Smith, Jane',
+    therapyTypes: 'TC',
+    amount: 100,
+    discount: 0,
+    amountPaid: 0,
+    amountDue: 100,
+    isPastDue: false,
+    isPaidOff: false,
+    notes: '',
+    patientId: 1,
+    therapistId: 1,
+    time: '09:00',
+    appointmentStatusId: 1,
+    statusName: 'Proposed',
+    isConfirmed: false,
+    siteId: 1,
+    siteName: 'Main',
+    specialtyTypeId: 5,
+    specialtyAbbreviation: 'TC',
+    specialtyName: 'Conduct Therapy',
+    isDiscovery: false,
+    caretakerName: null,
+    caretakerPhone: null,
+    caretakerEmail: null,
+    ...overrides,
+  } as Appointment;
+}
+
+// A zeroed cancellation (the 12339/12340 shape): status 3, all money 0, NOT paid-off.
+const zeroedCancelled = () =>
+  appt({ appointmentStatusId: 3, statusName: 'Cancelled', amount: 0, amountDue: 0, isPaidOff: false });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getPendingSummaryMock.mockResolvedValue({ totalPending: 0, therapistCount: 0, sessionCount: 0 });
+  getPastDuePatientsMock.mockResolvedValue([]);
+  getSessionsMock.mockResolvedValue([]);
+  getUpcomingMock.mockResolvedValue([]);
+});
+
+// ---- O2StatsBar: status-aware payment buckets ----
+
+function mountBar(appointments: Appointment[]) {
+  return mount(O2StatsBar, {
+    props: { appointments },
+    global: { plugins: [authAs('MGR')], stubs: { 'router-link': RouterLinkStub } },
+  });
+}
+
+const tileValue = (wrapper: ReturnType<typeof mountBar>, testId: string) =>
+  wrapper.find(`[data-testid="${testId}"]`).text();
+
+describe('O2StatsBar — payment buckets exclude cancelled/no-show', () => {
+  it('a zeroed cancelled session counts in Cancelled/No-Show but NOT in Pending Payment', async () => {
+    const wrapper = mountBar([zeroedCancelled(), appt()]); // 1 cancelled + 1 live proposed
+    await flushPromises();
+
+    expect(tileValue(wrapper, 'stat-pending-payment')).toContain('1'); // the live one only
+    expect(tileValue(wrapper, 'stat-cancelled-noshow')).toContain('1');
+    expect(tileValue(wrapper, 'stat-todays-appointments')).toContain('2'); // total keeps the known quirk
+  });
+
+  it('a cancelled day alone shows Pending Payment 0 (the owner-reported case)', async () => {
+    const wrapper = mountBar([zeroedCancelled()]);
+    await flushPromises();
+
+    expect(tileValue(wrapper, 'stat-pending-payment')).toContain('0');
+    expect(tileValue(wrapper, 'stat-cancelled-noshow')).toContain('1');
+  });
+
+  it('a paid-then-cancelled legacy row does not inflate Paid Off; a no-show row leaves Past Due alone', async () => {
+    const wrapper = mountBar([
+      appt({ appointmentStatusId: 3, statusName: 'Cancelled', isPaidOff: true, amountDue: 0 }),
+      appt({ appointmentStatusId: 5, statusName: 'NoShow', isPastDue: true }),
+      appt({ isPaidOff: true, amountDue: 0 }), // live paid session
+    ]);
+    await flushPromises();
+
+    expect(tileValue(wrapper, 'stat-paid-off')).toContain('1');   // live paid only
+    expect(tileValue(wrapper, 'stat-past-due')).toContain('0');   // no-show excluded
+    expect(tileValue(wrapper, 'stat-cancelled-noshow')).toContain('2');
+  });
+});
+
+// ---- O2Appointments: row chips ----
+
+async function mountPanel(appointments: Appointment[]) {
+  getSessionsMock.mockResolvedValue(appointments);
+  const wrapper = mount(O2Appointments, {
+    props: { selectedDate: '2026-07-28' },
+    global: { plugins: [authAs('MGR')] },
+  });
+  await flushPromises();
+  return wrapper;
+}
+
+describe('O2Appointments — cancelled/no-show rows show the appointment state, never payment chips', () => {
+  it('a zeroed cancelled row shows a "Cancelled" chip — not the gray "Pending" chip', async () => {
+    const cancelled = zeroedCancelled();
+    const wrapper = await mountPanel([cancelled]);
+
+    const chip = wrapper.find(`[data-testid="appt-status-chip-${cancelled.sessionId}"]`);
+    expect(chip.exists()).toBe(true);
+    expect(chip.text()).toBe('Cancelled');
+    expect(wrapper.text()).not.toContain('Pending');
+  });
+
+  it('a legacy cancelled row STILL carrying money gets no Pay button (and no Past Due chip)', async () => {
+    const legacy = appt({ appointmentStatusId: 3, statusName: 'Cancelled', amount: 100, amountDue: 100, isPastDue: true });
+    const wrapper = await mountPanel([legacy]);
+
+    expect(wrapper.find(`[data-testid="appt-status-chip-${legacy.sessionId}"]`).text()).toBe('Cancelled');
+    expect(wrapper.text()).not.toContain('Pay');
+    expect(wrapper.text()).not.toContain('Past Due');
+  });
+
+  it('a no-show row shows a "No Show" chip; live rows keep their payment chips', async () => {
+    const noShow = appt({ appointmentStatusId: 5, statusName: 'NoShow' });
+    const live = appt({ amountDue: 100 });
+    const wrapper = await mountPanel([noShow, live]);
+
+    expect(wrapper.find(`[data-testid="appt-status-chip-${noShow.sessionId}"]`).text()).toBe('No Show');
+    expect(wrapper.find(`[data-testid="appt-status-chip-${live.sessionId}"]`).exists()).toBe(false);
+    expect(wrapper.text()).toContain('Pay'); // the live row's Pay button survives
+  });
+});

--- a/app-ui/src/components/option02/O2Appointments.vue
+++ b/app-ui/src/components/option02/O2Appointments.vue
@@ -47,7 +47,7 @@
           <div
             :class="[
               'w-1 h-10 rounded-full flex-shrink-0',
-              appt.isPastDue ? 'bg-red-400' : appt.isPaidOff ? 'bg-green-400' : 'bg-violet-400',
+              isCancelledOrNoShow(appt) ? 'bg-slate-300' : appt.isPastDue ? 'bg-red-400' : appt.isPaidOff ? 'bg-green-400' : 'bg-violet-400',
             ]"
           ></div>
 
@@ -124,8 +124,19 @@
 
           <!-- Status badge (clickable) -->
           <div class="flex-shrink-0 flex items-center gap-1">
+            <!-- WP-42C cherry-pick (owner 2026-07-28): cancelled/no-show rows show their
+                 APPOINTMENT state, never a payment chip — and never a Pay button (pre-WP-42
+                 legacy rows can still carry money; collecting on a cancelled session is
+                 exactly the mistake this prevents). -->
+            <span
+              v-if="isCancelledOrNoShow(appt)"
+              :data-testid="`appt-status-chip-${appt.sessionId}`"
+              :class="['inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium', getStatusBadgeClass(appt.appointmentStatusId)]"
+            >
+              {{ appt.appointmentStatusId === 3 ? 'Cancelled' : 'No Show' }}
+            </span>
             <button
-              v-if="appt.amountDue > 0 && !appt.isPaidOff"
+              v-else-if="appt.amountDue > 0 && !appt.isPaidOff"
               class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium bg-blue-100 text-blue-700 hover:bg-blue-200 cursor-pointer transition-colors"
               title="Record payment for this session"
               @click.stop="$emit('pay', appt)"
@@ -134,7 +145,7 @@
               Pay
             </button>
             <button
-              v-if="appt.isPaidOff"
+              v-else-if="appt.isPaidOff"
               class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium bg-green-100 text-green-700 hover:bg-green-200 cursor-pointer transition-colors"
               title="View payment details"
               @click.stop="$emit('view-payments', appt)"
@@ -175,6 +186,7 @@
 import { defineComponent, ref, watch, computed, onMounted, nextTick } from 'vue';
 import { Appointment } from '../../interfaces/Appointment';
 import { formatCurrency } from '../../utils/formatCurrency';
+import { getStatusBadgeClass } from '../../utils/statusHelpers';
 import { useClaims, Permissions } from '../../composables/useClaims';
 import { SessionsHttpClient } from '../../services/SessionsHttpClient';
 import { library } from '@fortawesome/fontawesome-svg-core';
@@ -278,6 +290,10 @@ export default defineComponent({
       }
     );
 
+    // WP-42C cherry-pick: same id predicate as the WP-34 tile (statusName is admin-editable).
+    const isCancelledOrNoShow = (a: Appointment) =>
+      a.appointmentStatusId === 3 || a.appointmentStatusId === 5;
+
     return {
       allAppointments,
       amAppointments,
@@ -289,6 +305,8 @@ export default defineComponent({
       formatCurrency,
       hasClaim,
       Permissions,
+      isCancelledOrNoShow,
+      getStatusBadgeClass,
     };
   },
 });

--- a/app-ui/src/components/option02/O2StatsBar.vue
+++ b/app-ui/src/components/option02/O2StatsBar.vue
@@ -216,9 +216,16 @@ export default defineComponent({
 
     const stats = computed<StatTile[]>(() => {
       const total = props.appointments.length;
-      const paid = props.appointments.filter((a) => a.isPaidOff).length;
-      const pastDue = props.appointments.filter((a) => a.isPastDue).length;
-      const pending = total - paid - pastDue;
+      // WP-42C cherry-pick (owner 2026-07-28): the payment buckets are status-AWARE —
+      // cancelled/no-show sessions (ids 3/5, same predicate as the WP-34 tile) can never be
+      // "pending payment" or "paid off"; they have their own tile. "Today's Appointments"
+      // deliberately still counts them (known quirk, ruled out of scope in WP-34).
+      const payable = props.appointments.filter(
+        (a) => a.appointmentStatusId !== 3 && a.appointmentStatusId !== 5
+      );
+      const paid = payable.filter((a) => a.isPaidOff).length;
+      const pastDue = payable.filter((a) => a.isPastDue).length;
+      const pending = payable.length - paid - pastDue;
       // WP-34C (G3 ruling): combined Cancelled + No-Show tile, keyed on appointmentStatusId
       // (3 = Cancelled, 5 = NoShow — FK ids from the AppointmentStatus lookup seed; ids are
       // the robust representation, statusName strings are admin-editable lookup values).

--- a/app-ui/test-scenarios/fix-dashboard-cancelled-classification.md
+++ b/app-ui/test-scenarios/fix-dashboard-cancelled-classification.md
@@ -1,0 +1,37 @@
+# Quick-Fix Test Scenarios — Dashboard Cancelled/No-Show Classification (WP-42C cherry-pick)
+
+Fixes the owner-reported 2026-07-28 symptom: a (zeroed) cancelled session showed as
+**"Pending"** in Dashboard → Appointments and counted **1 in "Pending Payment"** while also
+counting 1 in "Cancelled". UI-only; no API change, no permission change, nobody re-logs-in.
+
+## 1. The reported case
+
+1. Open the Dashboard on a date whose only session is a cancelled one (e.g. the
+   July 13 or July 29 test cancellations).
+2. **Cards:** "Pending Payment" shows **0**; "Cancelled / No-Show" shows **1**;
+   "Today's Appointments" still counts it (known, deliberate — separate ruling).
+3. **Appointments panel row:** the session shows a **"Cancelled"** chip (slate pill, same
+   palette as the appointment status badges) — no gray "Pending" chip, and its color bar is
+   muted slate instead of violet.
+
+## 2. Mixed day
+
+1. Pick a date with live sessions + a cancelled one.
+2. "Pending Payment" counts ONLY the live unpaid sessions; "Paid Off" only live paid ones.
+3. Live rows keep their normal chips (Pay / Paid / Past Due / Pending); only the
+   cancelled/no-show rows show state chips.
+
+## 3. Safety behavior (legacy money on a cancelled row)
+
+Until WP-42 ships its write-side zeroing, a session cancelled TODAY still keeps its money.
+Cancel a test session and check the dashboard: the row shows **"Cancelled"** with **no Pay
+button** (previously it showed an active Pay button inviting collection on a cancelled
+appointment) and it does not count in Pending Payment / Past Due cards.
+
+## 4. No-show
+
+Mark a test session No-Show: row chip reads **"No Show"** (red pill); counts in the
+Cancelled/No-Show card only.
+
+**Suite:** `npx vue-tsc --noEmit && npm run lint && npx vitest run` → **313 passed**
+(baseline 307 + 6 in `wp42-dashboard-cancelled-classification.spec.ts`).


### PR DESCRIPTION
…-42C cherry-pick)

Owner-reported 2026-07-28: a zeroed cancelled session showed a gray 'Pending' row chip and counted 1 in the Pending Payment card (while also counting in Cancelled). Root cause: O2StatsBar's remainder math (total − paid − pastDue) and O2Appointments' chip fall-through never consult appointmentStatusId.

- O2StatsBar: Pending Payment / Paid Off / Past Due buckets now exclude status 3/5 (same id predicate as the WP-34 tile); Today's Appointments total deliberately unchanged (known quirk, separate ruling).
- O2Appointments: cancelled/no-show rows show their appointment state chip ('Cancelled'/'No Show', statusHelpers palette) — never 'Pending' and never a Pay button, even on pre-WP-42 legacy rows still carrying money; color bar muted slate for 3/5.
- vitest 307 → 313 (wp42-dashboard-cancelled-classification.spec.ts); vue-tsc + lint clean. Walkthrough: test-scenarios/fix-dashboard-cancelled-classification.md.

The write-side fix (zero-at-cancel, no-show fee, payroll-covered lock) remains WP-42.